### PR TITLE
Various apiary fixes

### DIFF
--- a/server/app.yaml
+++ b/server/app.yaml
@@ -3,4 +3,4 @@ env: flex
 automatic_scaling:
   max_num_instances: 2
 resources:
-  memory_gb: 2
+  memory_gb: 3

--- a/server/main.py
+++ b/server/main.py
@@ -58,7 +58,9 @@ def nodejs_release(filepath, github_account, force):
 def php_update(filepath, github_account):
     """Wrapper over the PHP release function to standardize parameters."""
     ddocs = discovery_artifact_manager.discovery_documents(
-        filepath, preferred=True, skip=['discovery:v1'])
+        filepath, preferred=True, skip=['discovery:v1',
+                                        'healthcare:v1alpha2',
+                                        'healthcare:v1alpha'])
     google_api_php_client_services.update(filepath, github_account, ddocs)
 
 

--- a/server/tasks/google_api_php_client_services.py
+++ b/server/tasks/google_api_php_client_services.py
@@ -80,7 +80,7 @@ def _generate_client(repo, venv_filepath, ddoc_filename):
         check_output([join(venv_filepath, 'bin/generate_library'),
                       '--input={}'.format(ddoc_filename),
                       '--language=php',
-                      '--language_variant=1.2.0',
+                      '--language_variant=1.2.1',
                       '--output_dir={}'.format(dest_filepath)])
         dirs = os.listdir(dest_filepath)
         client_name = os.path.splitext(dirs[0])[0]  # ex: "BigQuery"
@@ -115,7 +115,7 @@ def update(filepath, github_account, discovery_documents):
     # "google-apis-client-generator" package.
     check_output([join(venv_filepath, 'bin/pip'),
                   'install',
-                  'google-apis-client-generator==1.6.0'])
+                  'google-apis-client-generator==1.6.1'])
     added, updated = _generate_and_commit_all_clients(
         repo, venv_filepath, discovery_documents)
     commit_count = len(added) + len(updated)

--- a/server/tasks/google_api_ruby_client.py
+++ b/server/tasks/google_api_ruby_client.py
@@ -72,6 +72,13 @@ def _generate_all_clients(repo):
                   'generated/google/apis/discovery_v1'],
                  cwd=repo.filepath)
     check_output(['./script/generate'], cwd=repo.filepath)
+    # Temporarily disable generation of health care services.
+    check_output(['rm', '-rf',
+                  'generated/google/apis/healthcare_v1alpha2',
+                  'generated/google/apis/healthcare_v1alpha2.rb',
+                  'generated/google/apis/healthcare_v1alpha',
+                  'generated/google/apis/healthcare_v1alpha.rb'],
+                  cwd=repo.filepath)
     added, deleted, updated = set(), set(), set()
     status_to_ids = {
         _git.Status.ADDED: added,


### PR DESCRIPTION
- PHP can now utilize per API batch paths. (https://github.com/google/apis-client-generator/commit/747c6215659df6d8e694eb15ad010d42bedce01a)
- Temporarily disabled generation of the health care service for PHP/Ruby pending a more complete fix.
- Increased appengine memory limit to help prevent timeouts.

/cc @hzyi-google When you have a moment could you please take a look?