### PR TITLE
Use TypeScript file extensions

### DIFF
--- a/src/snippetgen/compilecheck/internal/nodejs/parselib.go
+++ b/src/snippetgen/compilecheck/internal/nodejs/parselib.go
@@ -57,7 +57,7 @@ var typeConvert = map[string]string{
 // parseLib is a helper of parseLibs, parsing only one file. It updates `params` with the content of
 // the file.
 func parseLib(libDir, apiName, apiVersion string, params langutil.MethodParamSets, opener filesys.Opener) error {
-	file, err := opener.Open(filepath.Join(libDir, apiName, apiVersion+".js"))
+	file, err := opener.Open(filepath.Join(libDir, apiName, apiVersion+".ts"))
 	if err != nil {
 		return err
 	}

--- a/src/snippetgen/compilecheck/internal/nodejs/parselib_test.go
+++ b/src/snippetgen/compilecheck/internal/nodejs/parselib_test.go
@@ -14,7 +14,7 @@ func TestParseLibs(t *testing.T) {
 		params         langutil.MethodParamSets
 	}{
 		{
-			fname: "/lib/myservice/v2.js",
+			fname: "/lib/myservice/v2.ts",
 			params: langutil.MethodParamSets{
 				{"myservice", "v2", "myService.myMethod"}: {
 					{"foo", "string"},
@@ -35,7 +35,7 @@ func TestParseLibs(t *testing.T) {
 		 `,
 		},
 		{
-			fname: "/lib/myservice/v1.js",
+			fname: "/lib/myservice/v1.ts",
 			params: langutil.MethodParamSets{
 				{"myservice", "v1", "appengine.apps.get"}: {
 					{"appsId", "string"},


### PR DESCRIPTION
The Node.js client library switched to TypeScript recently. This commit
updates the file extension that compilecheck looks for.