### PR TITLE
Regen compute_gapic.yaml from gapic-generator:master

### DIFF
--- a/gapic/google/compute/v1/compute_gapic.yaml
+++ b/gapic/google/compute/v1/compute_gapic.yaml
@@ -79,9 +79,6 @@ interfaces:
   #       message.
   #   required_fields - Fields that are always required for a request to be
   #       valid.
-  #   request_object_method - Turns on or off the generation of a method whose
-  #       sole parameter is a request object. Not all languages will generate
-  #       this method.
   #   resource_name_treatment - An enum that specifies how to treat the
   #       resource name formats defined in the field_name_patterns
   #       and response_field_name_patterns fields.
@@ -127,7 +124,6 @@ interfaces:
     # TODO: Configure which fields are required.
     required_fields:
     - project
-    request_object_method: true
     resource_name_treatment: STATIC_TYPES
     page_streaming:
       request:
@@ -154,7 +150,6 @@ interfaces:
     # TODO: Configure which fields are required.
     required_fields:
     - acceleratorType
-    request_object_method: true
     resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: idempotent
@@ -174,7 +169,6 @@ interfaces:
     # TODO: Configure which fields are required.
     required_fields:
     - zone
-    request_object_method: true
     resource_name_treatment: STATIC_TYPES
     page_streaming:
       request:
@@ -241,9 +235,6 @@ interfaces:
   #       message.
   #   required_fields - Fields that are always required for a request to be
   #       valid.
-  #   request_object_method - Turns on or off the generation of a method whose
-  #       sole parameter is a request object. Not all languages will generate
-  #       this method.
   #   resource_name_treatment - An enum that specifies how to treat the
   #       resource name formats defined in the field_name_patterns
   #       and response_field_name_patterns fields.
@@ -289,7 +280,6 @@ interfaces:
     # TODO: Configure which fields are required.
     required_fields:
     - project
-    request_object_method: true
     resource_name_treatment: STATIC_TYPES
     page_streaming:
       request:
@@ -316,7 +306,6 @@ interfaces:
     # TODO: Configure which fields are required.
     required_fields:
     - address
-    request_object_method: true
     resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: idempotent
@@ -336,7 +325,6 @@ interfaces:
     # TODO: Configure which fields are required.
     required_fields:
     - address
-    request_object_method: true
     resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: idempotent
@@ -358,7 +346,6 @@ interfaces:
     required_fields:
     - region
     - addressResource
-    request_object_method: true
     resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: non_idempotent
@@ -378,7 +365,6 @@ interfaces:
     # TODO: Configure which fields are required.
     required_fields:
     - region
-    request_object_method: true
     resource_name_treatment: STATIC_TYPES
     page_streaming:
       request:
@@ -445,9 +431,6 @@ interfaces:
   #       message.
   #   required_fields - Fields that are always required for a request to be
   #       valid.
-  #   request_object_method - Turns on or off the generation of a method whose
-  #       sole parameter is a request object. Not all languages will generate
-  #       this method.
   #   resource_name_treatment - An enum that specifies how to treat the
   #       resource name formats defined in the field_name_patterns
   #       and response_field_name_patterns fields.
@@ -493,7 +476,6 @@ interfaces:
     # TODO: Configure which fields are required.
     required_fields:
     - project
-    request_object_method: true
     resource_name_treatment: STATIC_TYPES
     page_streaming:
       request:
@@ -520,7 +502,6 @@ interfaces:
     # TODO: Configure which fields are required.
     required_fields:
     - autoscaler
-    request_object_method: true
     resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: idempotent
@@ -540,7 +521,6 @@ interfaces:
     # TODO: Configure which fields are required.
     required_fields:
     - autoscaler
-    request_object_method: true
     resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: idempotent
@@ -562,7 +542,6 @@ interfaces:
     required_fields:
     - zone
     - autoscalerResource
-    request_object_method: true
     resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: non_idempotent
@@ -582,7 +561,6 @@ interfaces:
     # TODO: Configure which fields are required.
     required_fields:
     - zone
-    request_object_method: true
     resource_name_treatment: STATIC_TYPES
     page_streaming:
       request:
@@ -613,7 +591,6 @@ interfaces:
     - autoscaler
     - zone
     - autoscalerResource
-    request_object_method: true
     resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: non_idempotent
@@ -637,7 +614,6 @@ interfaces:
     - autoscaler
     - zone
     - autoscalerResource
-    request_object_method: true
     resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: idempotent
@@ -695,9 +671,6 @@ interfaces:
   #       message.
   #   required_fields - Fields that are always required for a request to be
   #       valid.
-  #   request_object_method - Turns on or off the generation of a method whose
-  #       sole parameter is a request object. Not all languages will generate
-  #       this method.
   #   resource_name_treatment - An enum that specifies how to treat the
   #       resource name formats defined in the field_name_patterns
   #       and response_field_name_patterns fields.
@@ -745,7 +718,6 @@ interfaces:
     required_fields:
     - backendBucket
     - signedUrlKeyResource
-    request_object_method: true
     resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: non_idempotent
@@ -765,7 +737,6 @@ interfaces:
     # TODO: Configure which fields are required.
     required_fields:
     - backendBucket
-    request_object_method: true
     resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: idempotent
@@ -787,7 +758,6 @@ interfaces:
     required_fields:
     - backendBucket
     - keyName
-    request_object_method: true
     resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: non_idempotent
@@ -807,7 +777,6 @@ interfaces:
     # TODO: Configure which fields are required.
     required_fields:
     - backendBucket
-    request_object_method: true
     resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: idempotent
@@ -829,7 +798,6 @@ interfaces:
     required_fields:
     - project
     - backendBucketResource
-    request_object_method: true
     resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: non_idempotent
@@ -849,7 +817,6 @@ interfaces:
     # TODO: Configure which fields are required.
     required_fields:
     - project
-    request_object_method: true
     resource_name_treatment: STATIC_TYPES
     page_streaming:
       request:
@@ -878,7 +845,6 @@ interfaces:
     required_fields:
     - backendBucket
     - backendBucketResource
-    request_object_method: true
     resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: non_idempotent
@@ -900,7 +866,6 @@ interfaces:
     required_fields:
     - backendBucket
     - backendBucketResource
-    request_object_method: true
     resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: idempotent
@@ -958,9 +923,6 @@ interfaces:
   #       message.
   #   required_fields - Fields that are always required for a request to be
   #       valid.
-  #   request_object_method - Turns on or off the generation of a method whose
-  #       sole parameter is a request object. Not all languages will generate
-  #       this method.
   #   resource_name_treatment - An enum that specifies how to treat the
   #       resource name formats defined in the field_name_patterns
   #       and response_field_name_patterns fields.
@@ -1008,7 +970,6 @@ interfaces:
     required_fields:
     - backendService
     - signedUrlKeyResource
-    request_object_method: true
     resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: non_idempotent
@@ -1028,7 +989,6 @@ interfaces:
     # TODO: Configure which fields are required.
     required_fields:
     - project
-    request_object_method: true
     resource_name_treatment: STATIC_TYPES
     page_streaming:
       request:
@@ -1055,7 +1015,6 @@ interfaces:
     # TODO: Configure which fields are required.
     required_fields:
     - backendService
-    request_object_method: true
     resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: idempotent
@@ -1077,7 +1036,6 @@ interfaces:
     required_fields:
     - backendService
     - keyName
-    request_object_method: true
     resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: non_idempotent
@@ -1097,7 +1055,6 @@ interfaces:
     # TODO: Configure which fields are required.
     required_fields:
     - backendService
-    request_object_method: true
     resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: idempotent
@@ -1119,7 +1076,6 @@ interfaces:
     required_fields:
     - backendService
     - resourceGroupReferenceResource
-    request_object_method: true
     resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: non_idempotent
@@ -1141,7 +1097,6 @@ interfaces:
     required_fields:
     - project
     - backendServiceResource
-    request_object_method: true
     resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: non_idempotent
@@ -1161,7 +1116,6 @@ interfaces:
     # TODO: Configure which fields are required.
     required_fields:
     - project
-    request_object_method: true
     resource_name_treatment: STATIC_TYPES
     page_streaming:
       request:
@@ -1190,7 +1144,6 @@ interfaces:
     required_fields:
     - backendService
     - backendServiceResource
-    request_object_method: true
     resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: non_idempotent
@@ -1212,7 +1165,6 @@ interfaces:
     required_fields:
     - backendService
     - securityPolicyReferenceResource
-    request_object_method: true
     resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: non_idempotent
@@ -1234,7 +1186,6 @@ interfaces:
     required_fields:
     - backendService
     - backendServiceResource
-    request_object_method: true
     resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: idempotent
@@ -1294,9 +1245,6 @@ interfaces:
   #       message.
   #   required_fields - Fields that are always required for a request to be
   #       valid.
-  #   request_object_method - Turns on or off the generation of a method whose
-  #       sole parameter is a request object. Not all languages will generate
-  #       this method.
   #   resource_name_treatment - An enum that specifies how to treat the
   #       resource name formats defined in the field_name_patterns
   #       and response_field_name_patterns fields.
@@ -1342,7 +1290,6 @@ interfaces:
     # TODO: Configure which fields are required.
     required_fields:
     - project
-    request_object_method: true
     resource_name_treatment: STATIC_TYPES
     page_streaming:
       request:
@@ -1369,7 +1316,6 @@ interfaces:
     # TODO: Configure which fields are required.
     required_fields:
     - diskType
-    request_object_method: true
     resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: idempotent
@@ -1389,7 +1335,6 @@ interfaces:
     # TODO: Configure which fields are required.
     required_fields:
     - zone
-    request_object_method: true
     resource_name_treatment: STATIC_TYPES
     page_streaming:
       request:
@@ -1458,9 +1403,6 @@ interfaces:
   #       message.
   #   required_fields - Fields that are always required for a request to be
   #       valid.
-  #   request_object_method - Turns on or off the generation of a method whose
-  #       sole parameter is a request object. Not all languages will generate
-  #       this method.
   #   resource_name_treatment - An enum that specifies how to treat the
   #       resource name formats defined in the field_name_patterns
   #       and response_field_name_patterns fields.
@@ -1506,7 +1448,6 @@ interfaces:
     # TODO: Configure which fields are required.
     required_fields:
     - project
-    request_object_method: true
     resource_name_treatment: STATIC_TYPES
     page_streaming:
       request:
@@ -1537,7 +1478,6 @@ interfaces:
     - disk
     - guestFlush
     - snapshotResource
-    request_object_method: true
     resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: non_idempotent
@@ -1557,7 +1497,6 @@ interfaces:
     # TODO: Configure which fields are required.
     required_fields:
     - disk
-    request_object_method: true
     resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: idempotent
@@ -1577,7 +1516,6 @@ interfaces:
     # TODO: Configure which fields are required.
     required_fields:
     - disk
-    request_object_method: true
     resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: idempotent
@@ -1599,7 +1537,6 @@ interfaces:
     required_fields:
     - zone
     - diskResource
-    request_object_method: true
     resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: non_idempotent
@@ -1619,7 +1556,6 @@ interfaces:
     # TODO: Configure which fields are required.
     required_fields:
     - zone
-    request_object_method: true
     resource_name_treatment: STATIC_TYPES
     page_streaming:
       request:
@@ -1648,7 +1584,6 @@ interfaces:
     required_fields:
     - disk
     - disksResizeRequestResource
-    request_object_method: true
     resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: non_idempotent
@@ -1670,7 +1605,6 @@ interfaces:
     required_fields:
     - resource
     - zoneSetLabelsRequestResource
-    request_object_method: true
     resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: non_idempotent
@@ -1728,9 +1662,6 @@ interfaces:
   #       message.
   #   required_fields - Fields that are always required for a request to be
   #       valid.
-  #   request_object_method - Turns on or off the generation of a method whose
-  #       sole parameter is a request object. Not all languages will generate
-  #       this method.
   #   resource_name_treatment - An enum that specifies how to treat the
   #       resource name formats defined in the field_name_patterns
   #       and response_field_name_patterns fields.
@@ -1776,7 +1707,6 @@ interfaces:
     # TODO: Configure which fields are required.
     required_fields:
     - firewall
-    request_object_method: true
     resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: idempotent
@@ -1796,7 +1726,6 @@ interfaces:
     # TODO: Configure which fields are required.
     required_fields:
     - firewall
-    request_object_method: true
     resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: idempotent
@@ -1818,7 +1747,6 @@ interfaces:
     required_fields:
     - project
     - firewallResource
-    request_object_method: true
     resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: non_idempotent
@@ -1838,7 +1766,6 @@ interfaces:
     # TODO: Configure which fields are required.
     required_fields:
     - project
-    request_object_method: true
     resource_name_treatment: STATIC_TYPES
     page_streaming:
       request:
@@ -1867,7 +1794,6 @@ interfaces:
     required_fields:
     - firewall
     - firewallResource
-    request_object_method: true
     resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: non_idempotent
@@ -1889,7 +1815,6 @@ interfaces:
     required_fields:
     - firewall
     - firewallResource
-    request_object_method: true
     resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: idempotent
@@ -1949,9 +1874,6 @@ interfaces:
   #       message.
   #   required_fields - Fields that are always required for a request to be
   #       valid.
-  #   request_object_method - Turns on or off the generation of a method whose
-  #       sole parameter is a request object. Not all languages will generate
-  #       this method.
   #   resource_name_treatment - An enum that specifies how to treat the
   #       resource name formats defined in the field_name_patterns
   #       and response_field_name_patterns fields.
@@ -1997,7 +1919,6 @@ interfaces:
     # TODO: Configure which fields are required.
     required_fields:
     - project
-    request_object_method: true
     resource_name_treatment: STATIC_TYPES
     page_streaming:
       request:
@@ -2024,7 +1945,6 @@ interfaces:
     # TODO: Configure which fields are required.
     required_fields:
     - forwardingRule
-    request_object_method: true
     resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: idempotent
@@ -2044,7 +1964,6 @@ interfaces:
     # TODO: Configure which fields are required.
     required_fields:
     - forwardingRule
-    request_object_method: true
     resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: idempotent
@@ -2066,7 +1985,6 @@ interfaces:
     required_fields:
     - region
     - forwardingRuleResource
-    request_object_method: true
     resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: non_idempotent
@@ -2086,7 +2004,6 @@ interfaces:
     # TODO: Configure which fields are required.
     required_fields:
     - region
-    request_object_method: true
     resource_name_treatment: STATIC_TYPES
     page_streaming:
       request:
@@ -2115,7 +2032,6 @@ interfaces:
     required_fields:
     - forwardingRule
     - targetReferenceResource
-    request_object_method: true
     resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: non_idempotent
@@ -2173,9 +2089,6 @@ interfaces:
   #       message.
   #   required_fields - Fields that are always required for a request to be
   #       valid.
-  #   request_object_method - Turns on or off the generation of a method whose
-  #       sole parameter is a request object. Not all languages will generate
-  #       this method.
   #   resource_name_treatment - An enum that specifies how to treat the
   #       resource name formats defined in the field_name_patterns
   #       and response_field_name_patterns fields.
@@ -2221,7 +2134,6 @@ interfaces:
     # TODO: Configure which fields are required.
     required_fields:
     - address
-    request_object_method: true
     resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: idempotent
@@ -2241,7 +2153,6 @@ interfaces:
     # TODO: Configure which fields are required.
     required_fields:
     - address
-    request_object_method: true
     resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: idempotent
@@ -2263,7 +2174,6 @@ interfaces:
     required_fields:
     - project
     - addressResource
-    request_object_method: true
     resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: non_idempotent
@@ -2283,7 +2193,6 @@ interfaces:
     # TODO: Configure which fields are required.
     required_fields:
     - project
-    request_object_method: true
     resource_name_treatment: STATIC_TYPES
     page_streaming:
       request:
@@ -2348,9 +2257,6 @@ interfaces:
   #       message.
   #   required_fields - Fields that are always required for a request to be
   #       valid.
-  #   request_object_method - Turns on or off the generation of a method whose
-  #       sole parameter is a request object. Not all languages will generate
-  #       this method.
   #   resource_name_treatment - An enum that specifies how to treat the
   #       resource name formats defined in the field_name_patterns
   #       and response_field_name_patterns fields.
@@ -2396,7 +2302,6 @@ interfaces:
     # TODO: Configure which fields are required.
     required_fields:
     - forwardingRule
-    request_object_method: true
     resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: idempotent
@@ -2416,7 +2321,6 @@ interfaces:
     # TODO: Configure which fields are required.
     required_fields:
     - forwardingRule
-    request_object_method: true
     resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: idempotent
@@ -2438,7 +2342,6 @@ interfaces:
     required_fields:
     - project
     - forwardingRuleResource
-    request_object_method: true
     resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: non_idempotent
@@ -2458,7 +2361,6 @@ interfaces:
     # TODO: Configure which fields are required.
     required_fields:
     - project
-    request_object_method: true
     resource_name_treatment: STATIC_TYPES
     page_streaming:
       request:
@@ -2487,7 +2389,6 @@ interfaces:
     required_fields:
     - forwardingRule
     - targetReferenceResource
-    request_object_method: true
     resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: non_idempotent
@@ -2545,9 +2446,6 @@ interfaces:
   #       message.
   #   required_fields - Fields that are always required for a request to be
   #       valid.
-  #   request_object_method - Turns on or off the generation of a method whose
-  #       sole parameter is a request object. Not all languages will generate
-  #       this method.
   #   resource_name_treatment - An enum that specifies how to treat the
   #       resource name formats defined in the field_name_patterns
   #       and response_field_name_patterns fields.
@@ -2593,7 +2491,6 @@ interfaces:
     # TODO: Configure which fields are required.
     required_fields:
     - project
-    request_object_method: true
     resource_name_treatment: STATIC_TYPES
     page_streaming:
       request:
@@ -2620,7 +2517,6 @@ interfaces:
     # TODO: Configure which fields are required.
     required_fields:
     - operation
-    request_object_method: true
     resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: idempotent
@@ -2640,7 +2536,6 @@ interfaces:
     # TODO: Configure which fields are required.
     required_fields:
     - operation
-    request_object_method: true
     resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: idempotent
@@ -2660,7 +2555,6 @@ interfaces:
     # TODO: Configure which fields are required.
     required_fields:
     - project
-    request_object_method: true
     resource_name_treatment: STATIC_TYPES
     page_streaming:
       request:
@@ -2725,9 +2619,6 @@ interfaces:
   #       message.
   #   required_fields - Fields that are always required for a request to be
   #       valid.
-  #   request_object_method - Turns on or off the generation of a method whose
-  #       sole parameter is a request object. Not all languages will generate
-  #       this method.
   #   resource_name_treatment - An enum that specifies how to treat the
   #       resource name formats defined in the field_name_patterns
   #       and response_field_name_patterns fields.
@@ -2773,7 +2664,6 @@ interfaces:
     # TODO: Configure which fields are required.
     required_fields:
     - healthCheck
-    request_object_method: true
     resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: idempotent
@@ -2793,7 +2683,6 @@ interfaces:
     # TODO: Configure which fields are required.
     required_fields:
     - healthCheck
-    request_object_method: true
     resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: idempotent
@@ -2815,7 +2704,6 @@ interfaces:
     required_fields:
     - project
     - healthCheckResource
-    request_object_method: true
     resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: non_idempotent
@@ -2835,7 +2723,6 @@ interfaces:
     # TODO: Configure which fields are required.
     required_fields:
     - project
-    request_object_method: true
     resource_name_treatment: STATIC_TYPES
     page_streaming:
       request:
@@ -2864,7 +2751,6 @@ interfaces:
     required_fields:
     - healthCheck
     - healthCheckResource
-    request_object_method: true
     resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: non_idempotent
@@ -2886,7 +2772,6 @@ interfaces:
     required_fields:
     - healthCheck
     - healthCheckResource
-    request_object_method: true
     resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: idempotent
@@ -2944,9 +2829,6 @@ interfaces:
   #       message.
   #   required_fields - Fields that are always required for a request to be
   #       valid.
-  #   request_object_method - Turns on or off the generation of a method whose
-  #       sole parameter is a request object. Not all languages will generate
-  #       this method.
   #   resource_name_treatment - An enum that specifies how to treat the
   #       resource name formats defined in the field_name_patterns
   #       and response_field_name_patterns fields.
@@ -2992,7 +2874,6 @@ interfaces:
     # TODO: Configure which fields are required.
     required_fields:
     - httpHealthCheck
-    request_object_method: true
     resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: idempotent
@@ -3012,7 +2893,6 @@ interfaces:
     # TODO: Configure which fields are required.
     required_fields:
     - httpHealthCheck
-    request_object_method: true
     resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: idempotent
@@ -3034,7 +2914,6 @@ interfaces:
     required_fields:
     - project
     - httpHealthCheckResource
-    request_object_method: true
     resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: non_idempotent
@@ -3054,7 +2933,6 @@ interfaces:
     # TODO: Configure which fields are required.
     required_fields:
     - project
-    request_object_method: true
     resource_name_treatment: STATIC_TYPES
     page_streaming:
       request:
@@ -3083,7 +2961,6 @@ interfaces:
     required_fields:
     - httpHealthCheck
     - httpHealthCheckResource
-    request_object_method: true
     resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: non_idempotent
@@ -3105,7 +2982,6 @@ interfaces:
     required_fields:
     - httpHealthCheck
     - httpHealthCheckResource
-    request_object_method: true
     resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: idempotent
@@ -3163,9 +3039,6 @@ interfaces:
   #       message.
   #   required_fields - Fields that are always required for a request to be
   #       valid.
-  #   request_object_method - Turns on or off the generation of a method whose
-  #       sole parameter is a request object. Not all languages will generate
-  #       this method.
   #   resource_name_treatment - An enum that specifies how to treat the
   #       resource name formats defined in the field_name_patterns
   #       and response_field_name_patterns fields.
@@ -3211,7 +3084,6 @@ interfaces:
     # TODO: Configure which fields are required.
     required_fields:
     - httpsHealthCheck
-    request_object_method: true
     resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: idempotent
@@ -3231,7 +3103,6 @@ interfaces:
     # TODO: Configure which fields are required.
     required_fields:
     - httpsHealthCheck
-    request_object_method: true
     resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: idempotent
@@ -3253,7 +3124,6 @@ interfaces:
     required_fields:
     - project
     - httpsHealthCheckResource
-    request_object_method: true
     resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: non_idempotent
@@ -3273,7 +3143,6 @@ interfaces:
     # TODO: Configure which fields are required.
     required_fields:
     - project
-    request_object_method: true
     resource_name_treatment: STATIC_TYPES
     page_streaming:
       request:
@@ -3302,7 +3171,6 @@ interfaces:
     required_fields:
     - httpsHealthCheck
     - httpsHealthCheckResource
-    request_object_method: true
     resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: non_idempotent
@@ -3324,7 +3192,6 @@ interfaces:
     required_fields:
     - httpsHealthCheck
     - httpsHealthCheckResource
-    request_object_method: true
     resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: idempotent
@@ -3386,9 +3253,6 @@ interfaces:
   #       message.
   #   required_fields - Fields that are always required for a request to be
   #       valid.
-  #   request_object_method - Turns on or off the generation of a method whose
-  #       sole parameter is a request object. Not all languages will generate
-  #       this method.
   #   resource_name_treatment - An enum that specifies how to treat the
   #       resource name formats defined in the field_name_patterns
   #       and response_field_name_patterns fields.
@@ -3434,7 +3298,6 @@ interfaces:
     # TODO: Configure which fields are required.
     required_fields:
     - image
-    request_object_method: true
     resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: idempotent
@@ -3456,7 +3319,6 @@ interfaces:
     required_fields:
     - image
     - deprecationStatusResource
-    request_object_method: true
     resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: non_idempotent
@@ -3476,7 +3338,6 @@ interfaces:
     # TODO: Configure which fields are required.
     required_fields:
     - image
-    request_object_method: true
     resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: idempotent
@@ -3496,7 +3357,6 @@ interfaces:
     # TODO: Configure which fields are required.
     required_fields:
     - family
-    request_object_method: true
     resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: idempotent
@@ -3520,7 +3380,6 @@ interfaces:
     - forceCreate
     - project
     - imageResource
-    request_object_method: true
     resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: non_idempotent
@@ -3540,7 +3399,6 @@ interfaces:
     # TODO: Configure which fields are required.
     required_fields:
     - project
-    request_object_method: true
     resource_name_treatment: STATIC_TYPES
     page_streaming:
       request:
@@ -3569,7 +3427,6 @@ interfaces:
     required_fields:
     - resource
     - globalSetLabelsRequestResource
-    request_object_method: true
     resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: non_idempotent
@@ -3629,9 +3486,6 @@ interfaces:
   #       message.
   #   required_fields - Fields that are always required for a request to be
   #       valid.
-  #   request_object_method - Turns on or off the generation of a method whose
-  #       sole parameter is a request object. Not all languages will generate
-  #       this method.
   #   resource_name_treatment - An enum that specifies how to treat the
   #       resource name formats defined in the field_name_patterns
   #       and response_field_name_patterns fields.
@@ -3679,7 +3533,6 @@ interfaces:
     required_fields:
     - instanceGroupManager
     - instanceGroupManagersAbandonInstancesRequestResource
-    request_object_method: true
     resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: non_idempotent
@@ -3699,7 +3552,6 @@ interfaces:
     # TODO: Configure which fields are required.
     required_fields:
     - project
-    request_object_method: true
     resource_name_treatment: STATIC_TYPES
     page_streaming:
       request:
@@ -3726,7 +3578,6 @@ interfaces:
     # TODO: Configure which fields are required.
     required_fields:
     - instanceGroupManager
-    request_object_method: true
     resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: idempotent
@@ -3748,7 +3599,6 @@ interfaces:
     required_fields:
     - instanceGroupManager
     - instanceGroupManagersDeleteInstancesRequestResource
-    request_object_method: true
     resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: non_idempotent
@@ -3768,7 +3618,6 @@ interfaces:
     # TODO: Configure which fields are required.
     required_fields:
     - instanceGroupManager
-    request_object_method: true
     resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: idempotent
@@ -3790,7 +3639,6 @@ interfaces:
     required_fields:
     - zone
     - instanceGroupManagerResource
-    request_object_method: true
     resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: non_idempotent
@@ -3810,7 +3658,6 @@ interfaces:
     # TODO: Configure which fields are required.
     required_fields:
     - zone
-    request_object_method: true
     resource_name_treatment: STATIC_TYPES
     page_streaming:
       request:
@@ -3837,7 +3684,6 @@ interfaces:
     # TODO: Configure which fields are required.
     required_fields:
     - instanceGroupManager
-    request_object_method: true
     resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: non_idempotent
@@ -3859,7 +3705,6 @@ interfaces:
     required_fields:
     - instanceGroupManager
     - instanceGroupManagersRecreateInstancesRequestResource
-    request_object_method: true
     resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: non_idempotent
@@ -3881,7 +3726,6 @@ interfaces:
     required_fields:
     - size
     - instanceGroupManager
-    request_object_method: true
     resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: non_idempotent
@@ -3903,7 +3747,6 @@ interfaces:
     required_fields:
     - instanceGroupManager
     - instanceGroupManagersSetInstanceTemplateRequestResource
-    request_object_method: true
     resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: non_idempotent
@@ -3925,7 +3768,6 @@ interfaces:
     required_fields:
     - instanceGroupManager
     - instanceGroupManagersSetTargetPoolsRequestResource
-    request_object_method: true
     resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: non_idempotent
@@ -3985,9 +3827,6 @@ interfaces:
   #       message.
   #   required_fields - Fields that are always required for a request to be
   #       valid.
-  #   request_object_method - Turns on or off the generation of a method whose
-  #       sole parameter is a request object. Not all languages will generate
-  #       this method.
   #   resource_name_treatment - An enum that specifies how to treat the
   #       resource name formats defined in the field_name_patterns
   #       and response_field_name_patterns fields.
@@ -4035,7 +3874,6 @@ interfaces:
     required_fields:
     - instanceGroup
     - instanceGroupsAddInstancesRequestResource
-    request_object_method: true
     resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: non_idempotent
@@ -4055,7 +3893,6 @@ interfaces:
     # TODO: Configure which fields are required.
     required_fields:
     - project
-    request_object_method: true
     resource_name_treatment: STATIC_TYPES
     page_streaming:
       request:
@@ -4082,7 +3919,6 @@ interfaces:
     # TODO: Configure which fields are required.
     required_fields:
     - instanceGroup
-    request_object_method: true
     resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: idempotent
@@ -4102,7 +3938,6 @@ interfaces:
     # TODO: Configure which fields are required.
     required_fields:
     - instanceGroup
-    request_object_method: true
     resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: idempotent
@@ -4124,7 +3959,6 @@ interfaces:
     required_fields:
     - zone
     - instanceGroupResource
-    request_object_method: true
     resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: non_idempotent
@@ -4144,7 +3978,6 @@ interfaces:
     # TODO: Configure which fields are required.
     required_fields:
     - zone
-    request_object_method: true
     resource_name_treatment: STATIC_TYPES
     page_streaming:
       request:
@@ -4173,7 +4006,6 @@ interfaces:
     required_fields:
     - instanceGroup
     - instanceGroupsListInstancesRequestResource
-    request_object_method: true
     resource_name_treatment: STATIC_TYPES
     page_streaming:
       request:
@@ -4202,7 +4034,6 @@ interfaces:
     required_fields:
     - instanceGroup
     - instanceGroupsRemoveInstancesRequestResource
-    request_object_method: true
     resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: non_idempotent
@@ -4224,7 +4055,6 @@ interfaces:
     required_fields:
     - instanceGroup
     - instanceGroupsSetNamedPortsRequestResource
-    request_object_method: true
     resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: non_idempotent
@@ -4282,9 +4112,6 @@ interfaces:
   #       message.
   #   required_fields - Fields that are always required for a request to be
   #       valid.
-  #   request_object_method - Turns on or off the generation of a method whose
-  #       sole parameter is a request object. Not all languages will generate
-  #       this method.
   #   resource_name_treatment - An enum that specifies how to treat the
   #       resource name formats defined in the field_name_patterns
   #       and response_field_name_patterns fields.
@@ -4330,7 +4157,6 @@ interfaces:
     # TODO: Configure which fields are required.
     required_fields:
     - instanceTemplate
-    request_object_method: true
     resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: idempotent
@@ -4350,7 +4176,6 @@ interfaces:
     # TODO: Configure which fields are required.
     required_fields:
     - instanceTemplate
-    request_object_method: true
     resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: idempotent
@@ -4372,7 +4197,6 @@ interfaces:
     required_fields:
     - project
     - instanceTemplateResource
-    request_object_method: true
     resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: non_idempotent
@@ -4392,7 +4216,6 @@ interfaces:
     # TODO: Configure which fields are required.
     required_fields:
     - project
-    request_object_method: true
     resource_name_treatment: STATIC_TYPES
     page_streaming:
       request:
@@ -4461,9 +4284,6 @@ interfaces:
   #       message.
   #   required_fields - Fields that are always required for a request to be
   #       valid.
-  #   request_object_method - Turns on or off the generation of a method whose
-  #       sole parameter is a request object. Not all languages will generate
-  #       this method.
   #   resource_name_treatment - An enum that specifies how to treat the
   #       resource name formats defined in the field_name_patterns
   #       and response_field_name_patterns fields.
@@ -4513,7 +4333,6 @@ interfaces:
     - instance
     - networkInterface
     - accessConfigResource
-    request_object_method: true
     resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: non_idempotent
@@ -4533,7 +4352,6 @@ interfaces:
     # TODO: Configure which fields are required.
     required_fields:
     - project
-    request_object_method: true
     resource_name_treatment: STATIC_TYPES
     page_streaming:
       request:
@@ -4564,7 +4382,6 @@ interfaces:
     - instance
     - forceAttach
     - attachedDiskResource
-    request_object_method: true
     resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: non_idempotent
@@ -4584,7 +4401,6 @@ interfaces:
     # TODO: Configure which fields are required.
     required_fields:
     - instance
-    request_object_method: true
     resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: idempotent
@@ -4608,7 +4424,6 @@ interfaces:
     - instance
     - networkInterface
     - accessConfig
-    request_object_method: true
     resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: non_idempotent
@@ -4630,7 +4445,6 @@ interfaces:
     required_fields:
     - instance
     - deviceName
-    request_object_method: true
     resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: non_idempotent
@@ -4650,7 +4464,6 @@ interfaces:
     # TODO: Configure which fields are required.
     required_fields:
     - instance
-    request_object_method: true
     resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: idempotent
@@ -4674,7 +4487,6 @@ interfaces:
     - instance
     - port
     - start
-    request_object_method: true
     resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: idempotent
@@ -4696,7 +4508,6 @@ interfaces:
     required_fields:
     - zone
     - instanceResource
-    request_object_method: true
     resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: non_idempotent
@@ -4716,7 +4527,6 @@ interfaces:
     # TODO: Configure which fields are required.
     required_fields:
     - zone
-    request_object_method: true
     resource_name_treatment: STATIC_TYPES
     page_streaming:
       request:
@@ -4743,7 +4553,6 @@ interfaces:
     # TODO: Configure which fields are required.
     required_fields:
     - instance
-    request_object_method: true
     resource_name_treatment: STATIC_TYPES
     page_streaming:
       request:
@@ -4770,7 +4579,6 @@ interfaces:
     # TODO: Configure which fields are required.
     required_fields:
     - instance
-    request_object_method: true
     resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: non_idempotent
@@ -4792,7 +4600,6 @@ interfaces:
     required_fields:
     - resource
     - deletionProtection
-    request_object_method: true
     resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: non_idempotent
@@ -4816,7 +4623,6 @@ interfaces:
     - instance
     - autoDelete
     - deviceName
-    request_object_method: true
     resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: non_idempotent
@@ -4838,7 +4644,6 @@ interfaces:
     required_fields:
     - instance
     - instancesSetLabelsRequestResource
-    request_object_method: true
     resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: non_idempotent
@@ -4860,7 +4665,6 @@ interfaces:
     required_fields:
     - instance
     - instancesSetMachineResourcesRequestResource
-    request_object_method: true
     resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: non_idempotent
@@ -4882,7 +4686,6 @@ interfaces:
     required_fields:
     - instance
     - instancesSetMachineTypeRequestResource
-    request_object_method: true
     resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: non_idempotent
@@ -4904,7 +4707,6 @@ interfaces:
     required_fields:
     - instance
     - metadataResource
-    request_object_method: true
     resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: non_idempotent
@@ -4926,7 +4728,6 @@ interfaces:
     required_fields:
     - instance
     - instancesSetMinCpuPlatformRequestResource
-    request_object_method: true
     resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: non_idempotent
@@ -4948,7 +4749,6 @@ interfaces:
     required_fields:
     - instance
     - schedulingResource
-    request_object_method: true
     resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: non_idempotent
@@ -4970,7 +4770,6 @@ interfaces:
     required_fields:
     - instance
     - instancesSetServiceAccountRequestResource
-    request_object_method: true
     resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: non_idempotent
@@ -4992,7 +4791,6 @@ interfaces:
     required_fields:
     - instance
     - tagsResource
-    request_object_method: true
     resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: non_idempotent
@@ -5012,7 +4810,6 @@ interfaces:
     # TODO: Configure which fields are required.
     required_fields:
     - instance
-    request_object_method: true
     resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: non_idempotent
@@ -5032,7 +4829,6 @@ interfaces:
     # TODO: Configure which fields are required.
     required_fields:
     - instance
-    request_object_method: true
     resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: non_idempotent
@@ -5054,7 +4850,6 @@ interfaces:
     required_fields:
     - instance
     - instancesStartWithEncryptionKeyRequestResource
-    request_object_method: true
     resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: non_idempotent
@@ -5074,7 +4869,6 @@ interfaces:
     # TODO: Configure which fields are required.
     required_fields:
     - instance
-    request_object_method: true
     resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: non_idempotent
@@ -5098,7 +4892,6 @@ interfaces:
     - instance
     - networkInterface
     - accessConfigResource
-    request_object_method: true
     resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: non_idempotent
@@ -5122,7 +4915,6 @@ interfaces:
     - instance
     - networkInterface
     - networkInterfaceResource
-    request_object_method: true
     resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: non_idempotent
@@ -5182,9 +4974,6 @@ interfaces:
   #       message.
   #   required_fields - Fields that are always required for a request to be
   #       valid.
-  #   request_object_method - Turns on or off the generation of a method whose
-  #       sole parameter is a request object. Not all languages will generate
-  #       this method.
   #   resource_name_treatment - An enum that specifies how to treat the
   #       resource name formats defined in the field_name_patterns
   #       and response_field_name_patterns fields.
@@ -5230,7 +5019,6 @@ interfaces:
     # TODO: Configure which fields are required.
     required_fields:
     - project
-    request_object_method: true
     resource_name_treatment: STATIC_TYPES
     page_streaming:
       request:
@@ -5257,7 +5045,6 @@ interfaces:
     # TODO: Configure which fields are required.
     required_fields:
     - interconnectAttachment
-    request_object_method: true
     resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: idempotent
@@ -5277,7 +5064,6 @@ interfaces:
     # TODO: Configure which fields are required.
     required_fields:
     - interconnectAttachment
-    request_object_method: true
     resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: idempotent
@@ -5299,7 +5085,6 @@ interfaces:
     required_fields:
     - region
     - interconnectAttachmentResource
-    request_object_method: true
     resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: non_idempotent
@@ -5319,7 +5104,6 @@ interfaces:
     # TODO: Configure which fields are required.
     required_fields:
     - region
-    request_object_method: true
     resource_name_treatment: STATIC_TYPES
     page_streaming:
       request:
@@ -5348,7 +5132,6 @@ interfaces:
     required_fields:
     - interconnectAttachment
     - interconnectAttachmentResource
-    request_object_method: true
     resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: non_idempotent
@@ -5406,9 +5189,6 @@ interfaces:
   #       message.
   #   required_fields - Fields that are always required for a request to be
   #       valid.
-  #   request_object_method - Turns on or off the generation of a method whose
-  #       sole parameter is a request object. Not all languages will generate
-  #       this method.
   #   resource_name_treatment - An enum that specifies how to treat the
   #       resource name formats defined in the field_name_patterns
   #       and response_field_name_patterns fields.
@@ -5454,7 +5234,6 @@ interfaces:
     # TODO: Configure which fields are required.
     required_fields:
     - interconnectLocation
-    request_object_method: true
     resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: idempotent
@@ -5474,7 +5253,6 @@ interfaces:
     # TODO: Configure which fields are required.
     required_fields:
     - project
-    request_object_method: true
     resource_name_treatment: STATIC_TYPES
     page_streaming:
       request:
@@ -5539,9 +5317,6 @@ interfaces:
   #       message.
   #   required_fields - Fields that are always required for a request to be
   #       valid.
-  #   request_object_method - Turns on or off the generation of a method whose
-  #       sole parameter is a request object. Not all languages will generate
-  #       this method.
   #   resource_name_treatment - An enum that specifies how to treat the
   #       resource name formats defined in the field_name_patterns
   #       and response_field_name_patterns fields.
@@ -5587,7 +5362,6 @@ interfaces:
     # TODO: Configure which fields are required.
     required_fields:
     - interconnect
-    request_object_method: true
     resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: idempotent
@@ -5607,7 +5381,6 @@ interfaces:
     # TODO: Configure which fields are required.
     required_fields:
     - interconnect
-    request_object_method: true
     resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: idempotent
@@ -5629,7 +5402,6 @@ interfaces:
     required_fields:
     - project
     - interconnectResource
-    request_object_method: true
     resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: non_idempotent
@@ -5649,7 +5421,6 @@ interfaces:
     # TODO: Configure which fields are required.
     required_fields:
     - project
-    request_object_method: true
     resource_name_treatment: STATIC_TYPES
     page_streaming:
       request:
@@ -5678,7 +5449,6 @@ interfaces:
     required_fields:
     - interconnect
     - interconnectResource
-    request_object_method: true
     resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: non_idempotent
@@ -5736,9 +5506,6 @@ interfaces:
   #       message.
   #   required_fields - Fields that are always required for a request to be
   #       valid.
-  #   request_object_method - Turns on or off the generation of a method whose
-  #       sole parameter is a request object. Not all languages will generate
-  #       this method.
   #   resource_name_treatment - An enum that specifies how to treat the
   #       resource name formats defined in the field_name_patterns
   #       and response_field_name_patterns fields.
@@ -5784,7 +5551,6 @@ interfaces:
     # TODO: Configure which fields are required.
     required_fields:
     - licenseCode
-    request_object_method: true
     resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: idempotent
@@ -5806,7 +5572,6 @@ interfaces:
     required_fields:
     - resource
     - testPermissionsRequestResource
-    request_object_method: true
     resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: non_idempotent
@@ -5866,9 +5631,6 @@ interfaces:
   #       message.
   #   required_fields - Fields that are always required for a request to be
   #       valid.
-  #   request_object_method - Turns on or off the generation of a method whose
-  #       sole parameter is a request object. Not all languages will generate
-  #       this method.
   #   resource_name_treatment - An enum that specifies how to treat the
   #       resource name formats defined in the field_name_patterns
   #       and response_field_name_patterns fields.
@@ -5914,7 +5676,6 @@ interfaces:
     # TODO: Configure which fields are required.
     required_fields:
     - license
-    request_object_method: true
     resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: idempotent
@@ -5934,7 +5695,6 @@ interfaces:
     # TODO: Configure which fields are required.
     required_fields:
     - license
-    request_object_method: true
     resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: idempotent
@@ -5956,7 +5716,6 @@ interfaces:
     required_fields:
     - project
     - licenseResource
-    request_object_method: true
     resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: non_idempotent
@@ -5976,7 +5735,6 @@ interfaces:
     # TODO: Configure which fields are required.
     required_fields:
     - project
-    request_object_method: true
     resource_name_treatment: STATIC_TYPES
     page_streaming:
       request:
@@ -6005,7 +5763,6 @@ interfaces:
     required_fields:
     - resource
     - testPermissionsRequestResource
-    request_object_method: true
     resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: non_idempotent
@@ -6065,9 +5822,6 @@ interfaces:
   #       message.
   #   required_fields - Fields that are always required for a request to be
   #       valid.
-  #   request_object_method - Turns on or off the generation of a method whose
-  #       sole parameter is a request object. Not all languages will generate
-  #       this method.
   #   resource_name_treatment - An enum that specifies how to treat the
   #       resource name formats defined in the field_name_patterns
   #       and response_field_name_patterns fields.
@@ -6113,7 +5867,6 @@ interfaces:
     # TODO: Configure which fields are required.
     required_fields:
     - project
-    request_object_method: true
     resource_name_treatment: STATIC_TYPES
     page_streaming:
       request:
@@ -6140,7 +5893,6 @@ interfaces:
     # TODO: Configure which fields are required.
     required_fields:
     - machineType
-    request_object_method: true
     resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: idempotent
@@ -6160,7 +5912,6 @@ interfaces:
     # TODO: Configure which fields are required.
     required_fields:
     - zone
-    request_object_method: true
     resource_name_treatment: STATIC_TYPES
     page_streaming:
       request:
@@ -6225,9 +5976,6 @@ interfaces:
   #       message.
   #   required_fields - Fields that are always required for a request to be
   #       valid.
-  #   request_object_method - Turns on or off the generation of a method whose
-  #       sole parameter is a request object. Not all languages will generate
-  #       this method.
   #   resource_name_treatment - An enum that specifies how to treat the
   #       resource name formats defined in the field_name_patterns
   #       and response_field_name_patterns fields.
@@ -6275,7 +6023,6 @@ interfaces:
     required_fields:
     - network
     - networksAddPeeringRequestResource
-    request_object_method: true
     resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: non_idempotent
@@ -6295,7 +6042,6 @@ interfaces:
     # TODO: Configure which fields are required.
     required_fields:
     - network
-    request_object_method: true
     resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: idempotent
@@ -6315,7 +6061,6 @@ interfaces:
     # TODO: Configure which fields are required.
     required_fields:
     - network
-    request_object_method: true
     resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: idempotent
@@ -6337,7 +6082,6 @@ interfaces:
     required_fields:
     - project
     - networkResource
-    request_object_method: true
     resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: non_idempotent
@@ -6357,7 +6101,6 @@ interfaces:
     # TODO: Configure which fields are required.
     required_fields:
     - project
-    request_object_method: true
     resource_name_treatment: STATIC_TYPES
     page_streaming:
       request:
@@ -6386,7 +6129,6 @@ interfaces:
     required_fields:
     - network
     - networkResource
-    request_object_method: true
     resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: non_idempotent
@@ -6408,7 +6150,6 @@ interfaces:
     required_fields:
     - network
     - networksRemovePeeringRequestResource
-    request_object_method: true
     resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: non_idempotent
@@ -6428,7 +6169,6 @@ interfaces:
     # TODO: Configure which fields are required.
     required_fields:
     - network
-    request_object_method: true
     resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: non_idempotent
@@ -6488,9 +6228,6 @@ interfaces:
   #       message.
   #   required_fields - Fields that are always required for a request to be
   #       valid.
-  #   request_object_method - Turns on or off the generation of a method whose
-  #       sole parameter is a request object. Not all languages will generate
-  #       this method.
   #   resource_name_treatment - An enum that specifies how to treat the
   #       resource name formats defined in the field_name_patterns
   #       and response_field_name_patterns fields.
@@ -6538,7 +6275,6 @@ interfaces:
     required_fields:
     - nodeGroup
     - nodeGroupsAddNodesRequestResource
-    request_object_method: true
     resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: non_idempotent
@@ -6558,7 +6294,6 @@ interfaces:
     # TODO: Configure which fields are required.
     required_fields:
     - project
-    request_object_method: true
     resource_name_treatment: STATIC_TYPES
     page_streaming:
       request:
@@ -6585,7 +6320,6 @@ interfaces:
     # TODO: Configure which fields are required.
     required_fields:
     - nodeGroup
-    request_object_method: true
     resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: idempotent
@@ -6607,7 +6341,6 @@ interfaces:
     required_fields:
     - nodeGroup
     - nodeGroupsDeleteNodesRequestResource
-    request_object_method: true
     resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: non_idempotent
@@ -6627,7 +6360,6 @@ interfaces:
     # TODO: Configure which fields are required.
     required_fields:
     - nodeGroup
-    request_object_method: true
     resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: idempotent
@@ -6651,7 +6383,6 @@ interfaces:
     - initialNodeCount
     - zone
     - nodeGroupResource
-    request_object_method: true
     resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: non_idempotent
@@ -6671,7 +6402,6 @@ interfaces:
     # TODO: Configure which fields are required.
     required_fields:
     - zone
-    request_object_method: true
     resource_name_treatment: STATIC_TYPES
     page_streaming:
       request:
@@ -6698,7 +6428,6 @@ interfaces:
     # TODO: Configure which fields are required.
     required_fields:
     - nodeGroup
-    request_object_method: true
     resource_name_treatment: STATIC_TYPES
     page_streaming:
       request:
@@ -6727,7 +6456,6 @@ interfaces:
     required_fields:
     - nodeGroup
     - nodeGroupsSetNodeTemplateRequestResource
-    request_object_method: true
     resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: non_idempotent
@@ -6787,9 +6515,6 @@ interfaces:
   #       message.
   #   required_fields - Fields that are always required for a request to be
   #       valid.
-  #   request_object_method - Turns on or off the generation of a method whose
-  #       sole parameter is a request object. Not all languages will generate
-  #       this method.
   #   resource_name_treatment - An enum that specifies how to treat the
   #       resource name formats defined in the field_name_patterns
   #       and response_field_name_patterns fields.
@@ -6835,7 +6560,6 @@ interfaces:
     # TODO: Configure which fields are required.
     required_fields:
     - project
-    request_object_method: true
     resource_name_treatment: STATIC_TYPES
     page_streaming:
       request:
@@ -6862,7 +6586,6 @@ interfaces:
     # TODO: Configure which fields are required.
     required_fields:
     - nodeTemplate
-    request_object_method: true
     resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: idempotent
@@ -6882,7 +6605,6 @@ interfaces:
     # TODO: Configure which fields are required.
     required_fields:
     - nodeTemplate
-    request_object_method: true
     resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: idempotent
@@ -6904,7 +6626,6 @@ interfaces:
     required_fields:
     - region
     - nodeTemplateResource
-    request_object_method: true
     resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: non_idempotent
@@ -6924,7 +6645,6 @@ interfaces:
     # TODO: Configure which fields are required.
     required_fields:
     - region
-    request_object_method: true
     resource_name_treatment: STATIC_TYPES
     page_streaming:
       request:
@@ -6991,9 +6711,6 @@ interfaces:
   #       message.
   #   required_fields - Fields that are always required for a request to be
   #       valid.
-  #   request_object_method - Turns on or off the generation of a method whose
-  #       sole parameter is a request object. Not all languages will generate
-  #       this method.
   #   resource_name_treatment - An enum that specifies how to treat the
   #       resource name formats defined in the field_name_patterns
   #       and response_field_name_patterns fields.
@@ -7039,7 +6756,6 @@ interfaces:
     # TODO: Configure which fields are required.
     required_fields:
     - project
-    request_object_method: true
     resource_name_treatment: STATIC_TYPES
     page_streaming:
       request:
@@ -7066,7 +6782,6 @@ interfaces:
     # TODO: Configure which fields are required.
     required_fields:
     - nodeType
-    request_object_method: true
     resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: idempotent
@@ -7086,7 +6801,6 @@ interfaces:
     # TODO: Configure which fields are required.
     required_fields:
     - zone
-    request_object_method: true
     resource_name_treatment: STATIC_TYPES
     page_streaming:
       request:
@@ -7149,9 +6863,6 @@ interfaces:
   #       message.
   #   required_fields - Fields that are always required for a request to be
   #       valid.
-  #   request_object_method - Turns on or off the generation of a method whose
-  #       sole parameter is a request object. Not all languages will generate
-  #       this method.
   #   resource_name_treatment - An enum that specifies how to treat the
   #       resource name formats defined in the field_name_patterns
   #       and response_field_name_patterns fields.
@@ -7197,7 +6908,6 @@ interfaces:
     # TODO: Configure which fields are required.
     required_fields:
     - project
-    request_object_method: true
     resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: non_idempotent
@@ -7219,7 +6929,6 @@ interfaces:
     required_fields:
     - project
     - projectsDisableXpnResourceRequestResource
-    request_object_method: true
     resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: non_idempotent
@@ -7239,7 +6948,6 @@ interfaces:
     # TODO: Configure which fields are required.
     required_fields:
     - project
-    request_object_method: true
     resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: non_idempotent
@@ -7261,7 +6969,6 @@ interfaces:
     required_fields:
     - project
     - projectsEnableXpnResourceRequestResource
-    request_object_method: true
     resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: non_idempotent
@@ -7281,7 +6988,6 @@ interfaces:
     # TODO: Configure which fields are required.
     required_fields:
     - project
-    request_object_method: false
     resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: idempotent
@@ -7301,7 +7007,6 @@ interfaces:
     # TODO: Configure which fields are required.
     required_fields:
     - project
-    request_object_method: false
     resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: idempotent
@@ -7321,7 +7026,6 @@ interfaces:
     # TODO: Configure which fields are required.
     required_fields:
     - project
-    request_object_method: true
     resource_name_treatment: STATIC_TYPES
     page_streaming:
       request:
@@ -7350,7 +7054,6 @@ interfaces:
     required_fields:
     - project
     - projectsListXpnHostsRequestResource
-    request_object_method: true
     resource_name_treatment: STATIC_TYPES
     page_streaming:
       request:
@@ -7379,7 +7082,6 @@ interfaces:
     required_fields:
     - project
     - diskMoveRequestResource
-    request_object_method: true
     resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: non_idempotent
@@ -7401,7 +7103,6 @@ interfaces:
     required_fields:
     - project
     - instanceMoveRequestResource
-    request_object_method: true
     resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: non_idempotent
@@ -7423,7 +7124,6 @@ interfaces:
     required_fields:
     - project
     - metadataResource
-    request_object_method: true
     resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: non_idempotent
@@ -7445,7 +7145,6 @@ interfaces:
     required_fields:
     - project
     - projectsSetDefaultNetworkTierRequestResource
-    request_object_method: true
     resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: non_idempotent
@@ -7467,7 +7166,6 @@ interfaces:
     required_fields:
     - project
     - usageExportLocationResource
-    request_object_method: true
     resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: non_idempotent
@@ -7525,9 +7223,6 @@ interfaces:
   #       message.
   #   required_fields - Fields that are always required for a request to be
   #       valid.
-  #   request_object_method - Turns on or off the generation of a method whose
-  #       sole parameter is a request object. Not all languages will generate
-  #       this method.
   #   resource_name_treatment - An enum that specifies how to treat the
   #       resource name formats defined in the field_name_patterns
   #       and response_field_name_patterns fields.
@@ -7573,7 +7268,6 @@ interfaces:
     # TODO: Configure which fields are required.
     required_fields:
     - autoscaler
-    request_object_method: true
     resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: idempotent
@@ -7593,7 +7287,6 @@ interfaces:
     # TODO: Configure which fields are required.
     required_fields:
     - autoscaler
-    request_object_method: true
     resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: idempotent
@@ -7615,7 +7308,6 @@ interfaces:
     required_fields:
     - region
     - autoscalerResource
-    request_object_method: true
     resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: non_idempotent
@@ -7635,7 +7327,6 @@ interfaces:
     # TODO: Configure which fields are required.
     required_fields:
     - region
-    request_object_method: true
     resource_name_treatment: STATIC_TYPES
     page_streaming:
       request:
@@ -7666,7 +7357,6 @@ interfaces:
     - autoscaler
     - region
     - autoscalerResource
-    request_object_method: true
     resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: non_idempotent
@@ -7690,7 +7380,6 @@ interfaces:
     - autoscaler
     - region
     - autoscalerResource
-    request_object_method: true
     resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: idempotent
@@ -7748,9 +7437,6 @@ interfaces:
   #       message.
   #   required_fields - Fields that are always required for a request to be
   #       valid.
-  #   request_object_method - Turns on or off the generation of a method whose
-  #       sole parameter is a request object. Not all languages will generate
-  #       this method.
   #   resource_name_treatment - An enum that specifies how to treat the
   #       resource name formats defined in the field_name_patterns
   #       and response_field_name_patterns fields.
@@ -7796,7 +7482,6 @@ interfaces:
     # TODO: Configure which fields are required.
     required_fields:
     - backendService
-    request_object_method: true
     resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: idempotent
@@ -7816,7 +7501,6 @@ interfaces:
     # TODO: Configure which fields are required.
     required_fields:
     - backendService
-    request_object_method: true
     resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: idempotent
@@ -7838,7 +7522,6 @@ interfaces:
     required_fields:
     - backendService
     - resourceGroupReferenceResource
-    request_object_method: true
     resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: non_idempotent
@@ -7860,7 +7543,6 @@ interfaces:
     required_fields:
     - region
     - backendServiceResource
-    request_object_method: true
     resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: non_idempotent
@@ -7880,7 +7562,6 @@ interfaces:
     # TODO: Configure which fields are required.
     required_fields:
     - region
-    request_object_method: true
     resource_name_treatment: STATIC_TYPES
     page_streaming:
       request:
@@ -7909,7 +7590,6 @@ interfaces:
     required_fields:
     - backendService
     - backendServiceResource
-    request_object_method: true
     resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: non_idempotent
@@ -7931,7 +7611,6 @@ interfaces:
     required_fields:
     - backendService
     - backendServiceResource
-    request_object_method: true
     resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: idempotent
@@ -7991,9 +7670,6 @@ interfaces:
   #       message.
   #   required_fields - Fields that are always required for a request to be
   #       valid.
-  #   request_object_method - Turns on or off the generation of a method whose
-  #       sole parameter is a request object. Not all languages will generate
-  #       this method.
   #   resource_name_treatment - An enum that specifies how to treat the
   #       resource name formats defined in the field_name_patterns
   #       and response_field_name_patterns fields.
@@ -8039,7 +7715,6 @@ interfaces:
     # TODO: Configure which fields are required.
     required_fields:
     - project
-    request_object_method: true
     resource_name_treatment: STATIC_TYPES
     page_streaming:
       request:
@@ -8066,7 +7741,6 @@ interfaces:
     # TODO: Configure which fields are required.
     required_fields:
     - commitment
-    request_object_method: true
     resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: idempotent
@@ -8088,7 +7762,6 @@ interfaces:
     required_fields:
     - region
     - commitmentResource
-    request_object_method: true
     resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: non_idempotent
@@ -8108,7 +7781,6 @@ interfaces:
     # TODO: Configure which fields are required.
     required_fields:
     - region
-    request_object_method: true
     resource_name_treatment: STATIC_TYPES
     page_streaming:
       request:
@@ -8173,9 +7845,6 @@ interfaces:
   #       message.
   #   required_fields - Fields that are always required for a request to be
   #       valid.
-  #   request_object_method - Turns on or off the generation of a method whose
-  #       sole parameter is a request object. Not all languages will generate
-  #       this method.
   #   resource_name_treatment - An enum that specifies how to treat the
   #       resource name formats defined in the field_name_patterns
   #       and response_field_name_patterns fields.
@@ -8221,7 +7890,6 @@ interfaces:
     # TODO: Configure which fields are required.
     required_fields:
     - diskType
-    request_object_method: true
     resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: idempotent
@@ -8241,7 +7909,6 @@ interfaces:
     # TODO: Configure which fields are required.
     required_fields:
     - region
-    request_object_method: true
     resource_name_treatment: STATIC_TYPES
     page_streaming:
       request:
@@ -8308,9 +7975,6 @@ interfaces:
   #       message.
   #   required_fields - Fields that are always required for a request to be
   #       valid.
-  #   request_object_method - Turns on or off the generation of a method whose
-  #       sole parameter is a request object. Not all languages will generate
-  #       this method.
   #   resource_name_treatment - An enum that specifies how to treat the
   #       resource name formats defined in the field_name_patterns
   #       and response_field_name_patterns fields.
@@ -8358,7 +8022,6 @@ interfaces:
     required_fields:
     - disk
     - snapshotResource
-    request_object_method: true
     resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: non_idempotent
@@ -8378,7 +8041,6 @@ interfaces:
     # TODO: Configure which fields are required.
     required_fields:
     - disk
-    request_object_method: true
     resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: idempotent
@@ -8398,7 +8060,6 @@ interfaces:
     # TODO: Configure which fields are required.
     required_fields:
     - disk
-    request_object_method: true
     resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: idempotent
@@ -8420,7 +8081,6 @@ interfaces:
     required_fields:
     - region
     - diskResource
-    request_object_method: true
     resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: non_idempotent
@@ -8440,7 +8100,6 @@ interfaces:
     # TODO: Configure which fields are required.
     required_fields:
     - region
-    request_object_method: true
     resource_name_treatment: STATIC_TYPES
     page_streaming:
       request:
@@ -8469,7 +8128,6 @@ interfaces:
     required_fields:
     - disk
     - regionDisksResizeRequestResource
-    request_object_method: true
     resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: non_idempotent
@@ -8491,7 +8149,6 @@ interfaces:
     required_fields:
     - resource
     - regionSetLabelsRequestResource
-    request_object_method: true
     resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: non_idempotent
@@ -8513,7 +8170,6 @@ interfaces:
     required_fields:
     - resource
     - testPermissionsRequestResource
-    request_object_method: true
     resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: non_idempotent
@@ -8571,9 +8227,6 @@ interfaces:
   #       message.
   #   required_fields - Fields that are always required for a request to be
   #       valid.
-  #   request_object_method - Turns on or off the generation of a method whose
-  #       sole parameter is a request object. Not all languages will generate
-  #       this method.
   #   resource_name_treatment - An enum that specifies how to treat the
   #       resource name formats defined in the field_name_patterns
   #       and response_field_name_patterns fields.
@@ -8621,7 +8274,6 @@ interfaces:
     required_fields:
     - instanceGroupManager
     - regionInstanceGroupManagersAbandonInstancesRequestResource
-    request_object_method: true
     resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: non_idempotent
@@ -8641,7 +8293,6 @@ interfaces:
     # TODO: Configure which fields are required.
     required_fields:
     - instanceGroupManager
-    request_object_method: true
     resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: idempotent
@@ -8663,7 +8314,6 @@ interfaces:
     required_fields:
     - instanceGroupManager
     - regionInstanceGroupManagersDeleteInstancesRequestResource
-    request_object_method: true
     resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: non_idempotent
@@ -8683,7 +8333,6 @@ interfaces:
     # TODO: Configure which fields are required.
     required_fields:
     - instanceGroupManager
-    request_object_method: true
     resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: idempotent
@@ -8705,7 +8354,6 @@ interfaces:
     required_fields:
     - region
     - instanceGroupManagerResource
-    request_object_method: true
     resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: non_idempotent
@@ -8725,7 +8373,6 @@ interfaces:
     # TODO: Configure which fields are required.
     required_fields:
     - region
-    request_object_method: true
     resource_name_treatment: STATIC_TYPES
     page_streaming:
       request:
@@ -8752,7 +8399,6 @@ interfaces:
     # TODO: Configure which fields are required.
     required_fields:
     - instanceGroupManager
-    request_object_method: true
     resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: non_idempotent
@@ -8774,7 +8420,6 @@ interfaces:
     required_fields:
     - instanceGroupManager
     - regionInstanceGroupManagersRecreateRequestResource
-    request_object_method: true
     resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: non_idempotent
@@ -8796,7 +8441,6 @@ interfaces:
     required_fields:
     - size
     - instanceGroupManager
-    request_object_method: true
     resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: non_idempotent
@@ -8818,7 +8462,6 @@ interfaces:
     required_fields:
     - instanceGroupManager
     - regionInstanceGroupManagersSetTemplateRequestResource
-    request_object_method: true
     resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: non_idempotent
@@ -8840,7 +8483,6 @@ interfaces:
     required_fields:
     - instanceGroupManager
     - regionInstanceGroupManagersSetTargetPoolsRequestResource
-    request_object_method: true
     resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: non_idempotent
@@ -8898,9 +8540,6 @@ interfaces:
   #       message.
   #   required_fields - Fields that are always required for a request to be
   #       valid.
-  #   request_object_method - Turns on or off the generation of a method whose
-  #       sole parameter is a request object. Not all languages will generate
-  #       this method.
   #   resource_name_treatment - An enum that specifies how to treat the
   #       resource name formats defined in the field_name_patterns
   #       and response_field_name_patterns fields.
@@ -8946,7 +8585,6 @@ interfaces:
     # TODO: Configure which fields are required.
     required_fields:
     - instanceGroup
-    request_object_method: true
     resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: idempotent
@@ -8966,7 +8604,6 @@ interfaces:
     # TODO: Configure which fields are required.
     required_fields:
     - region
-    request_object_method: true
     resource_name_treatment: STATIC_TYPES
     page_streaming:
       request:
@@ -8995,7 +8632,6 @@ interfaces:
     required_fields:
     - instanceGroup
     - regionInstanceGroupsListInstancesRequestResource
-    request_object_method: true
     resource_name_treatment: STATIC_TYPES
     page_streaming:
       request:
@@ -9024,7 +8660,6 @@ interfaces:
     required_fields:
     - instanceGroup
     - regionInstanceGroupsSetNamedPortsRequestResource
-    request_object_method: true
     resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: non_idempotent
@@ -9082,9 +8717,6 @@ interfaces:
   #       message.
   #   required_fields - Fields that are always required for a request to be
   #       valid.
-  #   request_object_method - Turns on or off the generation of a method whose
-  #       sole parameter is a request object. Not all languages will generate
-  #       this method.
   #   resource_name_treatment - An enum that specifies how to treat the
   #       resource name formats defined in the field_name_patterns
   #       and response_field_name_patterns fields.
@@ -9130,7 +8762,6 @@ interfaces:
     # TODO: Configure which fields are required.
     required_fields:
     - operation
-    request_object_method: true
     resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: idempotent
@@ -9150,7 +8781,6 @@ interfaces:
     # TODO: Configure which fields are required.
     required_fields:
     - operation
-    request_object_method: true
     resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: idempotent
@@ -9170,7 +8800,6 @@ interfaces:
     # TODO: Configure which fields are required.
     required_fields:
     - region
-    request_object_method: true
     resource_name_treatment: STATIC_TYPES
     page_streaming:
       request:
@@ -9235,9 +8864,6 @@ interfaces:
   #       message.
   #   required_fields - Fields that are always required for a request to be
   #       valid.
-  #   request_object_method - Turns on or off the generation of a method whose
-  #       sole parameter is a request object. Not all languages will generate
-  #       this method.
   #   resource_name_treatment - An enum that specifies how to treat the
   #       resource name formats defined in the field_name_patterns
   #       and response_field_name_patterns fields.
@@ -9283,7 +8909,6 @@ interfaces:
     # TODO: Configure which fields are required.
     required_fields:
     - region
-    request_object_method: true
     resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: idempotent
@@ -9303,7 +8928,6 @@ interfaces:
     # TODO: Configure which fields are required.
     required_fields:
     - project
-    request_object_method: true
     resource_name_treatment: STATIC_TYPES
     page_streaming:
       request:
@@ -9370,9 +8994,6 @@ interfaces:
   #       message.
   #   required_fields - Fields that are always required for a request to be
   #       valid.
-  #   request_object_method - Turns on or off the generation of a method whose
-  #       sole parameter is a request object. Not all languages will generate
-  #       this method.
   #   resource_name_treatment - An enum that specifies how to treat the
   #       resource name formats defined in the field_name_patterns
   #       and response_field_name_patterns fields.
@@ -9418,7 +9039,6 @@ interfaces:
     # TODO: Configure which fields are required.
     required_fields:
     - project
-    request_object_method: true
     resource_name_treatment: STATIC_TYPES
     page_streaming:
       request:
@@ -9445,7 +9065,6 @@ interfaces:
     # TODO: Configure which fields are required.
     required_fields:
     - router
-    request_object_method: true
     resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: idempotent
@@ -9465,7 +9084,6 @@ interfaces:
     # TODO: Configure which fields are required.
     required_fields:
     - router
-    request_object_method: true
     resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: idempotent
@@ -9485,7 +9103,6 @@ interfaces:
     # TODO: Configure which fields are required.
     required_fields:
     - router
-    request_object_method: true
     resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: idempotent
@@ -9507,7 +9124,6 @@ interfaces:
     required_fields:
     - region
     - routerResource
-    request_object_method: true
     resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: non_idempotent
@@ -9527,7 +9143,6 @@ interfaces:
     # TODO: Configure which fields are required.
     required_fields:
     - region
-    request_object_method: true
     resource_name_treatment: STATIC_TYPES
     page_streaming:
       request:
@@ -9556,7 +9171,6 @@ interfaces:
     required_fields:
     - router
     - routerResource
-    request_object_method: true
     resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: non_idempotent
@@ -9578,7 +9192,6 @@ interfaces:
     required_fields:
     - router
     - routerResource
-    request_object_method: true
     resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: non_idempotent
@@ -9600,7 +9213,6 @@ interfaces:
     required_fields:
     - router
     - routerResource
-    request_object_method: true
     resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: idempotent
@@ -9658,9 +9270,6 @@ interfaces:
   #       message.
   #   required_fields - Fields that are always required for a request to be
   #       valid.
-  #   request_object_method - Turns on or off the generation of a method whose
-  #       sole parameter is a request object. Not all languages will generate
-  #       this method.
   #   resource_name_treatment - An enum that specifies how to treat the
   #       resource name formats defined in the field_name_patterns
   #       and response_field_name_patterns fields.
@@ -9706,7 +9315,6 @@ interfaces:
     # TODO: Configure which fields are required.
     required_fields:
     - route
-    request_object_method: true
     resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: idempotent
@@ -9726,7 +9334,6 @@ interfaces:
     # TODO: Configure which fields are required.
     required_fields:
     - route
-    request_object_method: true
     resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: idempotent
@@ -9748,7 +9355,6 @@ interfaces:
     required_fields:
     - project
     - routeResource
-    request_object_method: true
     resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: non_idempotent
@@ -9768,7 +9374,6 @@ interfaces:
     # TODO: Configure which fields are required.
     required_fields:
     - project
-    request_object_method: true
     resource_name_treatment: STATIC_TYPES
     page_streaming:
       request:
@@ -9833,9 +9438,6 @@ interfaces:
   #       message.
   #   required_fields - Fields that are always required for a request to be
   #       valid.
-  #   request_object_method - Turns on or off the generation of a method whose
-  #       sole parameter is a request object. Not all languages will generate
-  #       this method.
   #   resource_name_treatment - An enum that specifies how to treat the
   #       resource name formats defined in the field_name_patterns
   #       and response_field_name_patterns fields.
@@ -9883,7 +9485,6 @@ interfaces:
     required_fields:
     - securityPolicy
     - securityPolicyRuleResource
-    request_object_method: true
     resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: non_idempotent
@@ -9903,7 +9504,6 @@ interfaces:
     # TODO: Configure which fields are required.
     required_fields:
     - securityPolicy
-    request_object_method: true
     resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: idempotent
@@ -9923,7 +9523,6 @@ interfaces:
     # TODO: Configure which fields are required.
     required_fields:
     - securityPolicy
-    request_object_method: true
     resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: idempotent
@@ -9945,7 +9544,6 @@ interfaces:
     required_fields:
     - priority
     - securityPolicy
-    request_object_method: true
     resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: idempotent
@@ -9967,7 +9565,6 @@ interfaces:
     required_fields:
     - project
     - securityPolicyResource
-    request_object_method: true
     resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: non_idempotent
@@ -9987,7 +9584,6 @@ interfaces:
     # TODO: Configure which fields are required.
     required_fields:
     - project
-    request_object_method: true
     resource_name_treatment: STATIC_TYPES
     page_streaming:
       request:
@@ -10016,7 +9612,6 @@ interfaces:
     required_fields:
     - securityPolicy
     - securityPolicyResource
-    request_object_method: true
     resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: non_idempotent
@@ -10040,7 +9635,6 @@ interfaces:
     - priority
     - securityPolicy
     - securityPolicyRuleResource
-    request_object_method: true
     resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: non_idempotent
@@ -10062,7 +9656,6 @@ interfaces:
     required_fields:
     - priority
     - securityPolicy
-    request_object_method: true
     resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: non_idempotent
@@ -10122,9 +9715,6 @@ interfaces:
   #       message.
   #   required_fields - Fields that are always required for a request to be
   #       valid.
-  #   request_object_method - Turns on or off the generation of a method whose
-  #       sole parameter is a request object. Not all languages will generate
-  #       this method.
   #   resource_name_treatment - An enum that specifies how to treat the
   #       resource name formats defined in the field_name_patterns
   #       and response_field_name_patterns fields.
@@ -10170,7 +9760,6 @@ interfaces:
     # TODO: Configure which fields are required.
     required_fields:
     - snapshot
-    request_object_method: true
     resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: idempotent
@@ -10190,7 +9779,6 @@ interfaces:
     # TODO: Configure which fields are required.
     required_fields:
     - snapshot
-    request_object_method: true
     resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: idempotent
@@ -10210,7 +9798,6 @@ interfaces:
     # TODO: Configure which fields are required.
     required_fields:
     - project
-    request_object_method: true
     resource_name_treatment: STATIC_TYPES
     page_streaming:
       request:
@@ -10239,7 +9826,6 @@ interfaces:
     required_fields:
     - resource
     - globalSetLabelsRequestResource
-    request_object_method: true
     resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: non_idempotent
@@ -10297,9 +9883,6 @@ interfaces:
   #       message.
   #   required_fields - Fields that are always required for a request to be
   #       valid.
-  #   request_object_method - Turns on or off the generation of a method whose
-  #       sole parameter is a request object. Not all languages will generate
-  #       this method.
   #   resource_name_treatment - An enum that specifies how to treat the
   #       resource name formats defined in the field_name_patterns
   #       and response_field_name_patterns fields.
@@ -10345,7 +9928,6 @@ interfaces:
     # TODO: Configure which fields are required.
     required_fields:
     - sslCertificate
-    request_object_method: true
     resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: idempotent
@@ -10365,7 +9947,6 @@ interfaces:
     # TODO: Configure which fields are required.
     required_fields:
     - sslCertificate
-    request_object_method: true
     resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: idempotent
@@ -10387,7 +9968,6 @@ interfaces:
     required_fields:
     - project
     - sslCertificateResource
-    request_object_method: true
     resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: non_idempotent
@@ -10407,7 +9987,6 @@ interfaces:
     # TODO: Configure which fields are required.
     required_fields:
     - project
-    request_object_method: true
     resource_name_treatment: STATIC_TYPES
     page_streaming:
       request:
@@ -10472,9 +10051,6 @@ interfaces:
   #       message.
   #   required_fields - Fields that are always required for a request to be
   #       valid.
-  #   request_object_method - Turns on or off the generation of a method whose
-  #       sole parameter is a request object. Not all languages will generate
-  #       this method.
   #   resource_name_treatment - An enum that specifies how to treat the
   #       resource name formats defined in the field_name_patterns
   #       and response_field_name_patterns fields.
@@ -10520,7 +10096,6 @@ interfaces:
     # TODO: Configure which fields are required.
     required_fields:
     - sslPolicy
-    request_object_method: true
     resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: idempotent
@@ -10540,7 +10115,6 @@ interfaces:
     # TODO: Configure which fields are required.
     required_fields:
     - sslPolicy
-    request_object_method: true
     resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: idempotent
@@ -10562,7 +10136,6 @@ interfaces:
     required_fields:
     - project
     - sslPolicyResource
-    request_object_method: true
     resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: non_idempotent
@@ -10582,7 +10155,6 @@ interfaces:
     # TODO: Configure which fields are required.
     required_fields:
     - project
-    request_object_method: true
     resource_name_treatment: STATIC_TYPES
     page_streaming:
       request:
@@ -10609,7 +10181,6 @@ interfaces:
     # TODO: Configure which fields are required.
     required_fields:
     - project
-    request_object_method: true
     resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: idempotent
@@ -10631,7 +10202,6 @@ interfaces:
     required_fields:
     - sslPolicy
     - sslPolicyResource
-    request_object_method: true
     resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: non_idempotent
@@ -10691,9 +10261,6 @@ interfaces:
   #       message.
   #   required_fields - Fields that are always required for a request to be
   #       valid.
-  #   request_object_method - Turns on or off the generation of a method whose
-  #       sole parameter is a request object. Not all languages will generate
-  #       this method.
   #   resource_name_treatment - An enum that specifies how to treat the
   #       resource name formats defined in the field_name_patterns
   #       and response_field_name_patterns fields.
@@ -10739,7 +10306,6 @@ interfaces:
     # TODO: Configure which fields are required.
     required_fields:
     - project
-    request_object_method: true
     resource_name_treatment: STATIC_TYPES
     page_streaming:
       request:
@@ -10766,7 +10332,6 @@ interfaces:
     # TODO: Configure which fields are required.
     required_fields:
     - subnetwork
-    request_object_method: true
     resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: idempotent
@@ -10788,7 +10353,6 @@ interfaces:
     required_fields:
     - subnetwork
     - subnetworksExpandIpCidrRangeRequestResource
-    request_object_method: true
     resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: non_idempotent
@@ -10808,7 +10372,6 @@ interfaces:
     # TODO: Configure which fields are required.
     required_fields:
     - subnetwork
-    request_object_method: true
     resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: idempotent
@@ -10830,7 +10393,6 @@ interfaces:
     required_fields:
     - region
     - subnetworkResource
-    request_object_method: true
     resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: non_idempotent
@@ -10850,7 +10412,6 @@ interfaces:
     # TODO: Configure which fields are required.
     required_fields:
     - region
-    request_object_method: true
     resource_name_treatment: STATIC_TYPES
     page_streaming:
       request:
@@ -10877,7 +10438,6 @@ interfaces:
     # TODO: Configure which fields are required.
     required_fields:
     - project
-    request_object_method: true
     resource_name_treatment: STATIC_TYPES
     page_streaming:
       request:
@@ -10906,7 +10466,6 @@ interfaces:
     required_fields:
     - subnetwork
     - subnetworkResource
-    request_object_method: true
     resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: non_idempotent
@@ -10928,7 +10487,6 @@ interfaces:
     required_fields:
     - subnetwork
     - subnetworksSetPrivateIpGoogleAccessRequestResource
-    request_object_method: true
     resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: non_idempotent
@@ -10988,9 +10546,6 @@ interfaces:
   #       message.
   #   required_fields - Fields that are always required for a request to be
   #       valid.
-  #   request_object_method - Turns on or off the generation of a method whose
-  #       sole parameter is a request object. Not all languages will generate
-  #       this method.
   #   resource_name_treatment - An enum that specifies how to treat the
   #       resource name formats defined in the field_name_patterns
   #       and response_field_name_patterns fields.
@@ -11036,7 +10591,6 @@ interfaces:
     # TODO: Configure which fields are required.
     required_fields:
     - targetHttpProxy
-    request_object_method: true
     resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: idempotent
@@ -11056,7 +10610,6 @@ interfaces:
     # TODO: Configure which fields are required.
     required_fields:
     - targetHttpProxy
-    request_object_method: true
     resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: idempotent
@@ -11078,7 +10631,6 @@ interfaces:
     required_fields:
     - project
     - targetHttpProxyResource
-    request_object_method: true
     resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: non_idempotent
@@ -11098,7 +10650,6 @@ interfaces:
     # TODO: Configure which fields are required.
     required_fields:
     - project
-    request_object_method: true
     resource_name_treatment: STATIC_TYPES
     page_streaming:
       request:
@@ -11127,7 +10678,6 @@ interfaces:
     required_fields:
     - targetHttpProxy
     - urlMapReferenceResource
-    request_object_method: true
     resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: non_idempotent
@@ -11187,9 +10737,6 @@ interfaces:
   #       message.
   #   required_fields - Fields that are always required for a request to be
   #       valid.
-  #   request_object_method - Turns on or off the generation of a method whose
-  #       sole parameter is a request object. Not all languages will generate
-  #       this method.
   #   resource_name_treatment - An enum that specifies how to treat the
   #       resource name formats defined in the field_name_patterns
   #       and response_field_name_patterns fields.
@@ -11235,7 +10782,6 @@ interfaces:
     # TODO: Configure which fields are required.
     required_fields:
     - targetHttpsProxy
-    request_object_method: true
     resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: idempotent
@@ -11255,7 +10801,6 @@ interfaces:
     # TODO: Configure which fields are required.
     required_fields:
     - targetHttpsProxy
-    request_object_method: true
     resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: idempotent
@@ -11277,7 +10822,6 @@ interfaces:
     required_fields:
     - project
     - targetHttpsProxyResource
-    request_object_method: true
     resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: non_idempotent
@@ -11297,7 +10841,6 @@ interfaces:
     # TODO: Configure which fields are required.
     required_fields:
     - project
-    request_object_method: true
     resource_name_treatment: STATIC_TYPES
     page_streaming:
       request:
@@ -11326,7 +10869,6 @@ interfaces:
     required_fields:
     - targetHttpsProxy
     - targetHttpsProxiesSetQuicOverrideRequestResource
-    request_object_method: true
     resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: non_idempotent
@@ -11348,7 +10890,6 @@ interfaces:
     required_fields:
     - targetHttpsProxy
     - targetHttpsProxiesSetSslCertificatesRequestResource
-    request_object_method: true
     resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: non_idempotent
@@ -11370,7 +10911,6 @@ interfaces:
     required_fields:
     - targetHttpsProxy
     - sslPolicyReferenceResource
-    request_object_method: true
     resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: non_idempotent
@@ -11392,7 +10932,6 @@ interfaces:
     required_fields:
     - targetHttpsProxy
     - urlMapReferenceResource
-    request_object_method: true
     resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: non_idempotent
@@ -11452,9 +10991,6 @@ interfaces:
   #       message.
   #   required_fields - Fields that are always required for a request to be
   #       valid.
-  #   request_object_method - Turns on or off the generation of a method whose
-  #       sole parameter is a request object. Not all languages will generate
-  #       this method.
   #   resource_name_treatment - An enum that specifies how to treat the
   #       resource name formats defined in the field_name_patterns
   #       and response_field_name_patterns fields.
@@ -11500,7 +11036,6 @@ interfaces:
     # TODO: Configure which fields are required.
     required_fields:
     - project
-    request_object_method: true
     resource_name_treatment: STATIC_TYPES
     page_streaming:
       request:
@@ -11527,7 +11062,6 @@ interfaces:
     # TODO: Configure which fields are required.
     required_fields:
     - targetInstance
-    request_object_method: true
     resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: idempotent
@@ -11547,7 +11081,6 @@ interfaces:
     # TODO: Configure which fields are required.
     required_fields:
     - targetInstance
-    request_object_method: true
     resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: idempotent
@@ -11569,7 +11102,6 @@ interfaces:
     required_fields:
     - zone
     - targetInstanceResource
-    request_object_method: true
     resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: non_idempotent
@@ -11589,7 +11121,6 @@ interfaces:
     # TODO: Configure which fields are required.
     required_fields:
     - zone
-    request_object_method: true
     resource_name_treatment: STATIC_TYPES
     page_streaming:
       request:
@@ -11656,9 +11187,6 @@ interfaces:
   #       message.
   #   required_fields - Fields that are always required for a request to be
   #       valid.
-  #   request_object_method - Turns on or off the generation of a method whose
-  #       sole parameter is a request object. Not all languages will generate
-  #       this method.
   #   resource_name_treatment - An enum that specifies how to treat the
   #       resource name formats defined in the field_name_patterns
   #       and response_field_name_patterns fields.
@@ -11706,7 +11234,6 @@ interfaces:
     required_fields:
     - targetPool
     - targetPoolsAddHealthCheckRequestResource
-    request_object_method: true
     resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: non_idempotent
@@ -11728,7 +11255,6 @@ interfaces:
     required_fields:
     - targetPool
     - targetPoolsAddInstanceRequestResource
-    request_object_method: true
     resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: non_idempotent
@@ -11748,7 +11274,6 @@ interfaces:
     # TODO: Configure which fields are required.
     required_fields:
     - project
-    request_object_method: true
     resource_name_treatment: STATIC_TYPES
     page_streaming:
       request:
@@ -11775,7 +11300,6 @@ interfaces:
     # TODO: Configure which fields are required.
     required_fields:
     - targetPool
-    request_object_method: true
     resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: idempotent
@@ -11795,7 +11319,6 @@ interfaces:
     # TODO: Configure which fields are required.
     required_fields:
     - targetPool
-    request_object_method: true
     resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: idempotent
@@ -11817,7 +11340,6 @@ interfaces:
     required_fields:
     - targetPool
     - instanceReferenceResource
-    request_object_method: true
     resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: non_idempotent
@@ -11839,7 +11361,6 @@ interfaces:
     required_fields:
     - region
     - targetPoolResource
-    request_object_method: true
     resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: non_idempotent
@@ -11859,7 +11380,6 @@ interfaces:
     # TODO: Configure which fields are required.
     required_fields:
     - region
-    request_object_method: true
     resource_name_treatment: STATIC_TYPES
     page_streaming:
       request:
@@ -11888,7 +11408,6 @@ interfaces:
     required_fields:
     - targetPool
     - targetPoolsRemoveHealthCheckRequestResource
-    request_object_method: true
     resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: non_idempotent
@@ -11910,7 +11429,6 @@ interfaces:
     required_fields:
     - targetPool
     - targetPoolsRemoveInstanceRequestResource
-    request_object_method: true
     resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: non_idempotent
@@ -11934,7 +11452,6 @@ interfaces:
     - targetPool
     - failoverRatio
     - targetReferenceResource
-    request_object_method: true
     resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: non_idempotent
@@ -11992,9 +11509,6 @@ interfaces:
   #       message.
   #   required_fields - Fields that are always required for a request to be
   #       valid.
-  #   request_object_method - Turns on or off the generation of a method whose
-  #       sole parameter is a request object. Not all languages will generate
-  #       this method.
   #   resource_name_treatment - An enum that specifies how to treat the
   #       resource name formats defined in the field_name_patterns
   #       and response_field_name_patterns fields.
@@ -12040,7 +11554,6 @@ interfaces:
     # TODO: Configure which fields are required.
     required_fields:
     - targetSslProxy
-    request_object_method: true
     resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: idempotent
@@ -12060,7 +11573,6 @@ interfaces:
     # TODO: Configure which fields are required.
     required_fields:
     - targetSslProxy
-    request_object_method: true
     resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: idempotent
@@ -12082,7 +11594,6 @@ interfaces:
     required_fields:
     - project
     - targetSslProxyResource
-    request_object_method: true
     resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: non_idempotent
@@ -12102,7 +11613,6 @@ interfaces:
     # TODO: Configure which fields are required.
     required_fields:
     - project
-    request_object_method: true
     resource_name_treatment: STATIC_TYPES
     page_streaming:
       request:
@@ -12131,7 +11641,6 @@ interfaces:
     required_fields:
     - targetSslProxy
     - targetSslProxiesSetBackendServiceRequestResource
-    request_object_method: true
     resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: non_idempotent
@@ -12153,7 +11662,6 @@ interfaces:
     required_fields:
     - targetSslProxy
     - targetSslProxiesSetProxyHeaderRequestResource
-    request_object_method: true
     resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: non_idempotent
@@ -12175,7 +11683,6 @@ interfaces:
     required_fields:
     - targetSslProxy
     - targetSslProxiesSetSslCertificatesRequestResource
-    request_object_method: true
     resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: non_idempotent
@@ -12197,7 +11704,6 @@ interfaces:
     required_fields:
     - targetSslProxy
     - sslPolicyReferenceResource
-    request_object_method: true
     resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: non_idempotent
@@ -12255,9 +11761,6 @@ interfaces:
   #       message.
   #   required_fields - Fields that are always required for a request to be
   #       valid.
-  #   request_object_method - Turns on or off the generation of a method whose
-  #       sole parameter is a request object. Not all languages will generate
-  #       this method.
   #   resource_name_treatment - An enum that specifies how to treat the
   #       resource name formats defined in the field_name_patterns
   #       and response_field_name_patterns fields.
@@ -12303,7 +11806,6 @@ interfaces:
     # TODO: Configure which fields are required.
     required_fields:
     - targetTcpProxy
-    request_object_method: true
     resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: idempotent
@@ -12323,7 +11825,6 @@ interfaces:
     # TODO: Configure which fields are required.
     required_fields:
     - targetTcpProxy
-    request_object_method: true
     resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: idempotent
@@ -12345,7 +11846,6 @@ interfaces:
     required_fields:
     - project
     - targetTcpProxyResource
-    request_object_method: true
     resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: non_idempotent
@@ -12365,7 +11865,6 @@ interfaces:
     # TODO: Configure which fields are required.
     required_fields:
     - project
-    request_object_method: true
     resource_name_treatment: STATIC_TYPES
     page_streaming:
       request:
@@ -12394,7 +11893,6 @@ interfaces:
     required_fields:
     - targetTcpProxy
     - targetTcpProxiesSetBackendServiceRequestResource
-    request_object_method: true
     resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: non_idempotent
@@ -12416,7 +11914,6 @@ interfaces:
     required_fields:
     - targetTcpProxy
     - targetTcpProxiesSetProxyHeaderRequestResource
-    request_object_method: true
     resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: non_idempotent
@@ -12476,9 +11973,6 @@ interfaces:
   #       message.
   #   required_fields - Fields that are always required for a request to be
   #       valid.
-  #   request_object_method - Turns on or off the generation of a method whose
-  #       sole parameter is a request object. Not all languages will generate
-  #       this method.
   #   resource_name_treatment - An enum that specifies how to treat the
   #       resource name formats defined in the field_name_patterns
   #       and response_field_name_patterns fields.
@@ -12524,7 +12018,6 @@ interfaces:
     # TODO: Configure which fields are required.
     required_fields:
     - project
-    request_object_method: true
     resource_name_treatment: STATIC_TYPES
     page_streaming:
       request:
@@ -12551,7 +12044,6 @@ interfaces:
     # TODO: Configure which fields are required.
     required_fields:
     - targetVpnGateway
-    request_object_method: true
     resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: idempotent
@@ -12571,7 +12063,6 @@ interfaces:
     # TODO: Configure which fields are required.
     required_fields:
     - targetVpnGateway
-    request_object_method: true
     resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: idempotent
@@ -12593,7 +12084,6 @@ interfaces:
     required_fields:
     - region
     - targetVpnGatewayResource
-    request_object_method: true
     resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: non_idempotent
@@ -12613,7 +12103,6 @@ interfaces:
     # TODO: Configure which fields are required.
     required_fields:
     - region
-    request_object_method: true
     resource_name_treatment: STATIC_TYPES
     page_streaming:
       request:
@@ -12678,9 +12167,6 @@ interfaces:
   #       message.
   #   required_fields - Fields that are always required for a request to be
   #       valid.
-  #   request_object_method - Turns on or off the generation of a method whose
-  #       sole parameter is a request object. Not all languages will generate
-  #       this method.
   #   resource_name_treatment - An enum that specifies how to treat the
   #       resource name formats defined in the field_name_patterns
   #       and response_field_name_patterns fields.
@@ -12726,7 +12212,6 @@ interfaces:
     # TODO: Configure which fields are required.
     required_fields:
     - urlMap
-    request_object_method: true
     resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: idempotent
@@ -12746,7 +12231,6 @@ interfaces:
     # TODO: Configure which fields are required.
     required_fields:
     - urlMap
-    request_object_method: true
     resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: idempotent
@@ -12768,7 +12252,6 @@ interfaces:
     required_fields:
     - project
     - urlMapResource
-    request_object_method: true
     resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: non_idempotent
@@ -12790,7 +12273,6 @@ interfaces:
     required_fields:
     - urlMap
     - cacheInvalidationRuleResource
-    request_object_method: true
     resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: non_idempotent
@@ -12810,7 +12292,6 @@ interfaces:
     # TODO: Configure which fields are required.
     required_fields:
     - project
-    request_object_method: true
     resource_name_treatment: STATIC_TYPES
     page_streaming:
       request:
@@ -12839,7 +12320,6 @@ interfaces:
     required_fields:
     - urlMap
     - urlMapResource
-    request_object_method: true
     resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: non_idempotent
@@ -12861,7 +12341,6 @@ interfaces:
     required_fields:
     - urlMap
     - urlMapResource
-    request_object_method: true
     resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: idempotent
@@ -12883,7 +12362,6 @@ interfaces:
     required_fields:
     - urlMap
     - urlMapsValidateRequestResource
-    request_object_method: true
     resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: non_idempotent
@@ -12943,9 +12421,6 @@ interfaces:
   #       message.
   #   required_fields - Fields that are always required for a request to be
   #       valid.
-  #   request_object_method - Turns on or off the generation of a method whose
-  #       sole parameter is a request object. Not all languages will generate
-  #       this method.
   #   resource_name_treatment - An enum that specifies how to treat the
   #       resource name formats defined in the field_name_patterns
   #       and response_field_name_patterns fields.
@@ -12991,7 +12466,6 @@ interfaces:
     # TODO: Configure which fields are required.
     required_fields:
     - project
-    request_object_method: true
     resource_name_treatment: STATIC_TYPES
     page_streaming:
       request:
@@ -13018,7 +12492,6 @@ interfaces:
     # TODO: Configure which fields are required.
     required_fields:
     - vpnTunnel
-    request_object_method: true
     resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: idempotent
@@ -13038,7 +12511,6 @@ interfaces:
     # TODO: Configure which fields are required.
     required_fields:
     - vpnTunnel
-    request_object_method: true
     resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: idempotent
@@ -13060,7 +12532,6 @@ interfaces:
     required_fields:
     - region
     - vpnTunnelResource
-    request_object_method: true
     resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: non_idempotent
@@ -13080,7 +12551,6 @@ interfaces:
     # TODO: Configure which fields are required.
     required_fields:
     - region
-    request_object_method: true
     resource_name_treatment: STATIC_TYPES
     page_streaming:
       request:
@@ -13145,9 +12615,6 @@ interfaces:
   #       message.
   #   required_fields - Fields that are always required for a request to be
   #       valid.
-  #   request_object_method - Turns on or off the generation of a method whose
-  #       sole parameter is a request object. Not all languages will generate
-  #       this method.
   #   resource_name_treatment - An enum that specifies how to treat the
   #       resource name formats defined in the field_name_patterns
   #       and response_field_name_patterns fields.
@@ -13193,7 +12660,6 @@ interfaces:
     # TODO: Configure which fields are required.
     required_fields:
     - operation
-    request_object_method: true
     resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: idempotent
@@ -13213,7 +12679,6 @@ interfaces:
     # TODO: Configure which fields are required.
     required_fields:
     - operation
-    request_object_method: true
     resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: idempotent
@@ -13233,7 +12698,6 @@ interfaces:
     # TODO: Configure which fields are required.
     required_fields:
     - zone
-    request_object_method: true
     resource_name_treatment: STATIC_TYPES
     page_streaming:
       request:
@@ -13298,9 +12762,6 @@ interfaces:
   #       message.
   #   required_fields - Fields that are always required for a request to be
   #       valid.
-  #   request_object_method - Turns on or off the generation of a method whose
-  #       sole parameter is a request object. Not all languages will generate
-  #       this method.
   #   resource_name_treatment - An enum that specifies how to treat the
   #       resource name formats defined in the field_name_patterns
   #       and response_field_name_patterns fields.
@@ -13346,7 +12807,6 @@ interfaces:
     # TODO: Configure which fields are required.
     required_fields:
     - zone
-    request_object_method: true
     resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: idempotent
@@ -13366,7 +12826,6 @@ interfaces:
     # TODO: Configure which fields are required.
     required_fields:
     - project
-    request_object_method: true
     resource_name_treatment: STATIC_TYPES
     page_streaming:
       request:


### PR DESCRIPTION
Just regenerated compute_gapic.yaml from gapic-generator. Apparently resource_object_method config has become unsupported since last regen.