### PR TITLE
Fix 404 and past revision behavior

### DIFF
--- a/src/main/common/updatedisco.go
+++ b/src/main/common/updatedisco.go
@@ -209,7 +209,7 @@ func UpdateAPI(API apiInfo, absolutePath string, permissions os.FileMode, update
 	oldRevision, _ := oldAPI["revision"].(string)
 	// Do nothing if the revision of the new API is older than what already exists.
 	if newRevision < oldRevision {
-		return fmt.Errorf("Error validating Discovery doc revision %v: %v < %v", newRevision, oldRevision)
+		return fmt.Errorf("Error validating Discovery doc revision from %v: %v < %v", API.DiscoveryRestURL, newRevision, oldRevision)
 	}
 
 	if oldAPI == nil || !sameAPI(oldAPI, newAPI) {
@@ -239,6 +239,7 @@ func discoFromFile(absolutePath string) (contents []byte, err error) {
 // discoFromURL returns the Discovery `contents` at `URL`.
 func discoFromURL(URL string) (contents []byte, err error) {
 	response, err := http.Get(URL)
+	// Note that err is nil for non-200 responses.
 	if err != nil {
 		err = fmt.Errorf("Error downloading Discovery doc from %v: %v", URL, err)
 		return


### PR DESCRIPTION
1. Prevent APIs from being updated with past versions

   Sometimes, multiple consecutive requests to the Discovery service
   return Discovery documents with different revision tags.

   This commit adds a check to verify that the downloaded Discovery
   document has a revision that is at least as recent as the one that
   already exists (if one already exists).

   If the revision check fails, the update process for that particular
   Discovery document is aborted as a no-op without an error.

2. Error on non-200 Discovery document responses

   This commit also adds a check for non-200 responses from Discovery
   URLs. There are some cases where the Discovery directory lists APIs
   which point to missing Discovery documents. In the case that a
   non-200 response is returned from a Discovery document URL, an error
   is returned, but any existing Discovery document for that API version
   is not removed.