### PR TITLE
Force update of content v2 discovery

### DIFF
--- a/discoveries/content.v2.json
+++ b/discoveries/content.v2.json
@@ -1,12 +1,11 @@
 {
  "kind": "discovery#restDescription",
- "etag": "\"Zkyw9ACJZUvcYmlFaKGChzhmtnE/O1QXDlHS7167owCHVkvo0Mw47Yo\"",
+ "etag": "\"Zkyw9ACJZUvcYmlFaKGChzhmtnE/MzgF60zzzOG-2sW0R7344_YxT7w\"",
  "discoveryVersion": "v1",
  "id": "content:v2",
  "name": "content",
  "canonicalName": "Shopping Content",
  "version": "v2",
- "revision": "20180608",
  "title": "Content API for Shopping",
  "description": "Manages product items, inventory, and Merchant Center accounts for Google Shopping.",
  "ownerDomain": "google.com",
@@ -483,7 +482,7 @@
     },
     "accountId": {
      "type": "string",
-     "description": "The ID of the targeted account. Only defined if the method is get, delete or claimwebsite.",
+     "description": "The ID of the targeted account. Only defined if the method is not insert.",
      "format": "uint64"
     },
     "batchId": {
@@ -495,17 +494,40 @@
      "type": "boolean",
      "description": "Whether the account should be deleted if the account has offers. Only applicable if the method is delete."
     },
+    "linkRequest": {
+     "$ref": "AccountsCustomBatchRequestEntryLinkRequest",
+     "description": "Details about the link request."
+    },
     "merchantId": {
      "type": "string",
      "description": "The ID of the managing account.",
      "format": "uint64"
     },
     "method": {
-     "type": "string"
+     "type": "string",
+     "description": "The method of the batch entry."
     },
     "overwrite": {
      "type": "boolean",
      "description": "Only applicable if the method is claimwebsite. Indicates whether or not to take the claim from another account in case there is a conflict."
+    }
+   }
+  },
+  "AccountsCustomBatchRequestEntryLinkRequest": {
+   "id": "AccountsCustomBatchRequestEntryLinkRequest",
+   "type": "object",
+   "properties": {
+    "action": {
+     "type": "string",
+     "description": "Action to perform for this link."
+    },
+    "linkType": {
+     "type": "string",
+     "description": "Type of the link between the two accounts."
+    },
+    "linkedAccountId": {
+     "type": "string",
+     "description": "The ID of the linked account."
     }
    }
   },
@@ -534,7 +556,7 @@
    "properties": {
     "account": {
      "$ref": "Account",
-     "description": "The retrieved, created, or updated account. Not defined if the method was delete or claimwebsite."
+     "description": "The retrieved, created, or updated account. Not defined if the method was delete, claimwebsite or link."
     },
     "batchId": {
      "type": "integer",
@@ -549,6 +571,39 @@
      "type": "string",
      "description": "Identifies what kind of resource this is. Value: the fixed string \"content#accountsCustomBatchResponseEntry\".",
      "default": "content#accountsCustomBatchResponseEntry"
+    },
+    "linkStatus": {
+     "type": "string",
+     "description": "The status of the updated link. Only defined if the method is link."
+    }
+   }
+  },
+  "AccountsLinkRequest": {
+   "id": "AccountsLinkRequest",
+   "type": "object",
+   "properties": {
+    "action": {
+     "type": "string",
+     "description": "Action to perform for this link."
+    },
+    "linkType": {
+     "type": "string",
+     "description": "Type of the link between the two accounts."
+    },
+    "linkedAccountId": {
+     "type": "string",
+     "description": "The ID of the linked account."
+    }
+   }
+  },
+  "AccountsLinkResponse": {
+   "id": "AccountsLinkResponse",
+   "type": "object",
+   "properties": {
+    "kind": {
+     "type": "string",
+     "description": "Identifies what kind of resource this is. Value: the fixed string \"content#accountsLinkResponse\".",
+     "default": "content#accountsLinkResponse"
     }
    }
   },
@@ -790,11 +845,11 @@
    "properties": {
     "pretax": {
      "$ref": "Price",
-     "description": "Value before taxes."
+     "description": "[required] Value before taxes."
     },
     "tax": {
      "$ref": "Price",
-     "description": "Tax value."
+     "description": "[required] Tax value."
     }
    }
   },
@@ -1814,19 +1869,19 @@
     },
     "customerBalance": {
      "$ref": "Amount",
-     "description": "Customer balance on this invoice. A positive amount means the customer is paying, a negative one means the customer is receiving money. Note that it must always be true that merchant_balance + customer_balance + google_balance = 0."
+     "description": "[required] Customer balance on this invoice. A positive amount means the customer is paying, a negative one means the customer is receiving money. Note that it must always be true that merchant_balance + customer_balance + google_balance = 0."
     },
     "googleBalance": {
      "$ref": "Amount",
-     "description": "Google balance on this invoice. A positive amount means Google is paying, a negative one means Google is receiving money. Note that it must always be true that merchant_balance + customer_balance + google_balance = 0."
+     "description": "[required] Google balance on this invoice. A positive amount means Google is paying, a negative one means Google is receiving money. Note that it must always be true that merchant_balance + customer_balance + google_balance = 0."
     },
     "merchantBalance": {
      "$ref": "Amount",
-     "description": "Merchant balance on this invoice. A positive amount means the merchant is paying, a negative one means the merchant is receiving money. Note that it must always be true that merchant_balance + customer_balance + google_balance = 0."
+     "description": "[required] Merchant balance on this invoice. A positive amount means the merchant is paying, a negative one means the merchant is receiving money. Note that it must always be true that merchant_balance + customer_balance + google_balance = 0."
     },
     "productTotal": {
      "$ref": "Amount",
-     "description": "Total price for the product."
+     "description": "[required] Total price for the product."
     },
     "promotionSummaries": {
      "type": "array",
@@ -1843,11 +1898,11 @@
    "properties": {
     "totalAmount": {
      "$ref": "Amount",
-     "description": "Total additional charge for this type."
+     "description": "[required] Total additional charge for this type."
     },
     "type": {
      "type": "string",
-     "description": "Type of the additional charge."
+     "description": "[required] Type of the additional charge."
     }
    }
   },
@@ -2908,7 +2963,7 @@
     },
     "deliveryDate": {
      "type": "string",
-     "description": "Date on which the shipment has been delivered, in ISO 8601 format. Present only if status is delievered"
+     "description": "Date on which the shipment has been delivered, in ISO 8601 format. Present only if status is delivered"
     },
     "id": {
      "type": "string",
@@ -2956,26 +3011,26 @@
    "properties": {
     "invoiceId": {
      "type": "string",
-     "description": "The ID of the invoice."
+     "description": "[required] The ID of the invoice."
     },
     "invoiceSummary": {
      "$ref": "InvoiceSummary",
-     "description": "Invoice summary."
+     "description": "[required] Invoice summary."
     },
     "lineItemInvoices": {
      "type": "array",
-     "description": "Invoice details per line item.",
+     "description": "[required] Invoice details per line item.",
      "items": {
       "$ref": "ShipmentInvoiceLineItemInvoice"
      }
     },
     "operationId": {
      "type": "string",
-     "description": "The ID of the operation, unique across all operations for a given order."
+     "description": "[required] The ID of the operation, unique across all operations for a given order."
     },
     "shipmentGroupId": {
      "type": "string",
-     "description": "ID of the shipment group."
+     "description": "[required] ID of the shipment group."
     }
    }
   },
@@ -3000,19 +3055,19 @@
    "properties": {
     "invoiceId": {
      "type": "string",
-     "description": "The ID of the invoice."
+     "description": "[required] The ID of the invoice."
     },
     "operationId": {
      "type": "string",
-     "description": "The ID of the operation, unique across all operations for a given order."
+     "description": "[required] The ID of the operation, unique across all operations for a given order."
     },
     "refundOnlyOption": {
      "$ref": "OrderinvoicesCustomBatchRequestEntryCreateRefundInvoiceRefundOption",
-     "description": "Option to create a refund-only invoice. Exactly one of refund_option and return_option must be provided."
+     "description": "Option to create a refund-only invoice. Exactly one of refundOnlyOption or returnOption must be provided."
     },
     "returnOption": {
      "$ref": "OrderinvoicesCustomBatchRequestEntryCreateRefundInvoiceReturnOption",
-     "description": "Option to create an invoice for a refund and mark all items within the invoice as returned. Exactly one of refund_option and return_option must be provided."
+     "description": "Option to create an invoice for a refund and mark all items within the invoice as returned. Exactly one of refundOnlyOption or returnOption must be provided."
     },
     "shipmentInvoices": {
      "type": "array",
@@ -3048,7 +3103,7 @@
     },
     "reason": {
      "type": "string",
-     "description": "Reason for the refund."
+     "description": "[required] Reason for the refund."
     }
    }
   },
@@ -3062,7 +3117,7 @@
     },
     "reason": {
      "type": "string",
-     "description": "Reason for the return."
+     "description": "[required] Reason for the return."
     }
    }
   },
@@ -3733,6 +3788,10 @@
      "type": "string",
      "description": "The carrier handling the shipment. Not updated if missing. See shipments[].carrier in the  Orders resource representation for a list of acceptable values."
     },
+    "deliveryDate": {
+     "type": "string",
+     "description": "Date on which the shipment has been delivered, in ISO 8601 format. Optional and can be provided only if"
+    },
     "shipmentId": {
      "type": "string",
      "description": "The ID of the shipment."
@@ -4260,6 +4319,10 @@
     "carrier": {
      "type": "string",
      "description": "The carrier handling the shipment. Not updated if missing. See shipments[].carrier in the  Orders resource representation for a list of acceptable values."
+    },
+    "deliveryDate": {
+     "type": "string",
+     "description": "Date on which the shipment has been delivered, in ISO 8601 format. Optional and can be provided only if"
     },
     "operationId": {
      "type": "string",
@@ -5094,6 +5157,10 @@
       ]
      }
     },
+    "costOfGoodsSold": {
+     "$ref": "Price",
+     "description": "Cost of goods sold. Used for gross profit reporting."
+    },
     "customAttributes": {
      "type": "array",
      "description": "A list of custom (merchant-provided) attributes. It can also be used for submitting any attribute of the feed specification in its generic form (e.g., { \"name\": \"size type\", \"type\": \"text\", \"value\": \"regular\" }). This is useful for submitting attributes not explicitly exposed by the API.",
@@ -5224,10 +5291,18 @@
      "type": "string",
      "description": "The material of which the item is made."
     },
+    "maxEnergyEfficiencyClass": {
+     "type": "string",
+     "description": "The energy efficiency class as defined in EU directive 2010/30/EU."
+    },
     "maxHandlingTime": {
      "type": "string",
      "description": "Maximal product handling time (in business days).",
      "format": "int64"
+    },
+    "minEnergyEfficiencyClass": {
+     "type": "string",
+     "description": "The energy efficiency class as defined in EU directive 2010/30/EU."
     },
     "minHandlingTime": {
      "type": "string",
@@ -5961,11 +6036,11 @@
    "properties": {
     "promotionAmount": {
      "$ref": "Amount",
-     "description": "Amount of the promotion. The values here are the promotion applied to the unit price pretax and to the total of the tax amounts."
+     "description": "[required] Amount of the promotion. The values here are the promotion applied to the unit price pretax and to the total of the tax amounts."
     },
     "promotionId": {
      "type": "string",
-     "description": "ID of the promotion."
+     "description": "[required] ID of the promotion."
     }
    }
   },
@@ -6068,18 +6143,18 @@
    "properties": {
     "invoiceSummary": {
      "$ref": "InvoiceSummary",
-     "description": "Invoice summary."
+     "description": "[required] Invoice summary."
     },
     "lineItemInvoices": {
      "type": "array",
-     "description": "Invoice details per line item.",
+     "description": "[required] Invoice details per line item.",
      "items": {
       "$ref": "ShipmentInvoiceLineItemInvoice"
      }
     },
     "shipmentGroupId": {
      "type": "string",
-     "description": "ID of the shipment group."
+     "description": "[required] ID of the shipment group."
     }
    }
   },
@@ -6097,14 +6172,14 @@
     },
     "shipmentUnitIds": {
      "type": "array",
-     "description": "Unit IDs to define specific units within the line item.",
+     "description": "[required] Unit IDs to define specific units within the line item.",
      "items": {
       "type": "string"
      }
     },
     "unitInvoice": {
      "$ref": "UnitInvoice",
-     "description": "Invoice details for a single unit."
+     "description": "[required] Invoice details for a single unit."
     }
    }
   },
@@ -6630,7 +6705,7 @@
     },
     "unitPricePretax": {
      "$ref": "Price",
-     "description": "Price of the unit, before applying taxes."
+     "description": "[required] Price of the unit, before applying taxes."
     },
     "unitPriceTaxes": {
      "type": "array",
@@ -6647,7 +6722,7 @@
    "properties": {
     "additionalChargeAmount": {
      "$ref": "Amount",
-     "description": "Amount of the additional charge."
+     "description": "[required] Amount of the additional charge."
     },
     "additionalChargePromotions": {
      "type": "array",
@@ -6658,7 +6733,7 @@
     },
     "type": {
      "type": "string",
-     "description": "Type of the additional charge."
+     "description": "[required] Type of the additional charge."
     }
    }
   },
@@ -6668,15 +6743,15 @@
    "properties": {
     "taxAmount": {
      "$ref": "Price",
-     "description": "Tax amount for the tax type."
+     "description": "[required] Tax amount for the tax type."
     },
     "taxName": {
      "type": "string",
-     "description": "Optional name of the tax type."
+     "description": "Optional name of the tax type. This should only be provided if taxType is otherFeeTax."
     },
     "taxType": {
      "type": "string",
-     "description": "Type of the tax."
+     "description": "[required] Type of the tax."
     }
    }
   },
@@ -6895,6 +6970,41 @@
      },
      "response": {
       "$ref": "Account"
+     },
+     "scopes": [
+      "https://www.googleapis.com/auth/content"
+     ]
+    },
+    "link": {
+     "id": "content.accounts.link",
+     "path": "{merchantId}/accounts/{accountId}/link",
+     "httpMethod": "POST",
+     "description": "Performs an action on a link between a Merchant Center account and another account.",
+     "parameters": {
+      "accountId": {
+       "type": "string",
+       "description": "The ID of the account that should be linked.",
+       "required": true,
+       "format": "uint64",
+       "location": "path"
+      },
+      "merchantId": {
+       "type": "string",
+       "description": "The ID of the managing account. If this parameter is not the same as accountId, then this account must be a multi-client account and accountId must be the ID of a sub-account of this account.",
+       "required": true,
+       "format": "uint64",
+       "location": "path"
+      }
+     },
+     "parameterOrder": [
+      "merchantId",
+      "accountId"
+     ],
+     "request": {
+      "$ref": "AccountsLinkRequest"
+     },
+     "response": {
+      "$ref": "AccountsLinkResponse"
      },
      "scopes": [
       "https://www.googleapis.com/auth/content"


### PR DESCRIPTION
Force update of the content v2 discovery document.

It is currently failing to update automatically because the previous discovery document had a revision field but the new discovery document has no revision field. The current [updatedisco script](https://github.com/googleapis/discovery-artifact-manager/blob/master/src/main/common/updatedisco.go#L229) flags this as an error.

This is causing https://github.com/google/google-api-ruby-client/issues/691 downstream.

This PR performs a forced manual update of the content_v2 discovery doc from https://www.googleapis.com/discovery/v1/apis/content/v2/rest to remove the blockage for that one API, which is a current high priority issue (see internal issue b/111153891). I'll file a separate issue or PR for the general problem.