### PR TITLE
Add accounts module

### DIFF
--- a/server/tasks/__init__.py
+++ b/server/tasks/__init__.py
@@ -1,0 +1,13 @@
+# Copyright 2017, Google Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.

--- a/server/tasks/accounts.py
+++ b/server/tasks/accounts.py
@@ -22,9 +22,10 @@ NpmAccount = namedtuple('NpmAccount', 'auth_token')
 RubyGemsAccount = namedtuple('RubyGemsAccount', 'api_key')
 
 
-def _obj(kind):
+def _get(type_):
     client = datastore.Client()
-    return list(client.query(kind=kind).fetch())[0]
+    obj = list(client.query(kind=type_.__name__).fetch())[0]
+    return type_(*[obj[x] for x in type_._fields])
 
 
 def get_github_account():
@@ -33,9 +34,7 @@ def get_github_account():
     Returns:
         GitHubAccount: a GitHub account.
     """
-    obj = _obj('GitHubAccount')
-    return GitHubAccount(obj['name'], obj['email'], obj['username'],
-                         obj['personal_access_token'])
+    return _get(GitHubAccount)
 
 
 def get_npm_account():
@@ -44,8 +43,7 @@ def get_npm_account():
     Returns:
         NpmAccount: an npm account.
     """
-    obj = _obj('NpmAccount')
-    return NpmAccount(obj['auth_token'])
+    return _get(NpmAccount)
 
 
 def get_rubygems_account():
@@ -54,5 +52,4 @@ def get_rubygems_account():
     Returns:
         RubyGemsAccount: a RubyGems account.
     """
-    obj = _obj('RubyGemsAccount')
-    return RubyGemsAccount(obj['api_key'])
+    return _get(RubyGemsAccount)

--- a/server/tasks/accounts.py
+++ b/server/tasks/accounts.py
@@ -1,0 +1,58 @@
+# Copyright 2017, Google Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Contains definitions/getters for GitHub and package manager accounts."""
+from collections import namedtuple
+
+from google.cloud import datastore
+
+GitHubAccount = namedtuple('GitHubAccount',
+                           'name email username personal_access_token')
+NpmAccount = namedtuple('NpmAccount', 'auth_token')
+RubyGemsAccount = namedtuple('RubyGemsAccount', 'api_key')
+
+
+def _obj(kind):
+    client = datastore.Client()
+    return list(client.query(kind=kind).fetch())[0]
+
+
+def get_github_account():
+    """Returns the GitHub account stored in Datastore.
+
+    Returns:
+        GitHubAccount: a GitHub account.
+    """
+    obj = _obj('GitHubAccount')
+    return GitHubAccount(obj['name'], obj['email'], obj['username'],
+                         obj['personal_access_token'])
+
+
+def get_npm_account():
+    """Returns the npm account stored in Datastore.
+
+    Returns:
+        NpmAccount: an npm account.
+    """
+    obj = _obj('NpmAccount')
+    return NpmAccount(obj['auth_token'])
+
+
+def get_rubygems_account():
+    """Returns the RubyGems account stored in Datastore.
+
+    Returns:
+        RubyGemsAccount: a RubyGems account.
+    """
+    obj = _obj('RubyGemsAccount')
+    return RubyGemsAccount(obj['api_key'])

--- a/server/tests/test_accounts.py
+++ b/server/tests/test_accounts.py
@@ -1,0 +1,55 @@
+# Copyright 2017, Google Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+from unittest.mock import Mock, patch
+
+from tasks import accounts
+
+
+@patch('tasks.accounts.datastore.Client', autospec=True)
+def test_get_github_account(client_mock):
+    query_mock = Mock()
+    query_mock.return_value.fetch.return_value = [{
+        'name': 'Test',
+        'email': 'test@example.com',
+        'username': 'test',
+        'personal_access_token': 'token'
+    }]
+    client_mock.return_value.query = query_mock
+    expected = accounts.GitHubAccount(
+        'Test', 'test@example.com', 'test', 'token')
+    actual = accounts.get_github_account()
+    query_mock.assert_called_once_with(kind='GitHubAccount')
+    assert actual == expected
+
+
+@patch('tasks.accounts.datastore.Client', autospec=True)
+def test_get_npm_account(client_mock):
+    query_mock = Mock()
+    query_mock.return_value.fetch.return_value = [{'auth_token': 'token'}]
+    client_mock.return_value.query = query_mock
+    expected = accounts.NpmAccount('token')
+    actual = accounts.get_npm_account()
+    query_mock.assert_called_once_with(kind='NpmAccount')
+    assert actual == expected
+
+
+@patch('tasks.accounts.datastore.Client', autospec=True)
+def test_get_rubygems_account(client_mock):
+    query_mock = Mock()
+    query_mock.return_value.fetch.return_value = [{'api_key': 'key'}]
+    client_mock.return_value.query = query_mock
+    expected = accounts.RubyGemsAccount('key')
+    actual = accounts.get_rubygems_account()
+    query_mock.assert_called_once_with(kind='RubyGemsAccount')
+    assert actual == expected


### PR DESCRIPTION
Contains definitions and getters for the various accounts the server
needs access to.

Account information is retrieved from Datastore.