### PR TITLE
Allow creating ApiTypeName from anyCamel

### DIFF
--- a/toolkit/src/main/java/com/google/api/codegen/discovery/config/ruby/RubyTypeNameGenerator.java
+++ b/toolkit/src/main/java/com/google/api/codegen/discovery/config/ruby/RubyTypeNameGenerator.java
@@ -108,7 +108,7 @@ public class RubyTypeNameGenerator extends TypeNameGenerator {
 
   @Override
   public String getApiTypeName(String apiName) {
-    return Name.upperCamel(apiName.replace(" ", ""), "Service").toUpperCamel();
+    return Name.anyCamel(apiName.replace(" ", ""), "Service").toUpperCamel();
   }
 
   @Override

--- a/toolkit/src/main/java/com/google/api/codegen/discovery/transformer/SampleNamer.java
+++ b/toolkit/src/main/java/com/google/api/codegen/discovery/transformer/SampleNamer.java
@@ -33,12 +33,12 @@ public class SampleNamer extends NameFormatterDelegator {
 
   /** Returns the class name of the sample. */
   public String getSampleClassName(String apiTypeName) {
-    return publicClassName(Name.upperCamel(apiTypeName, "Example"));
+    return publicClassName(Name.anyCamel(apiTypeName, "Example"));
   }
 
   /** Returns the variable name of the service. */
   public String getServiceVarName(String apiTypeName) {
-    return localVarName(Name.upperCamel(apiTypeName, "Service"));
+    return localVarName(Name.anyCamel(apiTypeName, "Service"));
   }
 
   /** Returns the variable name for a field. */
@@ -88,6 +88,6 @@ public class SampleNamer extends NameFormatterDelegator {
 
   /** Returns the name of the createService function. */
   public String createServiceFuncName(String apiTypeName) {
-    return publicMethodName(Name.upperCamel("Create", apiTypeName, "Service"));
+    return publicMethodName(Name.anyCamel("Create", apiTypeName, "Service"));
   }
 }

--- a/toolkit/src/main/java/com/google/api/codegen/discovery/transformer/csharp/CSharpSampleNamer.java
+++ b/toolkit/src/main/java/com/google/api/codegen/discovery/transformer/csharp/CSharpSampleNamer.java
@@ -33,7 +33,7 @@ class CSharpSampleNamer extends SampleNamer {
 
   @Override
   public String getServiceVarName(String apiTypeName) {
-    return Name.upperCamel(apiTypeName).toLowerCamel();
+    return Name.anyCamel(apiTypeName).toLowerCamel();
   }
 
   @Override

--- a/toolkit/src/main/java/com/google/api/codegen/discovery/transformer/js/JSSampleNamer.java
+++ b/toolkit/src/main/java/com/google/api/codegen/discovery/transformer/js/JSSampleNamer.java
@@ -26,7 +26,7 @@ public class JSSampleNamer extends SampleNamer {
 
   @Override
   public String getServiceVarName(String apiTypeName) {
-    return localVarName(Name.upperCamelKeepUpperAcronyms(apiTypeName));
+    return localVarName(Name.anyCamelKeepUpperAcronyms(apiTypeName));
   }
 
   @Override


### PR DESCRIPTION
The `canonicalName` for `iam` API is `iam` which is not `UpperCamel`. Allow creating ApiTypeName from `anyCamel` names to allow us generate samples for `iam`.