### PR TITLE
Regenerate compute_gapic.yaml

### DIFF
--- a/gapic/google/compute/v1/compute_gapic.yaml
+++ b/gapic/google/compute/v1/compute_gapic.yaml
@@ -6397,6 +6397,671 @@ interfaces:
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
   # The fully qualified name of the API interface.
+- name: google.compute.v1.NodeGroups
+  # A list of resource collection configurations.
+  # Consists of a name_pattern and an entity_name.
+  # The name_pattern is a pattern to describe the names of the resources of this
+  # collection, using the platform's conventions for URI patterns. A generator
+  # may use this to generate methods to compose and decompose such names. The
+  # pattern should use named placeholders as in `shelves/{shelf}/books/{book}`;
+  # those will be taken as hints for the parameter names of the generated
+  # methods. If empty, no name methods are generated.
+  # The entity_name is the name to be used as a basis for generated methods and
+  # classes.
+  collections:
+  - name_pattern: projects/{project}
+    entity_name: project
+  - name_pattern: projects/{project}/zones/{zone}
+    entity_name: projectZone
+  - name_pattern: projects/{project}/zones/{zone}/nodeGroups/{nodeGroup}
+    entity_name: projectZoneNodeGroup
+  # Definition for retryable codes.
+  retry_codes_def:
+  - name: idempotent
+    retry_codes:
+    - UNAVAILABLE
+    - DEADLINE_EXCEEDED
+  - name: non_idempotent
+    retry_codes: []
+  # Definition for retry/backoff parameters.
+  retry_params_def:
+  - name: default
+    initial_retry_delay_millis: 100
+    retry_delay_multiplier: 1.3
+    max_retry_delay_millis: 60000
+    initial_rpc_timeout_millis: 20000
+    rpc_timeout_multiplier: 1
+    max_rpc_timeout_millis: 20000
+    total_timeout_millis: 600000
+  # A list of method configurations.
+  # Common properties:
+  #   name - The simple name of the method.
+  #   flattening - Specifies the configuration for parameter flattening.
+  #       Describes the parameter groups for which a generator should produce
+  #       method overloads which allow a client to directly pass request message
+  #       fields as method parameters. This information may or may not be used,
+  #       depending on the target language.
+  #       Consists of groups, which each represent a list of parameters to be
+  #       flattened. Each parameter listed must be a field of the request
+  #       message.
+  #   required_fields - Fields that are always required for a request to be
+  #       valid.
+  #   request_object_method - Turns on or off the generation of a method whose
+  #       sole parameter is a request object. Not all languages will generate
+  #       this method.
+  #   resource_name_treatment - An enum that specifies how to treat the
+  #       resource name formats defined in the field_name_patterns
+  #       and response_field_name_patterns fields.
+  #       UNSET: default value
+  #       NONE: the collection configs will not be used by the generated code.
+  #       VALIDATE: string fields will be validated by the client against the
+  #           specified resource name formats.
+  #       STATIC_TYPES: the client will use generated types for resource names.
+  #   page_streaming - Specifies the configuration for paging.
+  #       Describes information for generating a method which transforms a
+  #       paging list RPC into a stream of resources.
+  #       Consists of a request and a response.
+  #       The request specifies request information of the list method. It
+  #       defines which fields match the paging pattern in the request. The
+  #       request consists of a page_size_field and a token_field. The
+  #       page_size_field is the name of the optional field specifying the
+  #       maximum number of elements to be returned in the response. The
+  #       token_field is the name of the field in the request containing the
+  #       page token.
+  #       The response specifies response information of the list method. It
+  #       defines which fields match the paging pattern in the response. The
+  #       response consists of a token_field and a resources_field. The
+  #       token_field is the name of the field in the response containing the
+  #       next page token. The resources_field is the name of the field in the
+  #       response containing the list of resources belonging to the page.
+  #   retry_codes_name - Specifies the configuration for retryable codes. The
+  #       name must be defined in interfaces.retry_codes_def.
+  #   retry_params_name - Specifies the configuration for retry/backoff
+  #       parameters. The name must be defined in interfaces.retry_params_def.
+  #   field_name_patterns - Maps the field name of the request type to
+  #       entity_name of interfaces.collections.
+  #       Specifies the string pattern that the field must follow.
+  #   timeout_millis - Specifies the default timeout for a non-retrying call. If
+  #       the call is retrying, refer to retry_params_name instead.
+  methods:
+  - name: compute.nodeGroups.addNodes
+    # TODO: Configure which groups of fields should be flattened into method
+    # params.
+    flattening:
+      groups:
+      - parameters:
+        - nodeGroup
+        - nodeGroupsAddNodesRequestResource
+    # TODO: Configure which fields are required.
+    required_fields:
+    - nodeGroup
+    - nodeGroupsAddNodesRequestResource
+    request_object_method: true
+    resource_name_treatment: STATIC_TYPES
+    # TODO: Configure the retryable codes for this method.
+    retry_codes_name: non_idempotent
+    # TODO: Configure the retryable params for this method.
+    retry_params_name: default
+    field_name_patterns:
+      nodeGroup: projectZoneNodeGroup
+    # TODO: Configure the default timeout for a non-retrying call.
+    timeout_millis: 60000
+  - name: compute.nodeGroups.aggregatedList
+    # TODO: Configure which groups of fields should be flattened into method
+    # params.
+    flattening:
+      groups:
+      - parameters:
+        - project
+    # TODO: Configure which fields are required.
+    required_fields:
+    - project
+    request_object_method: true
+    resource_name_treatment: STATIC_TYPES
+    page_streaming:
+      request:
+        page_size_field: maxResults
+        token_field: pageToken
+      response:
+        token_field: nextPageToken
+        resources_field: items
+    # TODO: Configure the retryable codes for this method.
+    retry_codes_name: idempotent
+    # TODO: Configure the retryable params for this method.
+    retry_params_name: default
+    field_name_patterns:
+      project: project
+    # TODO: Configure the default timeout for a non-retrying call.
+    timeout_millis: 60000
+  - name: compute.nodeGroups.delete
+    # TODO: Configure which groups of fields should be flattened into method
+    # params.
+    flattening:
+      groups:
+      - parameters:
+        - nodeGroup
+    # TODO: Configure which fields are required.
+    required_fields:
+    - nodeGroup
+    request_object_method: true
+    resource_name_treatment: STATIC_TYPES
+    # TODO: Configure the retryable codes for this method.
+    retry_codes_name: idempotent
+    # TODO: Configure the retryable params for this method.
+    retry_params_name: default
+    field_name_patterns:
+      nodeGroup: projectZoneNodeGroup
+    # TODO: Configure the default timeout for a non-retrying call.
+    timeout_millis: 60000
+  - name: compute.nodeGroups.deleteNodes
+    # TODO: Configure which groups of fields should be flattened into method
+    # params.
+    flattening:
+      groups:
+      - parameters:
+        - nodeGroup
+        - nodeGroupsDeleteNodesRequestResource
+    # TODO: Configure which fields are required.
+    required_fields:
+    - nodeGroup
+    - nodeGroupsDeleteNodesRequestResource
+    request_object_method: true
+    resource_name_treatment: STATIC_TYPES
+    # TODO: Configure the retryable codes for this method.
+    retry_codes_name: non_idempotent
+    # TODO: Configure the retryable params for this method.
+    retry_params_name: default
+    field_name_patterns:
+      nodeGroup: projectZoneNodeGroup
+    # TODO: Configure the default timeout for a non-retrying call.
+    timeout_millis: 60000
+  - name: compute.nodeGroups.get
+    # TODO: Configure which groups of fields should be flattened into method
+    # params.
+    flattening:
+      groups:
+      - parameters:
+        - nodeGroup
+    # TODO: Configure which fields are required.
+    required_fields:
+    - nodeGroup
+    request_object_method: true
+    resource_name_treatment: STATIC_TYPES
+    # TODO: Configure the retryable codes for this method.
+    retry_codes_name: idempotent
+    # TODO: Configure the retryable params for this method.
+    retry_params_name: default
+    field_name_patterns:
+      nodeGroup: projectZoneNodeGroup
+    # TODO: Configure the default timeout for a non-retrying call.
+    timeout_millis: 60000
+  - name: compute.nodeGroups.insert
+    # TODO: Configure which groups of fields should be flattened into method
+    # params.
+    flattening:
+      groups:
+      - parameters:
+        - initialNodeCount
+        - zone
+        - nodeGroupResource
+    # TODO: Configure which fields are required.
+    required_fields:
+    - initialNodeCount
+    - zone
+    - nodeGroupResource
+    request_object_method: true
+    resource_name_treatment: STATIC_TYPES
+    # TODO: Configure the retryable codes for this method.
+    retry_codes_name: non_idempotent
+    # TODO: Configure the retryable params for this method.
+    retry_params_name: default
+    field_name_patterns:
+      zone: projectZone
+    # TODO: Configure the default timeout for a non-retrying call.
+    timeout_millis: 60000
+  - name: compute.nodeGroups.list
+    # TODO: Configure which groups of fields should be flattened into method
+    # params.
+    flattening:
+      groups:
+      - parameters:
+        - zone
+    # TODO: Configure which fields are required.
+    required_fields:
+    - zone
+    request_object_method: true
+    resource_name_treatment: STATIC_TYPES
+    page_streaming:
+      request:
+        page_size_field: maxResults
+        token_field: pageToken
+      response:
+        token_field: nextPageToken
+        resources_field: items
+    # TODO: Configure the retryable codes for this method.
+    retry_codes_name: idempotent
+    # TODO: Configure the retryable params for this method.
+    retry_params_name: default
+    field_name_patterns:
+      zone: projectZone
+    # TODO: Configure the default timeout for a non-retrying call.
+    timeout_millis: 60000
+  - name: compute.nodeGroups.listNodes
+    # TODO: Configure which groups of fields should be flattened into method
+    # params.
+    flattening:
+      groups:
+      - parameters:
+        - nodeGroup
+    # TODO: Configure which fields are required.
+    required_fields:
+    - nodeGroup
+    request_object_method: true
+    resource_name_treatment: STATIC_TYPES
+    page_streaming:
+      request:
+        page_size_field: maxResults
+        token_field: pageToken
+      response:
+        token_field: nextPageToken
+        resources_field: items
+    # TODO: Configure the retryable codes for this method.
+    retry_codes_name: non_idempotent
+    # TODO: Configure the retryable params for this method.
+    retry_params_name: default
+    field_name_patterns:
+      nodeGroup: projectZoneNodeGroup
+    # TODO: Configure the default timeout for a non-retrying call.
+    timeout_millis: 60000
+  - name: compute.nodeGroups.setNodeTemplate
+    # TODO: Configure which groups of fields should be flattened into method
+    # params.
+    flattening:
+      groups:
+      - parameters:
+        - nodeGroup
+        - nodeGroupsSetNodeTemplateRequestResource
+    # TODO: Configure which fields are required.
+    required_fields:
+    - nodeGroup
+    - nodeGroupsSetNodeTemplateRequestResource
+    request_object_method: true
+    resource_name_treatment: STATIC_TYPES
+    # TODO: Configure the retryable codes for this method.
+    retry_codes_name: non_idempotent
+    # TODO: Configure the retryable params for this method.
+    retry_params_name: default
+    field_name_patterns:
+      nodeGroup: projectZoneNodeGroup
+    # TODO: Configure the default timeout for a non-retrying call.
+    timeout_millis: 60000
+  # The fully qualified name of the API interface.
+- name: google.compute.v1.NodeTemplates
+  # A list of resource collection configurations.
+  # Consists of a name_pattern and an entity_name.
+  # The name_pattern is a pattern to describe the names of the resources of this
+  # collection, using the platform's conventions for URI patterns. A generator
+  # may use this to generate methods to compose and decompose such names. The
+  # pattern should use named placeholders as in `shelves/{shelf}/books/{book}`;
+  # those will be taken as hints for the parameter names of the generated
+  # methods. If empty, no name methods are generated.
+  # The entity_name is the name to be used as a basis for generated methods and
+  # classes.
+  collections:
+  - name_pattern: projects/{project}
+    entity_name: project
+  - name_pattern: projects/{project}/regions/{region}
+    entity_name: projectRegion
+  - name_pattern: projects/{project}/regions/{region}/nodeTemplates/{nodeTemplate}
+    entity_name: projectRegionNodeTemplate
+  # Definition for retryable codes.
+  retry_codes_def:
+  - name: idempotent
+    retry_codes:
+    - UNAVAILABLE
+    - DEADLINE_EXCEEDED
+  - name: non_idempotent
+    retry_codes: []
+  # Definition for retry/backoff parameters.
+  retry_params_def:
+  - name: default
+    initial_retry_delay_millis: 100
+    retry_delay_multiplier: 1.3
+    max_retry_delay_millis: 60000
+    initial_rpc_timeout_millis: 20000
+    rpc_timeout_multiplier: 1
+    max_rpc_timeout_millis: 20000
+    total_timeout_millis: 600000
+  # A list of method configurations.
+  # Common properties:
+  #   name - The simple name of the method.
+  #   flattening - Specifies the configuration for parameter flattening.
+  #       Describes the parameter groups for which a generator should produce
+  #       method overloads which allow a client to directly pass request message
+  #       fields as method parameters. This information may or may not be used,
+  #       depending on the target language.
+  #       Consists of groups, which each represent a list of parameters to be
+  #       flattened. Each parameter listed must be a field of the request
+  #       message.
+  #   required_fields - Fields that are always required for a request to be
+  #       valid.
+  #   request_object_method - Turns on or off the generation of a method whose
+  #       sole parameter is a request object. Not all languages will generate
+  #       this method.
+  #   resource_name_treatment - An enum that specifies how to treat the
+  #       resource name formats defined in the field_name_patterns
+  #       and response_field_name_patterns fields.
+  #       UNSET: default value
+  #       NONE: the collection configs will not be used by the generated code.
+  #       VALIDATE: string fields will be validated by the client against the
+  #           specified resource name formats.
+  #       STATIC_TYPES: the client will use generated types for resource names.
+  #   page_streaming - Specifies the configuration for paging.
+  #       Describes information for generating a method which transforms a
+  #       paging list RPC into a stream of resources.
+  #       Consists of a request and a response.
+  #       The request specifies request information of the list method. It
+  #       defines which fields match the paging pattern in the request. The
+  #       request consists of a page_size_field and a token_field. The
+  #       page_size_field is the name of the optional field specifying the
+  #       maximum number of elements to be returned in the response. The
+  #       token_field is the name of the field in the request containing the
+  #       page token.
+  #       The response specifies response information of the list method. It
+  #       defines which fields match the paging pattern in the response. The
+  #       response consists of a token_field and a resources_field. The
+  #       token_field is the name of the field in the response containing the
+  #       next page token. The resources_field is the name of the field in the
+  #       response containing the list of resources belonging to the page.
+  #   retry_codes_name - Specifies the configuration for retryable codes. The
+  #       name must be defined in interfaces.retry_codes_def.
+  #   retry_params_name - Specifies the configuration for retry/backoff
+  #       parameters. The name must be defined in interfaces.retry_params_def.
+  #   field_name_patterns - Maps the field name of the request type to
+  #       entity_name of interfaces.collections.
+  #       Specifies the string pattern that the field must follow.
+  #   timeout_millis - Specifies the default timeout for a non-retrying call. If
+  #       the call is retrying, refer to retry_params_name instead.
+  methods:
+  - name: compute.nodeTemplates.aggregatedList
+    # TODO: Configure which groups of fields should be flattened into method
+    # params.
+    flattening:
+      groups:
+      - parameters:
+        - project
+    # TODO: Configure which fields are required.
+    required_fields:
+    - project
+    request_object_method: true
+    resource_name_treatment: STATIC_TYPES
+    page_streaming:
+      request:
+        page_size_field: maxResults
+        token_field: pageToken
+      response:
+        token_field: nextPageToken
+        resources_field: items
+    # TODO: Configure the retryable codes for this method.
+    retry_codes_name: idempotent
+    # TODO: Configure the retryable params for this method.
+    retry_params_name: default
+    field_name_patterns:
+      project: project
+    # TODO: Configure the default timeout for a non-retrying call.
+    timeout_millis: 60000
+  - name: compute.nodeTemplates.delete
+    # TODO: Configure which groups of fields should be flattened into method
+    # params.
+    flattening:
+      groups:
+      - parameters:
+        - nodeTemplate
+    # TODO: Configure which fields are required.
+    required_fields:
+    - nodeTemplate
+    request_object_method: true
+    resource_name_treatment: STATIC_TYPES
+    # TODO: Configure the retryable codes for this method.
+    retry_codes_name: idempotent
+    # TODO: Configure the retryable params for this method.
+    retry_params_name: default
+    field_name_patterns:
+      nodeTemplate: projectRegionNodeTemplate
+    # TODO: Configure the default timeout for a non-retrying call.
+    timeout_millis: 60000
+  - name: compute.nodeTemplates.get
+    # TODO: Configure which groups of fields should be flattened into method
+    # params.
+    flattening:
+      groups:
+      - parameters:
+        - nodeTemplate
+    # TODO: Configure which fields are required.
+    required_fields:
+    - nodeTemplate
+    request_object_method: true
+    resource_name_treatment: STATIC_TYPES
+    # TODO: Configure the retryable codes for this method.
+    retry_codes_name: idempotent
+    # TODO: Configure the retryable params for this method.
+    retry_params_name: default
+    field_name_patterns:
+      nodeTemplate: projectRegionNodeTemplate
+    # TODO: Configure the default timeout for a non-retrying call.
+    timeout_millis: 60000
+  - name: compute.nodeTemplates.insert
+    # TODO: Configure which groups of fields should be flattened into method
+    # params.
+    flattening:
+      groups:
+      - parameters:
+        - region
+        - nodeTemplateResource
+    # TODO: Configure which fields are required.
+    required_fields:
+    - region
+    - nodeTemplateResource
+    request_object_method: true
+    resource_name_treatment: STATIC_TYPES
+    # TODO: Configure the retryable codes for this method.
+    retry_codes_name: non_idempotent
+    # TODO: Configure the retryable params for this method.
+    retry_params_name: default
+    field_name_patterns:
+      region: projectRegion
+    # TODO: Configure the default timeout for a non-retrying call.
+    timeout_millis: 60000
+  - name: compute.nodeTemplates.list
+    # TODO: Configure which groups of fields should be flattened into method
+    # params.
+    flattening:
+      groups:
+      - parameters:
+        - region
+    # TODO: Configure which fields are required.
+    required_fields:
+    - region
+    request_object_method: true
+    resource_name_treatment: STATIC_TYPES
+    page_streaming:
+      request:
+        page_size_field: maxResults
+        token_field: pageToken
+      response:
+        token_field: nextPageToken
+        resources_field: items
+    # TODO: Configure the retryable codes for this method.
+    retry_codes_name: idempotent
+    # TODO: Configure the retryable params for this method.
+    retry_params_name: default
+    field_name_patterns:
+      region: projectRegion
+    # TODO: Configure the default timeout for a non-retrying call.
+    timeout_millis: 60000
+  # The fully qualified name of the API interface.
+- name: google.compute.v1.NodeTypes
+  # A list of resource collection configurations.
+  # Consists of a name_pattern and an entity_name.
+  # The name_pattern is a pattern to describe the names of the resources of this
+  # collection, using the platform's conventions for URI patterns. A generator
+  # may use this to generate methods to compose and decompose such names. The
+  # pattern should use named placeholders as in `shelves/{shelf}/books/{book}`;
+  # those will be taken as hints for the parameter names of the generated
+  # methods. If empty, no name methods are generated.
+  # The entity_name is the name to be used as a basis for generated methods and
+  # classes.
+  collections:
+  - name_pattern: projects/{project}
+    entity_name: project
+  - name_pattern: projects/{project}/zones/{zone}
+    entity_name: projectZone
+  - name_pattern: projects/{project}/zones/{zone}/nodeTypes/{nodeType}
+    entity_name: projectZoneNodeType
+  # Definition for retryable codes.
+  retry_codes_def:
+  - name: idempotent
+    retry_codes:
+    - UNAVAILABLE
+    - DEADLINE_EXCEEDED
+  - name: non_idempotent
+    retry_codes: []
+  # Definition for retry/backoff parameters.
+  retry_params_def:
+  - name: default
+    initial_retry_delay_millis: 100
+    retry_delay_multiplier: 1.3
+    max_retry_delay_millis: 60000
+    initial_rpc_timeout_millis: 20000
+    rpc_timeout_multiplier: 1
+    max_rpc_timeout_millis: 20000
+    total_timeout_millis: 600000
+  # A list of method configurations.
+  # Common properties:
+  #   name - The simple name of the method.
+  #   flattening - Specifies the configuration for parameter flattening.
+  #       Describes the parameter groups for which a generator should produce
+  #       method overloads which allow a client to directly pass request message
+  #       fields as method parameters. This information may or may not be used,
+  #       depending on the target language.
+  #       Consists of groups, which each represent a list of parameters to be
+  #       flattened. Each parameter listed must be a field of the request
+  #       message.
+  #   required_fields - Fields that are always required for a request to be
+  #       valid.
+  #   request_object_method - Turns on or off the generation of a method whose
+  #       sole parameter is a request object. Not all languages will generate
+  #       this method.
+  #   resource_name_treatment - An enum that specifies how to treat the
+  #       resource name formats defined in the field_name_patterns
+  #       and response_field_name_patterns fields.
+  #       UNSET: default value
+  #       NONE: the collection configs will not be used by the generated code.
+  #       VALIDATE: string fields will be validated by the client against the
+  #           specified resource name formats.
+  #       STATIC_TYPES: the client will use generated types for resource names.
+  #   page_streaming - Specifies the configuration for paging.
+  #       Describes information for generating a method which transforms a
+  #       paging list RPC into a stream of resources.
+  #       Consists of a request and a response.
+  #       The request specifies request information of the list method. It
+  #       defines which fields match the paging pattern in the request. The
+  #       request consists of a page_size_field and a token_field. The
+  #       page_size_field is the name of the optional field specifying the
+  #       maximum number of elements to be returned in the response. The
+  #       token_field is the name of the field in the request containing the
+  #       page token.
+  #       The response specifies response information of the list method. It
+  #       defines which fields match the paging pattern in the response. The
+  #       response consists of a token_field and a resources_field. The
+  #       token_field is the name of the field in the response containing the
+  #       next page token. The resources_field is the name of the field in the
+  #       response containing the list of resources belonging to the page.
+  #   retry_codes_name - Specifies the configuration for retryable codes. The
+  #       name must be defined in interfaces.retry_codes_def.
+  #   retry_params_name - Specifies the configuration for retry/backoff
+  #       parameters. The name must be defined in interfaces.retry_params_def.
+  #   field_name_patterns - Maps the field name of the request type to
+  #       entity_name of interfaces.collections.
+  #       Specifies the string pattern that the field must follow.
+  #   timeout_millis - Specifies the default timeout for a non-retrying call. If
+  #       the call is retrying, refer to retry_params_name instead.
+  methods:
+  - name: compute.nodeTypes.aggregatedList
+    # TODO: Configure which groups of fields should be flattened into method
+    # params.
+    flattening:
+      groups:
+      - parameters:
+        - project
+    # TODO: Configure which fields are required.
+    required_fields:
+    - project
+    request_object_method: true
+    resource_name_treatment: STATIC_TYPES
+    page_streaming:
+      request:
+        page_size_field: maxResults
+        token_field: pageToken
+      response:
+        token_field: nextPageToken
+        resources_field: items
+    # TODO: Configure the retryable codes for this method.
+    retry_codes_name: idempotent
+    # TODO: Configure the retryable params for this method.
+    retry_params_name: default
+    field_name_patterns:
+      project: project
+    # TODO: Configure the default timeout for a non-retrying call.
+    timeout_millis: 60000
+  - name: compute.nodeTypes.get
+    # TODO: Configure which groups of fields should be flattened into method
+    # params.
+    flattening:
+      groups:
+      - parameters:
+        - nodeType
+    # TODO: Configure which fields are required.
+    required_fields:
+    - nodeType
+    request_object_method: true
+    resource_name_treatment: STATIC_TYPES
+    # TODO: Configure the retryable codes for this method.
+    retry_codes_name: idempotent
+    # TODO: Configure the retryable params for this method.
+    retry_params_name: default
+    field_name_patterns:
+      nodeType: projectZoneNodeType
+    # TODO: Configure the default timeout for a non-retrying call.
+    timeout_millis: 60000
+  - name: compute.nodeTypes.list
+    # TODO: Configure which groups of fields should be flattened into method
+    # params.
+    flattening:
+      groups:
+      - parameters:
+        - zone
+    # TODO: Configure which fields are required.
+    required_fields:
+    - zone
+    request_object_method: true
+    resource_name_treatment: STATIC_TYPES
+    page_streaming:
+      request:
+        page_size_field: maxResults
+        token_field: pageToken
+      response:
+        token_field: nextPageToken
+        resources_field: items
+    # TODO: Configure the retryable codes for this method.
+    retry_codes_name: idempotent
+    # TODO: Configure the retryable params for this method.
+    retry_params_name: default
+    field_name_patterns:
+      zone: projectZone
+    # TODO: Configure the default timeout for a non-retrying call.
+    timeout_millis: 60000
+  # The fully qualified name of the API interface.
 - name: google.compute.v1.Projects
   # A list of resource collection configurations.
   # Consists of a name_pattern and an entity_name.
@@ -6716,6 +7381,28 @@ interfaces:
     required_fields:
     - project
     - metadataResource
+    request_object_method: true
+    resource_name_treatment: STATIC_TYPES
+    # TODO: Configure the retryable codes for this method.
+    retry_codes_name: non_idempotent
+    # TODO: Configure the retryable params for this method.
+    retry_params_name: default
+    field_name_patterns:
+      project: project
+    # TODO: Configure the default timeout for a non-retrying call.
+    timeout_millis: 60000
+  - name: compute.projects.setDefaultNetworkTier
+    # TODO: Configure which groups of fields should be flattened into method
+    # params.
+    flattening:
+      groups:
+      - parameters:
+        - project
+        - projectsSetDefaultNetworkTierRequestResource
+    # TODO: Configure which fields are required.
+    required_fields:
+    - project
+    - projectsSetDefaultNetworkTierRequestResource
     request_object_method: true
     resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
@@ -9851,6 +10538,33 @@ interfaces:
       region: projectRegion
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
+  - name: compute.subnetworks.listUsable
+    # TODO: Configure which groups of fields should be flattened into method
+    # params.
+    flattening:
+      groups:
+      - parameters:
+        - project
+    # TODO: Configure which fields are required.
+    required_fields:
+    - project
+    request_object_method: true
+    resource_name_treatment: STATIC_TYPES
+    page_streaming:
+      request:
+        page_size_field: maxResults
+        token_field: pageToken
+      response:
+        token_field: nextPageToken
+        resources_field: items
+    # TODO: Configure the retryable codes for this method.
+    retry_codes_name: idempotent
+    # TODO: Configure the retryable params for this method.
+    retry_params_name: default
+    field_name_patterns:
+      project: project
+    # TODO: Configure the default timeout for a non-retrying call.
+    timeout_millis: 60000
   - name: compute.subnetworks.patch
     # TODO: Configure which groups of fields should be flattened into method
     # params.
@@ -12872,6 +13586,57 @@ resource_name_generation:
 - message_name: SwitchToCustomModeNetworkHttpRequest
   field_entity_map:
     network: projectGlobalNetwork
+- message_name: AddNodesNodeGroupHttpRequest
+  field_entity_map:
+    nodeGroup: projectZoneNodeGroup
+- message_name: AggregatedListNodeGroupsHttpRequest
+  field_entity_map:
+    project: project
+- message_name: DeleteNodeGroupHttpRequest
+  field_entity_map:
+    nodeGroup: projectZoneNodeGroup
+- message_name: DeleteNodesNodeGroupHttpRequest
+  field_entity_map:
+    nodeGroup: projectZoneNodeGroup
+- message_name: GetNodeGroupHttpRequest
+  field_entity_map:
+    nodeGroup: projectZoneNodeGroup
+- message_name: InsertNodeGroupHttpRequest
+  field_entity_map:
+    zone: projectZone
+- message_name: ListNodeGroupsHttpRequest
+  field_entity_map:
+    zone: projectZone
+- message_name: ListNodesNodeGroupsHttpRequest
+  field_entity_map:
+    nodeGroup: projectZoneNodeGroup
+- message_name: SetNodeTemplateNodeGroupHttpRequest
+  field_entity_map:
+    nodeGroup: projectZoneNodeGroup
+- message_name: AggregatedListNodeTemplatesHttpRequest
+  field_entity_map:
+    project: project
+- message_name: DeleteNodeTemplateHttpRequest
+  field_entity_map:
+    nodeTemplate: projectRegionNodeTemplate
+- message_name: GetNodeTemplateHttpRequest
+  field_entity_map:
+    nodeTemplate: projectRegionNodeTemplate
+- message_name: InsertNodeTemplateHttpRequest
+  field_entity_map:
+    region: projectRegion
+- message_name: ListNodeTemplatesHttpRequest
+  field_entity_map:
+    region: projectRegion
+- message_name: AggregatedListNodeTypesHttpRequest
+  field_entity_map:
+    project: project
+- message_name: GetNodeTypeHttpRequest
+  field_entity_map:
+    nodeType: projectZoneNodeType
+- message_name: ListNodeTypesHttpRequest
+  field_entity_map:
+    zone: projectZone
 - message_name: DisableXpnHostProjectHttpRequest
   field_entity_map:
     project: project
@@ -12903,6 +13668,9 @@ resource_name_generation:
   field_entity_map:
     project: project
 - message_name: SetCommonInstanceMetadataProjectHttpRequest
+  field_entity_map:
+    project: project
+- message_name: SetDefaultNetworkTierProjectHttpRequest
   field_entity_map:
     project: project
 - message_name: SetUsageExportBucketProjectHttpRequest
@@ -13148,6 +13916,9 @@ resource_name_generation:
 - message_name: ListSubnetworksHttpRequest
   field_entity_map:
     region: projectRegion
+- message_name: ListUsableSubnetworksHttpRequest
+  field_entity_map:
+    project: project
 - message_name: PatchSubnetworkHttpRequest
   field_entity_map:
     subnetwork: projectRegionSubnetwork

--- a/gapic/google/compute/v1/compute_gapic.yaml
+++ b/gapic/google/compute/v1/compute_gapic.yaml
@@ -733,6 +733,28 @@ interfaces:
   #   timeout_millis - Specifies the default timeout for a non-retrying call. If
   #       the call is retrying, refer to retry_params_name instead.
   methods:
+  - name: compute.backendBuckets.addSignedUrlKey
+    # TODO: Configure which groups of fields should be flattened into method
+    # params.
+    flattening:
+      groups:
+      - parameters:
+        - backendBucket
+        - signedUrlKeyResource
+    # TODO: Configure which fields are required.
+    required_fields:
+    - backendBucket
+    - signedUrlKeyResource
+    request_object_method: true
+    resource_name_treatment: STATIC_TYPES
+    # TODO: Configure the retryable codes for this method.
+    retry_codes_name: non_idempotent
+    # TODO: Configure the retryable params for this method.
+    retry_params_name: default
+    field_name_patterns:
+      backendBucket: projectGlobalBackendBucket
+    # TODO: Configure the default timeout for a non-retrying call.
+    timeout_millis: 60000
   - name: compute.backendBuckets.delete
     # TODO: Configure which groups of fields should be flattened into method
     # params.
@@ -747,6 +769,28 @@ interfaces:
     resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: idempotent
+    # TODO: Configure the retryable params for this method.
+    retry_params_name: default
+    field_name_patterns:
+      backendBucket: projectGlobalBackendBucket
+    # TODO: Configure the default timeout for a non-retrying call.
+    timeout_millis: 60000
+  - name: compute.backendBuckets.deleteSignedUrlKey
+    # TODO: Configure which groups of fields should be flattened into method
+    # params.
+    flattening:
+      groups:
+      - parameters:
+        - backendBucket
+        - keyName
+    # TODO: Configure which fields are required.
+    required_fields:
+    - backendBucket
+    - keyName
+    request_object_method: true
+    resource_name_treatment: STATIC_TYPES
+    # TODO: Configure the retryable codes for this method.
+    retry_codes_name: non_idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
@@ -952,6 +996,28 @@ interfaces:
   #   timeout_millis - Specifies the default timeout for a non-retrying call. If
   #       the call is retrying, refer to retry_params_name instead.
   methods:
+  - name: compute.backendServices.addSignedUrlKey
+    # TODO: Configure which groups of fields should be flattened into method
+    # params.
+    flattening:
+      groups:
+      - parameters:
+        - backendService
+        - signedUrlKeyResource
+    # TODO: Configure which fields are required.
+    required_fields:
+    - backendService
+    - signedUrlKeyResource
+    request_object_method: true
+    resource_name_treatment: STATIC_TYPES
+    # TODO: Configure the retryable codes for this method.
+    retry_codes_name: non_idempotent
+    # TODO: Configure the retryable params for this method.
+    retry_params_name: default
+    field_name_patterns:
+      backendService: projectGlobalBackendService
+    # TODO: Configure the default timeout for a non-retrying call.
+    timeout_millis: 60000
   - name: compute.backendServices.aggregatedList
     # TODO: Configure which groups of fields should be flattened into method
     # params.
@@ -993,6 +1059,28 @@ interfaces:
     resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: idempotent
+    # TODO: Configure the retryable params for this method.
+    retry_params_name: default
+    field_name_patterns:
+      backendService: projectGlobalBackendService
+    # TODO: Configure the default timeout for a non-retrying call.
+    timeout_millis: 60000
+  - name: compute.backendServices.deleteSignedUrlKey
+    # TODO: Configure which groups of fields should be flattened into method
+    # params.
+    flattening:
+      groups:
+      - parameters:
+        - backendService
+        - keyName
+    # TODO: Configure which fields are required.
+    required_fields:
+    - backendService
+    - keyName
+    request_object_method: true
+    resource_name_treatment: STATIC_TYPES
+    # TODO: Configure the retryable codes for this method.
+    retry_codes_name: non_idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
@@ -5204,6 +5292,28 @@ interfaces:
     retry_params_name: default
     field_name_patterns:
       region: projectRegion
+    # TODO: Configure the default timeout for a non-retrying call.
+    timeout_millis: 60000
+  - name: compute.interconnectAttachments.patch
+    # TODO: Configure which groups of fields should be flattened into method
+    # params.
+    flattening:
+      groups:
+      - parameters:
+        - interconnectAttachment
+        - interconnectAttachmentResource
+    # TODO: Configure which fields are required.
+    required_fields:
+    - interconnectAttachment
+    - interconnectAttachmentResource
+    request_object_method: true
+    resource_name_treatment: STATIC_TYPES
+    # TODO: Configure the retryable codes for this method.
+    retry_codes_name: non_idempotent
+    # TODO: Configure the retryable params for this method.
+    retry_params_name: default
+    field_name_patterns:
+      interconnectAttachment: projectRegionInterconnectAttachment
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
   # The fully qualified name of the API interface.
@@ -10161,6 +10271,28 @@ interfaces:
       project: project
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
+  - name: compute.targetHttpsProxies.setQuicOverride
+    # TODO: Configure which groups of fields should be flattened into method
+    # params.
+    flattening:
+      groups:
+      - parameters:
+        - targetHttpsProxy
+        - targetHttpsProxiesSetQuicOverrideRequestResource
+    # TODO: Configure which fields are required.
+    required_fields:
+    - targetHttpsProxy
+    - targetHttpsProxiesSetQuicOverrideRequestResource
+    request_object_method: true
+    resource_name_treatment: STATIC_TYPES
+    # TODO: Configure the retryable codes for this method.
+    retry_codes_name: non_idempotent
+    # TODO: Configure the retryable params for this method.
+    retry_params_name: default
+    field_name_patterns:
+      targetHttpsProxy: projectGlobalTargetHttpsProxy
+    # TODO: Configure the default timeout for a non-retrying call.
+    timeout_millis: 60000
   - name: compute.targetHttpsProxies.setSslCertificates
     # TODO: Configure which groups of fields should be flattened into method
     # params.
@@ -12254,7 +12386,13 @@ resource_name_generation:
 - message_name: UpdateAutoscalerHttpRequest
   field_entity_map:
     zone: projectZone
+- message_name: AddSignedUrlKeyBackendBucketHttpRequest
+  field_entity_map:
+    backendBucket: projectGlobalBackendBucket
 - message_name: DeleteBackendBucketHttpRequest
+  field_entity_map:
+    backendBucket: projectGlobalBackendBucket
+- message_name: DeleteSignedUrlKeyBackendBucketHttpRequest
   field_entity_map:
     backendBucket: projectGlobalBackendBucket
 - message_name: GetBackendBucketHttpRequest
@@ -12272,10 +12410,16 @@ resource_name_generation:
 - message_name: UpdateBackendBucketHttpRequest
   field_entity_map:
     backendBucket: projectGlobalBackendBucket
+- message_name: AddSignedUrlKeyBackendServiceHttpRequest
+  field_entity_map:
+    backendService: projectGlobalBackendService
 - message_name: AggregatedListBackendServicesHttpRequest
   field_entity_map:
     project: project
 - message_name: DeleteBackendServiceHttpRequest
+  field_entity_map:
+    backendService: projectGlobalBackendService
+- message_name: DeleteSignedUrlKeyBackendServiceHttpRequest
   field_entity_map:
     backendService: projectGlobalBackendService
 - message_name: GetBackendServiceHttpRequest
@@ -12650,6 +12794,9 @@ resource_name_generation:
 - message_name: ListInterconnectAttachmentsHttpRequest
   field_entity_map:
     region: projectRegion
+- message_name: PatchInterconnectAttachmentHttpRequest
+  field_entity_map:
+    interconnectAttachment: projectRegionInterconnectAttachment
 - message_name: GetInterconnectLocationHttpRequest
   field_entity_map:
     interconnectLocation: projectGlobalInterconnectLocation
@@ -13034,6 +13181,9 @@ resource_name_generation:
 - message_name: ListTargetHttpsProxiesHttpRequest
   field_entity_map:
     project: project
+- message_name: SetQuicOverrideTargetHttpsProxyHttpRequest
+  field_entity_map:
+    targetHttpsProxy: projectGlobalTargetHttpsProxy
 - message_name: SetSslCertificatesTargetHttpsProxyHttpRequest
   field_entity_map:
     targetHttpsProxy: projectTargetHttpsProxy


### PR DESCRIPTION
Ran `artman --config=gapic/google/compute/artman_compute.yaml --root-dir=`pwd` --local generate discogapic_config`
on latest compute.v1.json.

Successfully generated a client from this config afterwards.