### PR TITLE
Align Python compilecheck with latest changes

### DIFF
--- a/src/snippetgen/compilecheck/internal/py/python.go
+++ b/src/snippetgen/compilecheck/internal/py/python.go
@@ -45,12 +45,12 @@ var (
 	// 	}
 	//
 	initRequestPattern = regexp.MustCompile(
-		`\w+ = {\n    # TODO: Add desired entries to the request body\.( Only assigned entries\n    # will be changed\.| All existing entries\n    # will be replaced\.)?\n}`)
+		`\w+ = {\n([\s\S]*?)    # TODO: Add desired entries to the request body\.( Only assigned entries\n    # will be changed\.| All existing entries\n    # will be replaced\.)?\n}`)
 
 	// initRequestGeneric uses the generic name 'body' for the request object (used in Python
 	// client libraries) in place of the request object name in initRequestPattern
 	initRequestGeneric = `body = {
-    # TODO: Add desired entries to the request body.$1
+$1    # TODO: Add desired entries to the request body.$2
 }`
 )
 

--- a/src/snippetgen/compilecheck/internal/py/writetest_test.go
+++ b/src/snippetgen/compilecheck/internal/py/writetest_test.go
@@ -43,6 +43,7 @@ body = {
 	got := mapFS["path/to/tst/check.py"]
 	want := `
 from __future__ import print_function
+import keyword
 import sys
 
 tests = []
@@ -60,12 +61,22 @@ def test_pubsub_v1_projects_subscriptions_create():
   }
 
 
-  if not (isinstance(name, basestring)):
-    print("In test_pubsub_v1_projects_subscriptions_create, expected name to be string, found %s" % type(name))
-    top_errors += 1
-  if not (isinstance(body, dict)):
-    print("In test_pubsub_v1_projects_subscriptions_create, expected body to be object, found %s" % type(body))
-    top_errors += 1
+  if keyword.iskeyword('name') or 'name' in dir(__builtins__):
+    if not (isinstance(name_, basestring)):
+      print("In test_pubsub_v1_projects_subscriptions_create, expected name_ to be string, found %s" % type(name_))
+      top_errors += 1
+  else:
+    if not (isinstance(name, basestring)):
+      print("In test_pubsub_v1_projects_subscriptions_create, expected name to be string, found %s" % type(name))
+      top_errors += 1
+  if keyword.iskeyword('body') or 'body' in dir(__builtins__):
+    if not (isinstance(body_, dict)):
+      print("In test_pubsub_v1_projects_subscriptions_create, expected body_ to be object, found %s" % type(body_))
+      top_errors += 1
+  else:
+    if not (isinstance(body, dict)):
+      print("In test_pubsub_v1_projects_subscriptions_create, expected body to be object, found %s" % type(body))
+      top_errors += 1
 
 tests.append(test_pubsub_v1_projects_subscriptions_create)
 


### PR DESCRIPTION
This commit changes the request body regex to support request body
fields. It also changes the test to assume that any variables which
shadow keywords or built-in functions have a `_` suffix, as they now do
in the samples.