### PR TITLE
Sample regen of compute, no manual edits (DO NOT MERGE)

### DIFF
--- a/gapic/google/compute/v1/compute_gapic.yaml
+++ b/gapic/google/compute/v1/compute_gapic.yaml
@@ -8,7 +8,7 @@ config_schema_version: 1.0.0
 # The settings of generated code in a specific language.
 language_settings:
   java:
-    package_name: com.google.cloud.compute.v1
+    package_name: com.google.compute.v1
   python:
     package_name: com.google.compute_v1.gapic
   go:
@@ -7485,7 +7485,7 @@ interfaces:
         token_field: pageToken
       response:
         token_field: nextPageToken
-        resources_field: resources
+        resources_field: _TODO_
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: idempotent
     # TODO: Configure the retryable params for this method.
@@ -9583,7 +9583,7 @@ interfaces:
         token_field: pageToken
       response:
         token_field: nextPageToken
-        resources_field: result
+        resources_field: _TODO_
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: idempotent
     # TODO: Configure the retryable params for this method.


### PR DESCRIPTION
Example of the result when `artman --config=gapic/google/compute/artman_compute.yaml  generate discogapic_config` is used to generated the `compute_gapic.yaml` file.

This contains no hand edits. Therefore, the diff in this PR are things that I have to manually revert back to the right values, every time I regenerate this file..