### PR TITLE
Require latest version of google-apis-client-generator

### DIFF
--- a/server/tasks/google_api_php_client_services.py
+++ b/server/tasks/google_api_php_client_services.py
@@ -115,7 +115,7 @@ def update(filepath, github_account, discovery_documents):
     # "google-apis-client-generator" package.
     check_output([join(venv_filepath, 'bin/pip'),
                   'install',
-                  'google-apis-client-generator==1.4.3'])
+                  'google-apis-client-generator==1.6.0'])
     added, updated = _generate_and_commit_all_clients(
         repo, venv_filepath, discovery_documents)
     commit_count = len(added) + len(updated)


### PR DESCRIPTION
[google-apis-client-generator v1.6.0](https://pypi.org/project/google-apis-client-generator/1.6.0/) includes a few required fixes in the PHP generation process.

/cc @bshaffer 