### PR TITLE
Increase memory allocation

### DIFF
--- a/server/app.yaml
+++ b/server/app.yaml
@@ -3,4 +3,4 @@ env: flex
 automatic_scaling:
   max_num_instances: 2
 resources:
-  memory_gb: 3
+  memory_gb: 3.5


### PR DESCRIPTION
Go apiary builds are continuing to be fail due to running out of memory. Nudging this value up a bit to hopefully resolve this in the short term, but we may want to look into a more permanent solution.