### PR TITLE
Re-enable cloud health care generation for PHP/ruby

### DIFF
--- a/server/main.py
+++ b/server/main.py
@@ -58,9 +58,7 @@ def nodejs_release(filepath, github_account, force):
 def php_update(filepath, github_account):
     """Wrapper over the PHP release function to standardize parameters."""
     ddocs = discovery_artifact_manager.discovery_documents(
-        filepath, preferred=True, skip=['discovery:v1',
-                                        'healthcare:v1alpha2',
-                                        'healthcare:v1alpha'])
+        filepath, preferred=True, skip=['discovery:v1'])
     google_api_php_client_services.update(filepath, github_account, ddocs)
 
 

--- a/server/tasks/google_api_ruby_client.py
+++ b/server/tasks/google_api_ruby_client.py
@@ -72,13 +72,6 @@ def _generate_all_clients(repo):
                   'generated/google/apis/discovery_v1'],
                  cwd=repo.filepath)
     check_output(['./script/generate'], cwd=repo.filepath)
-    # Temporarily disable generation of health care services.
-    check_output(['rm', '-rf',
-                  'generated/google/apis/healthcare_v1alpha2',
-                  'generated/google/apis/healthcare_v1alpha2.rb',
-                  'generated/google/apis/healthcare_v1alpha',
-                  'generated/google/apis/healthcare_v1alpha.rb'],
-                  cwd=repo.filepath)
     added, deleted, updated = set(), set(), set()
     status_to_ids = {
         _git.Status.ADDED: added,


### PR DESCRIPTION
We had previously halted generation of the Cloud HealthCare clients due to issues with `$`s in method names. A fix is being pushed to the service which will resolve this.

Please hold off on merging until we get the ok the service is updated in production.