### PR TITLE
fix: example of fetching auth client does not match API

### DIFF
--- a/toolkit/src/main/resources/com/google/api/codegen/nodejs/sample.snip
+++ b/toolkit/src/main/resources/com/google/api/codegen/nodejs/sample.snip
@@ -165,16 +165,12 @@
 
 @private authFunc_ADC(class)
   function {@class.auth.authFuncName}(callback) {
-    google.auth.getApplicationDefault(function(err, authClient) {
-      if (err) {
-        console.error('authentication failed: ', err);
-        return;
-      }
-      if ({@class.auth.authVarName}.createScopedRequired && authClient.createScopedRequired()) {
-        var scopes = ['https://www.googleapis.com/auth/cloud-platform'];
-        authClient = authClient.createScoped(scopes);
-      }
-      callback(authClient);
+    google.auth.getClient({
+      scopes: ['https://www.googleapis.com/auth/cloud-platform']
+    }).then(client => {
+      callback(client);
+    }).catch(err => {
+      console.error('authentication failed: ', err);
     });
   }
 @end


### PR DESCRIPTION
Our authentication API is now promise based, and has in general a slightly different API signature than documented in these historic samples.