### PR TITLE
Regenerate compute_gapic.yaml

### DIFF
--- a/gapic/google/compute/v1/compute_gapic.yaml
+++ b/gapic/google/compute/v1/compute_gapic.yaml
@@ -1200,6 +1200,28 @@ interfaces:
       backendService: projectGlobalBackendService
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
+  - name: compute.backendServices.setSecurityPolicy
+    # TODO: Configure which groups of fields should be flattened into method
+    # params.
+    flattening:
+      groups:
+      - parameters:
+        - backendService
+        - securityPolicyReferenceResource
+    # TODO: Configure which fields are required.
+    required_fields:
+    - backendService
+    - securityPolicyReferenceResource
+    request_object_method: true
+    resource_name_treatment: STATIC_TYPES
+    # TODO: Configure the retryable codes for this method.
+    retry_codes_name: non_idempotent
+    # TODO: Configure the retryable params for this method.
+    retry_params_name: default
+    field_name_patterns:
+      backendService: projectGlobalBackendService
+    # TODO: Configure the default timeout for a non-retrying call.
+    timeout_millis: 60000
   - name: compute.backendServices.update
     # TODO: Configure which groups of fields should be flattened into method
     # params.
@@ -4970,6 +4992,26 @@ interfaces:
     required_fields:
     - instance
     - tagsResource
+    request_object_method: true
+    resource_name_treatment: STATIC_TYPES
+    # TODO: Configure the retryable codes for this method.
+    retry_codes_name: non_idempotent
+    # TODO: Configure the retryable params for this method.
+    retry_params_name: default
+    field_name_patterns:
+      instance: projectZoneInstance
+    # TODO: Configure the default timeout for a non-retrying call.
+    timeout_millis: 60000
+  - name: compute.instances.simulateMaintenanceEvent
+    # TODO: Configure which groups of fields should be flattened into method
+    # params.
+    flattening:
+      groups:
+      - parameters:
+        - instance
+    # TODO: Configure which fields are required.
+    required_fields:
+    - instance
     request_object_method: true
     resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
@@ -9744,6 +9786,293 @@ interfaces:
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
   # The fully qualified name of the API interface.
+- name: google.compute.v1.SecurityPolicies
+  # A list of resource collection configurations.
+  # Consists of a name_pattern and an entity_name.
+  # The name_pattern is a pattern to describe the names of the resources of this
+  # collection, using the platform's conventions for URI patterns. A generator
+  # may use this to generate methods to compose and decompose such names. The
+  # pattern should use named placeholders as in `shelves/{shelf}/books/{book}`;
+  # those will be taken as hints for the parameter names of the generated
+  # methods. If empty, no name methods are generated.
+  # The entity_name is the name to be used as a basis for generated methods and
+  # classes.
+  collections:
+  - name_pattern: projects/{project}
+    entity_name: project
+  - name_pattern: projects/{project}/global/securityPolicies/{securityPolicy}
+    entity_name: projectGlobalSecurityPolicy
+  # Definition for retryable codes.
+  retry_codes_def:
+  - name: idempotent
+    retry_codes:
+    - UNAVAILABLE
+    - DEADLINE_EXCEEDED
+  - name: non_idempotent
+    retry_codes: []
+  # Definition for retry/backoff parameters.
+  retry_params_def:
+  - name: default
+    initial_retry_delay_millis: 100
+    retry_delay_multiplier: 1.3
+    max_retry_delay_millis: 60000
+    initial_rpc_timeout_millis: 20000
+    rpc_timeout_multiplier: 1
+    max_rpc_timeout_millis: 20000
+    total_timeout_millis: 600000
+  # A list of method configurations.
+  # Common properties:
+  #   name - The simple name of the method.
+  #   flattening - Specifies the configuration for parameter flattening.
+  #       Describes the parameter groups for which a generator should produce
+  #       method overloads which allow a client to directly pass request message
+  #       fields as method parameters. This information may or may not be used,
+  #       depending on the target language.
+  #       Consists of groups, which each represent a list of parameters to be
+  #       flattened. Each parameter listed must be a field of the request
+  #       message.
+  #   required_fields - Fields that are always required for a request to be
+  #       valid.
+  #   request_object_method - Turns on or off the generation of a method whose
+  #       sole parameter is a request object. Not all languages will generate
+  #       this method.
+  #   resource_name_treatment - An enum that specifies how to treat the
+  #       resource name formats defined in the field_name_patterns
+  #       and response_field_name_patterns fields.
+  #       UNSET: default value
+  #       NONE: the collection configs will not be used by the generated code.
+  #       VALIDATE: string fields will be validated by the client against the
+  #           specified resource name formats.
+  #       STATIC_TYPES: the client will use generated types for resource names.
+  #   page_streaming - Specifies the configuration for paging.
+  #       Describes information for generating a method which transforms a
+  #       paging list RPC into a stream of resources.
+  #       Consists of a request and a response.
+  #       The request specifies request information of the list method. It
+  #       defines which fields match the paging pattern in the request. The
+  #       request consists of a page_size_field and a token_field. The
+  #       page_size_field is the name of the optional field specifying the
+  #       maximum number of elements to be returned in the response. The
+  #       token_field is the name of the field in the request containing the
+  #       page token.
+  #       The response specifies response information of the list method. It
+  #       defines which fields match the paging pattern in the response. The
+  #       response consists of a token_field and a resources_field. The
+  #       token_field is the name of the field in the response containing the
+  #       next page token. The resources_field is the name of the field in the
+  #       response containing the list of resources belonging to the page.
+  #   retry_codes_name - Specifies the configuration for retryable codes. The
+  #       name must be defined in interfaces.retry_codes_def.
+  #   retry_params_name - Specifies the configuration for retry/backoff
+  #       parameters. The name must be defined in interfaces.retry_params_def.
+  #   field_name_patterns - Maps the field name of the request type to
+  #       entity_name of interfaces.collections.
+  #       Specifies the string pattern that the field must follow.
+  #   timeout_millis - Specifies the default timeout for a non-retrying call. If
+  #       the call is retrying, refer to retry_params_name instead.
+  methods:
+  - name: compute.securityPolicies.addRule
+    # TODO: Configure which groups of fields should be flattened into method
+    # params.
+    flattening:
+      groups:
+      - parameters:
+        - securityPolicy
+        - securityPolicyRuleResource
+    # TODO: Configure which fields are required.
+    required_fields:
+    - securityPolicy
+    - securityPolicyRuleResource
+    request_object_method: true
+    resource_name_treatment: STATIC_TYPES
+    # TODO: Configure the retryable codes for this method.
+    retry_codes_name: non_idempotent
+    # TODO: Configure the retryable params for this method.
+    retry_params_name: default
+    field_name_patterns:
+      securityPolicy: projectGlobalSecurityPolicy
+    # TODO: Configure the default timeout for a non-retrying call.
+    timeout_millis: 60000
+  - name: compute.securityPolicies.delete
+    # TODO: Configure which groups of fields should be flattened into method
+    # params.
+    flattening:
+      groups:
+      - parameters:
+        - securityPolicy
+    # TODO: Configure which fields are required.
+    required_fields:
+    - securityPolicy
+    request_object_method: true
+    resource_name_treatment: STATIC_TYPES
+    # TODO: Configure the retryable codes for this method.
+    retry_codes_name: idempotent
+    # TODO: Configure the retryable params for this method.
+    retry_params_name: default
+    field_name_patterns:
+      securityPolicy: projectGlobalSecurityPolicy
+    # TODO: Configure the default timeout for a non-retrying call.
+    timeout_millis: 60000
+  - name: compute.securityPolicies.get
+    # TODO: Configure which groups of fields should be flattened into method
+    # params.
+    flattening:
+      groups:
+      - parameters:
+        - securityPolicy
+    # TODO: Configure which fields are required.
+    required_fields:
+    - securityPolicy
+    request_object_method: true
+    resource_name_treatment: STATIC_TYPES
+    # TODO: Configure the retryable codes for this method.
+    retry_codes_name: idempotent
+    # TODO: Configure the retryable params for this method.
+    retry_params_name: default
+    field_name_patterns:
+      securityPolicy: projectGlobalSecurityPolicy
+    # TODO: Configure the default timeout for a non-retrying call.
+    timeout_millis: 60000
+  - name: compute.securityPolicies.getRule
+    # TODO: Configure which groups of fields should be flattened into method
+    # params.
+    flattening:
+      groups:
+      - parameters:
+        - priority
+        - securityPolicy
+    # TODO: Configure which fields are required.
+    required_fields:
+    - priority
+    - securityPolicy
+    request_object_method: true
+    resource_name_treatment: STATIC_TYPES
+    # TODO: Configure the retryable codes for this method.
+    retry_codes_name: idempotent
+    # TODO: Configure the retryable params for this method.
+    retry_params_name: default
+    field_name_patterns:
+      securityPolicy: projectGlobalSecurityPolicy
+    # TODO: Configure the default timeout for a non-retrying call.
+    timeout_millis: 60000
+  - name: compute.securityPolicies.insert
+    # TODO: Configure which groups of fields should be flattened into method
+    # params.
+    flattening:
+      groups:
+      - parameters:
+        - project
+        - securityPolicyResource
+    # TODO: Configure which fields are required.
+    required_fields:
+    - project
+    - securityPolicyResource
+    request_object_method: true
+    resource_name_treatment: STATIC_TYPES
+    # TODO: Configure the retryable codes for this method.
+    retry_codes_name: non_idempotent
+    # TODO: Configure the retryable params for this method.
+    retry_params_name: default
+    field_name_patterns:
+      project: project
+    # TODO: Configure the default timeout for a non-retrying call.
+    timeout_millis: 60000
+  - name: compute.securityPolicies.list
+    # TODO: Configure which groups of fields should be flattened into method
+    # params.
+    flattening:
+      groups:
+      - parameters:
+        - project
+    # TODO: Configure which fields are required.
+    required_fields:
+    - project
+    request_object_method: true
+    resource_name_treatment: STATIC_TYPES
+    page_streaming:
+      request:
+        page_size_field: maxResults
+        token_field: pageToken
+      response:
+        token_field: nextPageToken
+        resources_field: items
+    # TODO: Configure the retryable codes for this method.
+    retry_codes_name: idempotent
+    # TODO: Configure the retryable params for this method.
+    retry_params_name: default
+    field_name_patterns:
+      project: project
+    # TODO: Configure the default timeout for a non-retrying call.
+    timeout_millis: 60000
+  - name: compute.securityPolicies.patch
+    # TODO: Configure which groups of fields should be flattened into method
+    # params.
+    flattening:
+      groups:
+      - parameters:
+        - securityPolicy
+        - securityPolicyResource
+    # TODO: Configure which fields are required.
+    required_fields:
+    - securityPolicy
+    - securityPolicyResource
+    request_object_method: true
+    resource_name_treatment: STATIC_TYPES
+    # TODO: Configure the retryable codes for this method.
+    retry_codes_name: non_idempotent
+    # TODO: Configure the retryable params for this method.
+    retry_params_name: default
+    field_name_patterns:
+      securityPolicy: projectGlobalSecurityPolicy
+    # TODO: Configure the default timeout for a non-retrying call.
+    timeout_millis: 60000
+  - name: compute.securityPolicies.patchRule
+    # TODO: Configure which groups of fields should be flattened into method
+    # params.
+    flattening:
+      groups:
+      - parameters:
+        - priority
+        - securityPolicy
+        - securityPolicyRuleResource
+    # TODO: Configure which fields are required.
+    required_fields:
+    - priority
+    - securityPolicy
+    - securityPolicyRuleResource
+    request_object_method: true
+    resource_name_treatment: STATIC_TYPES
+    # TODO: Configure the retryable codes for this method.
+    retry_codes_name: non_idempotent
+    # TODO: Configure the retryable params for this method.
+    retry_params_name: default
+    field_name_patterns:
+      securityPolicy: projectGlobalSecurityPolicy
+    # TODO: Configure the default timeout for a non-retrying call.
+    timeout_millis: 60000
+  - name: compute.securityPolicies.removeRule
+    # TODO: Configure which groups of fields should be flattened into method
+    # params.
+    flattening:
+      groups:
+      - parameters:
+        - priority
+        - securityPolicy
+    # TODO: Configure which fields are required.
+    required_fields:
+    - priority
+    - securityPolicy
+    request_object_method: true
+    resource_name_treatment: STATIC_TYPES
+    # TODO: Configure the retryable codes for this method.
+    retry_codes_name: non_idempotent
+    # TODO: Configure the retryable params for this method.
+    retry_params_name: default
+    field_name_patterns:
+      securityPolicy: projectGlobalSecurityPolicy
+    # TODO: Configure the default timeout for a non-retrying call.
+    timeout_millis: 60000
+  # The fully qualified name of the API interface.
 - name: google.compute.v1.Snapshots
   # A list of resource collection configurations.
   # Consists of a name_pattern and an entity_name.
@@ -13151,6 +13480,9 @@ resource_name_generation:
 - message_name: PatchBackendServiceHttpRequest
   field_entity_map:
     backendService: projectGlobalBackendService
+- message_name: SetSecurityPolicyBackendServiceHttpRequest
+  field_entity_map:
+    backendService: projectGlobalBackendService
 - message_name: UpdateBackendServiceHttpRequest
   field_entity_map:
     backendService: projectGlobalBackendService
@@ -13476,6 +13808,9 @@ resource_name_generation:
   field_entity_map:
     instance: projectZoneInstance
 - message_name: SetTagsInstanceHttpRequest
+  field_entity_map:
+    instance: projectZoneInstance
+- message_name: SimulateMaintenanceEventInstanceHttpRequest
   field_entity_map:
     instance: projectZoneInstance
 - message_name: StartInstanceHttpRequest
@@ -13856,6 +14191,33 @@ resource_name_generation:
 - message_name: ListRoutesHttpRequest
   field_entity_map:
     project: project
+- message_name: AddRuleSecurityPolicyHttpRequest
+  field_entity_map:
+    securityPolicy: projectGlobalSecurityPolicy
+- message_name: DeleteSecurityPolicyHttpRequest
+  field_entity_map:
+    securityPolicy: projectGlobalSecurityPolicy
+- message_name: GetSecurityPolicyHttpRequest
+  field_entity_map:
+    securityPolicy: projectGlobalSecurityPolicy
+- message_name: GetRuleSecurityPolicyHttpRequest
+  field_entity_map:
+    securityPolicy: projectGlobalSecurityPolicy
+- message_name: InsertSecurityPolicyHttpRequest
+  field_entity_map:
+    project: project
+- message_name: ListSecurityPoliciesHttpRequest
+  field_entity_map:
+    project: project
+- message_name: PatchSecurityPolicyHttpRequest
+  field_entity_map:
+    securityPolicy: projectGlobalSecurityPolicy
+- message_name: PatchRuleSecurityPolicyHttpRequest
+  field_entity_map:
+    securityPolicy: projectGlobalSecurityPolicy
+- message_name: RemoveRuleSecurityPolicyHttpRequest
+  field_entity_map:
+    securityPolicy: projectGlobalSecurityPolicy
 - message_name: DeleteSnapshotHttpRequest
   field_entity_map:
     snapshot: projectGlobalSnapshot


### PR DESCRIPTION
We need to regenerate the gapic config for compute in order to refresh the library itself, because the gapic config defines new resource types and methods that were introduced in the compute Discovery doc.