### PR TITLE
Update common-protos dep to match gapic-generator

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -40,7 +40,7 @@ maven_jar(
 
 maven_jar(
     name = "com_google_api_grpc_proto_google_common_protos__com_google_api_codegen",
-    artifact = "com.google.api.grpc:proto-google-common-protos:1.13.0-pre1",
+    artifact = "com.google.api.grpc:proto-google-common-protos:1.13.0-pre2",
 )
 
 git_repository(
@@ -94,4 +94,3 @@ com_google_api_codegen_repositories(
 com_google_api_codegen_test_repositories()
 
 com_google_api_codegen_tools_repositories()
-


### PR DESCRIPTION
gapic-generator just started using v1.13.0-pre2 in https://github.com/googleapis/gapic-generator/pull/2394