### PR TITLE
Refresh compute_gapic.yaml, and make it clearer how to do so

### DIFF
--- a/gapic/google/compute/v1/compute_gapic.yaml
+++ b/gapic/google/compute/v1/compute_gapic.yaml
@@ -23,7 +23,7 @@ language_settings:
     package_name: compute.v1
 # A list of API interface configurations.
 interfaces:
-# The fully qualified name of the API interface.
+  # The fully qualified name of the API interface.
 - name: google.compute.v1.AcceleratorTypes
   # A list of resource collection configurations.
   # Consists of a name_pattern and an entity_name.
@@ -36,18 +36,18 @@ interfaces:
   # The entity_name is the name to be used as a basis for generated methods and
   # classes.
   collections:
-  - name_pattern: '{project}'
+  - name_pattern: projects/{project}
     entity_name: project
-  - name_pattern: '{project}/zones/{zone}'
-    entity_name: projectZone
-  - name_pattern: '{project}/zones/{zone}/acceleratorTypes/{acceleratorType}'
-    entity_name: projectZoneAcceleratorType
+  - name_pattern: projects/{project}/zones/{zone}
+    entity_name: zone
+  - name_pattern: projects/{project}/zones/{zone}/acceleratorTypes/{acceleratorType}
+    entity_name: acceleratorType
   # Definition for retryable codes.
   retry_codes_def:
   - name: idempotent
     retry_codes:
-    - UNAVAILABLE
-    - DEADLINE_EXCEEDED
+    - SC_SERVICE_UNAVAILABLE
+    - SC_GATEWAY_TIMEOUT
   - name: non_idempotent
     retry_codes: []
   # Definition for retry/backoff parameters.
@@ -73,6 +73,17 @@ interfaces:
   #       message.
   #   required_fields - Fields that are always required for a request to be
   #       valid.
+  #   request_object_method - Turns on or off the generation of a method whose
+  #       sole parameter is a request object. Not all languages will generate
+  #       this method.
+  #   resource_name_treatment - An enum that specifies how to treat the
+  #       resource name formats defined in the field_name_patterns
+  #       and response_field_name_patterns fields.
+  #       UNSET: default value
+  #       NONE: the collection configs will not be used by the generated code.
+  #       VALIDATE: string fields will be validated by the client against the
+  #           specified resource name formats.
+  #       STATIC_TYPES: the client will use generated types for resource names.
   #   page_streaming - Specifies the configuration for paging.
   #       Describes information for generating a method which transforms a
   #       paging list RPC into a stream of resources.
@@ -110,13 +121,15 @@ interfaces:
     # TODO: Configure which fields are required.
     required_fields:
     - project
+    request_object_method: true
+    resource_name_treatment: STATIC_TYPES
     page_streaming:
       request:
         page_size_field: maxResults
         token_field: pageToken
       response:
         token_field: nextPageToken
-        resources_field: items
+        resources_field: AcceleratorTypeAggregatedList
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: idempotent
     # TODO: Configure the retryable params for this method.
@@ -135,12 +148,14 @@ interfaces:
     # TODO: Configure which fields are required.
     required_fields:
     - acceleratorType
+    request_object_method: true
+    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      acceleratorType: projectZoneAcceleratorType
+      acceleratorType: acceleratorType
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
   - name: compute.acceleratorTypes.list
@@ -153,22 +168,24 @@ interfaces:
     # TODO: Configure which fields are required.
     required_fields:
     - zone
+    request_object_method: true
+    resource_name_treatment: STATIC_TYPES
     page_streaming:
       request:
         page_size_field: maxResults
         token_field: pageToken
       response:
         token_field: nextPageToken
-        resources_field: items
+        resources_field: AcceleratorTypeList
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      zone: projectZone
+      zone: zone
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
-# The fully qualified name of the API interface.
+  # The fully qualified name of the API interface.
 - name: google.compute.v1.Addresses
   # A list of resource collection configurations.
   # Consists of a name_pattern and an entity_name.
@@ -181,18 +198,18 @@ interfaces:
   # The entity_name is the name to be used as a basis for generated methods and
   # classes.
   collections:
-  - name_pattern: '{project}'
+  - name_pattern: projects/{project}
     entity_name: project
-  - name_pattern: '{project}/regions/{region}'
-    entity_name: projectRegion
-  - name_pattern: '{project}/regions/{region}/addresses/{address}'
-    entity_name: projectRegionAddress
+  - name_pattern: projects/{project}/regions/{region}
+    entity_name: region
+  - name_pattern: projects/{project}/regions/{region}/addresses/{address}
+    entity_name: address
   # Definition for retryable codes.
   retry_codes_def:
   - name: idempotent
     retry_codes:
-    - UNAVAILABLE
-    - DEADLINE_EXCEEDED
+    - SC_SERVICE_UNAVAILABLE
+    - SC_GATEWAY_TIMEOUT
   - name: non_idempotent
     retry_codes: []
   # Definition for retry/backoff parameters.
@@ -218,6 +235,17 @@ interfaces:
   #       message.
   #   required_fields - Fields that are always required for a request to be
   #       valid.
+  #   request_object_method - Turns on or off the generation of a method whose
+  #       sole parameter is a request object. Not all languages will generate
+  #       this method.
+  #   resource_name_treatment - An enum that specifies how to treat the
+  #       resource name formats defined in the field_name_patterns
+  #       and response_field_name_patterns fields.
+  #       UNSET: default value
+  #       NONE: the collection configs will not be used by the generated code.
+  #       VALIDATE: string fields will be validated by the client against the
+  #           specified resource name formats.
+  #       STATIC_TYPES: the client will use generated types for resource names.
   #   page_streaming - Specifies the configuration for paging.
   #       Describes information for generating a method which transforms a
   #       paging list RPC into a stream of resources.
@@ -255,13 +283,15 @@ interfaces:
     # TODO: Configure which fields are required.
     required_fields:
     - project
+    request_object_method: true
+    resource_name_treatment: STATIC_TYPES
     page_streaming:
       request:
         page_size_field: maxResults
         token_field: pageToken
       response:
         token_field: nextPageToken
-        resources_field: items
+        resources_field: AddressAggregatedList
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: idempotent
     # TODO: Configure the retryable params for this method.
@@ -277,15 +307,19 @@ interfaces:
       groups:
       - parameters:
         - address
+        - requestId
     # TODO: Configure which fields are required.
     required_fields:
     - address
+    - requestId
+    request_object_method: true
+    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      address: projectRegionAddress
+      address: address
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
   - name: compute.addresses.get
@@ -298,12 +332,14 @@ interfaces:
     # TODO: Configure which fields are required.
     required_fields:
     - address
+    request_object_method: true
+    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      address: projectRegionAddress
+      address: address
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
   - name: compute.addresses.insert
@@ -312,18 +348,22 @@ interfaces:
     flattening:
       groups:
       - parameters:
+        - requestId
         - region
         - addressResource
     # TODO: Configure which fields are required.
     required_fields:
+    - requestId
     - region
     - addressResource
+    request_object_method: true
+    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: non_idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      region: projectRegion
+      region: region
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
   - name: compute.addresses.list
@@ -336,22 +376,24 @@ interfaces:
     # TODO: Configure which fields are required.
     required_fields:
     - region
+    request_object_method: true
+    resource_name_treatment: STATIC_TYPES
     page_streaming:
       request:
         page_size_field: maxResults
         token_field: pageToken
       response:
         token_field: nextPageToken
-        resources_field: items
+        resources_field: AddressList
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      region: projectRegion
+      region: region
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
-# The fully qualified name of the API interface.
+  # The fully qualified name of the API interface.
 - name: google.compute.v1.Autoscalers
   # A list of resource collection configurations.
   # Consists of a name_pattern and an entity_name.
@@ -364,18 +406,18 @@ interfaces:
   # The entity_name is the name to be used as a basis for generated methods and
   # classes.
   collections:
-  - name_pattern: '{project}'
+  - name_pattern: projects/{project}
     entity_name: project
-  - name_pattern: '{project}/zones/{zone}'
-    entity_name: projectZone
-  - name_pattern: '{project}/zones/{zone}/autoscalers/{autoscaler}'
-    entity_name: projectZoneAutoscaler
+  - name_pattern: projects/{project}/zones/{zone}
+    entity_name: zone
+  - name_pattern: projects/{project}/zones/{zone}/autoscalers/{autoscaler}
+    entity_name: autoscaler
   # Definition for retryable codes.
   retry_codes_def:
   - name: idempotent
     retry_codes:
-    - UNAVAILABLE
-    - DEADLINE_EXCEEDED
+    - SC_SERVICE_UNAVAILABLE
+    - SC_GATEWAY_TIMEOUT
   - name: non_idempotent
     retry_codes: []
   # Definition for retry/backoff parameters.
@@ -401,6 +443,17 @@ interfaces:
   #       message.
   #   required_fields - Fields that are always required for a request to be
   #       valid.
+  #   request_object_method - Turns on or off the generation of a method whose
+  #       sole parameter is a request object. Not all languages will generate
+  #       this method.
+  #   resource_name_treatment - An enum that specifies how to treat the
+  #       resource name formats defined in the field_name_patterns
+  #       and response_field_name_patterns fields.
+  #       UNSET: default value
+  #       NONE: the collection configs will not be used by the generated code.
+  #       VALIDATE: string fields will be validated by the client against the
+  #           specified resource name formats.
+  #       STATIC_TYPES: the client will use generated types for resource names.
   #   page_streaming - Specifies the configuration for paging.
   #       Describes information for generating a method which transforms a
   #       paging list RPC into a stream of resources.
@@ -438,13 +491,15 @@ interfaces:
     # TODO: Configure which fields are required.
     required_fields:
     - project
+    request_object_method: true
+    resource_name_treatment: STATIC_TYPES
     page_streaming:
       request:
         page_size_field: maxResults
         token_field: pageToken
       response:
         token_field: nextPageToken
-        resources_field: items
+        resources_field: AutoscalerAggregatedList
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: idempotent
     # TODO: Configure the retryable params for this method.
@@ -460,15 +515,19 @@ interfaces:
       groups:
       - parameters:
         - autoscaler
+        - requestId
     # TODO: Configure which fields are required.
     required_fields:
     - autoscaler
+    - requestId
+    request_object_method: true
+    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      autoscaler: projectZoneAutoscaler
+      autoscaler: autoscaler
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
   - name: compute.autoscalers.get
@@ -481,12 +540,14 @@ interfaces:
     # TODO: Configure which fields are required.
     required_fields:
     - autoscaler
+    request_object_method: true
+    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      autoscaler: projectZoneAutoscaler
+      autoscaler: autoscaler
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
   - name: compute.autoscalers.insert
@@ -496,17 +557,21 @@ interfaces:
       groups:
       - parameters:
         - zone
+        - requestId
         - autoscalerResource
     # TODO: Configure which fields are required.
     required_fields:
     - zone
+    - requestId
     - autoscalerResource
+    request_object_method: true
+    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: non_idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      zone: projectZone
+      zone: zone
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
   - name: compute.autoscalers.list
@@ -519,19 +584,21 @@ interfaces:
     # TODO: Configure which fields are required.
     required_fields:
     - zone
+    request_object_method: true
+    resource_name_treatment: STATIC_TYPES
     page_streaming:
       request:
         page_size_field: maxResults
         token_field: pageToken
       response:
         token_field: nextPageToken
-        resources_field: items
+        resources_field: AutoscalerList
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      zone: projectZone
+      zone: zone
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
   - name: compute.autoscalers.patch
@@ -542,18 +609,22 @@ interfaces:
       - parameters:
         - autoscaler
         - zone
+        - requestId
         - autoscalerResource
     # TODO: Configure which fields are required.
     required_fields:
     - autoscaler
     - zone
+    - requestId
     - autoscalerResource
+    request_object_method: true
+    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: non_idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      zone: projectZone
+      zone: zone
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
   - name: compute.autoscalers.update
@@ -564,21 +635,25 @@ interfaces:
       - parameters:
         - autoscaler
         - zone
+        - requestId
         - autoscalerResource
     # TODO: Configure which fields are required.
     required_fields:
     - autoscaler
     - zone
+    - requestId
     - autoscalerResource
+    request_object_method: true
+    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      zone: projectZone
+      zone: zone
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
-# The fully qualified name of the API interface.
+  # The fully qualified name of the API interface.
 - name: google.compute.v1.BackendBuckets
   # A list of resource collection configurations.
   # Consists of a name_pattern and an entity_name.
@@ -591,16 +666,16 @@ interfaces:
   # The entity_name is the name to be used as a basis for generated methods and
   # classes.
   collections:
-  - name_pattern: '{project}'
+  - name_pattern: projects/{project}
     entity_name: project
-  - name_pattern: '{project}/global/backendBuckets/{backendBucket}'
-    entity_name: projectGlobalBackendBucket
+  - name_pattern: projects/{project}/backendBuckets/{backendBucket}
+    entity_name: backendBucket
   # Definition for retryable codes.
   retry_codes_def:
   - name: idempotent
     retry_codes:
-    - UNAVAILABLE
-    - DEADLINE_EXCEEDED
+    - SC_SERVICE_UNAVAILABLE
+    - SC_GATEWAY_TIMEOUT
   - name: non_idempotent
     retry_codes: []
   # Definition for retry/backoff parameters.
@@ -626,6 +701,17 @@ interfaces:
   #       message.
   #   required_fields - Fields that are always required for a request to be
   #       valid.
+  #   request_object_method - Turns on or off the generation of a method whose
+  #       sole parameter is a request object. Not all languages will generate
+  #       this method.
+  #   resource_name_treatment - An enum that specifies how to treat the
+  #       resource name formats defined in the field_name_patterns
+  #       and response_field_name_patterns fields.
+  #       UNSET: default value
+  #       NONE: the collection configs will not be used by the generated code.
+  #       VALIDATE: string fields will be validated by the client against the
+  #           specified resource name formats.
+  #       STATIC_TYPES: the client will use generated types for resource names.
   #   page_streaming - Specifies the configuration for paging.
   #       Describes information for generating a method which transforms a
   #       paging list RPC into a stream of resources.
@@ -660,17 +746,21 @@ interfaces:
       groups:
       - parameters:
         - backendBucket
+        - requestId
         - signedUrlKeyResource
     # TODO: Configure which fields are required.
     required_fields:
     - backendBucket
+    - requestId
     - signedUrlKeyResource
+    request_object_method: true
+    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: non_idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      backendBucket: projectGlobalBackendBucket
+      backendBucket: backendBucket
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
   - name: compute.backendBuckets.delete
@@ -680,15 +770,19 @@ interfaces:
       groups:
       - parameters:
         - backendBucket
+        - requestId
     # TODO: Configure which fields are required.
     required_fields:
     - backendBucket
+    - requestId
+    request_object_method: true
+    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      backendBucket: projectGlobalBackendBucket
+      backendBucket: backendBucket
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
   - name: compute.backendBuckets.deleteSignedUrlKey
@@ -698,17 +792,21 @@ interfaces:
       groups:
       - parameters:
         - backendBucket
+        - requestId
         - keyName
     # TODO: Configure which fields are required.
     required_fields:
     - backendBucket
+    - requestId
     - keyName
+    request_object_method: true
+    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: non_idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      backendBucket: projectGlobalBackendBucket
+      backendBucket: backendBucket
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
   - name: compute.backendBuckets.get
@@ -721,12 +819,14 @@ interfaces:
     # TODO: Configure which fields are required.
     required_fields:
     - backendBucket
+    request_object_method: true
+    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      backendBucket: projectGlobalBackendBucket
+      backendBucket: backendBucket
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
   - name: compute.backendBuckets.insert
@@ -735,12 +835,16 @@ interfaces:
     flattening:
       groups:
       - parameters:
+        - requestId
         - project
         - backendBucketResource
     # TODO: Configure which fields are required.
     required_fields:
+    - requestId
     - project
     - backendBucketResource
+    request_object_method: true
+    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: non_idempotent
     # TODO: Configure the retryable params for this method.
@@ -759,13 +863,15 @@ interfaces:
     # TODO: Configure which fields are required.
     required_fields:
     - project
+    request_object_method: true
+    resource_name_treatment: STATIC_TYPES
     page_streaming:
       request:
         page_size_field: maxResults
         token_field: pageToken
       response:
         token_field: nextPageToken
-        resources_field: items
+        resources_field: BackendBucketList
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: idempotent
     # TODO: Configure the retryable params for this method.
@@ -781,17 +887,21 @@ interfaces:
       groups:
       - parameters:
         - backendBucket
+        - requestId
         - backendBucketResource
     # TODO: Configure which fields are required.
     required_fields:
     - backendBucket
+    - requestId
     - backendBucketResource
+    request_object_method: true
+    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: non_idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      backendBucket: projectGlobalBackendBucket
+      backendBucket: backendBucket
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
   - name: compute.backendBuckets.update
@@ -801,20 +911,24 @@ interfaces:
       groups:
       - parameters:
         - backendBucket
+        - requestId
         - backendBucketResource
     # TODO: Configure which fields are required.
     required_fields:
     - backendBucket
+    - requestId
     - backendBucketResource
+    request_object_method: true
+    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      backendBucket: projectGlobalBackendBucket
+      backendBucket: backendBucket
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
-# The fully qualified name of the API interface.
+  # The fully qualified name of the API interface.
 - name: google.compute.v1.BackendServices
   # A list of resource collection configurations.
   # Consists of a name_pattern and an entity_name.
@@ -827,16 +941,16 @@ interfaces:
   # The entity_name is the name to be used as a basis for generated methods and
   # classes.
   collections:
-  - name_pattern: '{project}'
+  - name_pattern: projects/{project}
     entity_name: project
-  - name_pattern: '{project}/global/backendServices/{backendService}'
-    entity_name: projectGlobalBackendService
+  - name_pattern: projects/{project}/backendServices/{backendService}
+    entity_name: backendService
   # Definition for retryable codes.
   retry_codes_def:
   - name: idempotent
     retry_codes:
-    - UNAVAILABLE
-    - DEADLINE_EXCEEDED
+    - SC_SERVICE_UNAVAILABLE
+    - SC_GATEWAY_TIMEOUT
   - name: non_idempotent
     retry_codes: []
   # Definition for retry/backoff parameters.
@@ -862,6 +976,17 @@ interfaces:
   #       message.
   #   required_fields - Fields that are always required for a request to be
   #       valid.
+  #   request_object_method - Turns on or off the generation of a method whose
+  #       sole parameter is a request object. Not all languages will generate
+  #       this method.
+  #   resource_name_treatment - An enum that specifies how to treat the
+  #       resource name formats defined in the field_name_patterns
+  #       and response_field_name_patterns fields.
+  #       UNSET: default value
+  #       NONE: the collection configs will not be used by the generated code.
+  #       VALIDATE: string fields will be validated by the client against the
+  #           specified resource name formats.
+  #       STATIC_TYPES: the client will use generated types for resource names.
   #   page_streaming - Specifies the configuration for paging.
   #       Describes information for generating a method which transforms a
   #       paging list RPC into a stream of resources.
@@ -895,18 +1020,22 @@ interfaces:
     flattening:
       groups:
       - parameters:
+        - requestId
         - backendService
         - signedUrlKeyResource
     # TODO: Configure which fields are required.
     required_fields:
+    - requestId
     - backendService
     - signedUrlKeyResource
+    request_object_method: true
+    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: non_idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      backendService: projectGlobalBackendService
+      backendService: backendService
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
   - name: compute.backendServices.aggregatedList
@@ -919,13 +1048,15 @@ interfaces:
     # TODO: Configure which fields are required.
     required_fields:
     - project
+    request_object_method: true
+    resource_name_treatment: STATIC_TYPES
     page_streaming:
       request:
         page_size_field: maxResults
         token_field: pageToken
       response:
         token_field: nextPageToken
-        resources_field: items
+        resources_field: BackendServiceAggregatedList
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: idempotent
     # TODO: Configure the retryable params for this method.
@@ -940,16 +1071,20 @@ interfaces:
     flattening:
       groups:
       - parameters:
+        - requestId
         - backendService
     # TODO: Configure which fields are required.
     required_fields:
+    - requestId
     - backendService
+    request_object_method: true
+    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      backendService: projectGlobalBackendService
+      backendService: backendService
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
   - name: compute.backendServices.deleteSignedUrlKey
@@ -958,18 +1093,22 @@ interfaces:
     flattening:
       groups:
       - parameters:
+        - requestId
         - backendService
         - keyName
     # TODO: Configure which fields are required.
     required_fields:
+    - requestId
     - backendService
     - keyName
+    request_object_method: true
+    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: non_idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      backendService: projectGlobalBackendService
+      backendService: backendService
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
   - name: compute.backendServices.get
@@ -982,12 +1121,14 @@ interfaces:
     # TODO: Configure which fields are required.
     required_fields:
     - backendService
+    request_object_method: true
+    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      backendService: projectGlobalBackendService
+      backendService: backendService
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
   - name: compute.backendServices.getHealth
@@ -1002,12 +1143,14 @@ interfaces:
     required_fields:
     - backendService
     - resourceGroupReferenceResource
+    request_object_method: true
+    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: non_idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      backendService: projectGlobalBackendService
+      backendService: backendService
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
   - name: compute.backendServices.insert
@@ -1016,12 +1159,16 @@ interfaces:
     flattening:
       groups:
       - parameters:
+        - requestId
         - project
         - backendServiceResource
     # TODO: Configure which fields are required.
     required_fields:
+    - requestId
     - project
     - backendServiceResource
+    request_object_method: true
+    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: non_idempotent
     # TODO: Configure the retryable params for this method.
@@ -1040,13 +1187,15 @@ interfaces:
     # TODO: Configure which fields are required.
     required_fields:
     - project
+    request_object_method: true
+    resource_name_treatment: STATIC_TYPES
     page_streaming:
       request:
         page_size_field: maxResults
         token_field: pageToken
       response:
         token_field: nextPageToken
-        resources_field: items
+        resources_field: BackendServiceList
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: idempotent
     # TODO: Configure the retryable params for this method.
@@ -1061,18 +1210,22 @@ interfaces:
     flattening:
       groups:
       - parameters:
+        - requestId
         - backendService
         - backendServiceResource
     # TODO: Configure which fields are required.
     required_fields:
+    - requestId
     - backendService
     - backendServiceResource
+    request_object_method: true
+    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: non_idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      backendService: projectGlobalBackendService
+      backendService: backendService
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
   - name: compute.backendServices.setSecurityPolicy
@@ -1081,18 +1234,22 @@ interfaces:
     flattening:
       groups:
       - parameters:
+        - requestId
         - backendService
         - securityPolicyReferenceResource
     # TODO: Configure which fields are required.
     required_fields:
+    - requestId
     - backendService
     - securityPolicyReferenceResource
+    request_object_method: true
+    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: non_idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      backendService: projectGlobalBackendService
+      backendService: backendService
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
   - name: compute.backendServices.update
@@ -1101,21 +1258,25 @@ interfaces:
     flattening:
       groups:
       - parameters:
+        - requestId
         - backendService
         - backendServiceResource
     # TODO: Configure which fields are required.
     required_fields:
+    - requestId
     - backendService
     - backendServiceResource
+    request_object_method: true
+    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      backendService: projectGlobalBackendService
+      backendService: backendService
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
-# The fully qualified name of the API interface.
+  # The fully qualified name of the API interface.
 - name: google.compute.v1.DiskTypes
   # A list of resource collection configurations.
   # Consists of a name_pattern and an entity_name.
@@ -1128,18 +1289,18 @@ interfaces:
   # The entity_name is the name to be used as a basis for generated methods and
   # classes.
   collections:
-  - name_pattern: '{project}'
+  - name_pattern: projects/{project}
     entity_name: project
-  - name_pattern: '{project}/zones/{zone}'
-    entity_name: projectZone
-  - name_pattern: '{project}/zones/{zone}/diskTypes/{diskType}'
-    entity_name: projectZoneDiskType
+  - name_pattern: projects/{project}/zones/{zone}
+    entity_name: zone
+  - name_pattern: projects/{project}/zones/{zone}/diskTypes/{diskType}
+    entity_name: diskType
   # Definition for retryable codes.
   retry_codes_def:
   - name: idempotent
     retry_codes:
-    - UNAVAILABLE
-    - DEADLINE_EXCEEDED
+    - SC_SERVICE_UNAVAILABLE
+    - SC_GATEWAY_TIMEOUT
   - name: non_idempotent
     retry_codes: []
   # Definition for retry/backoff parameters.
@@ -1165,6 +1326,17 @@ interfaces:
   #       message.
   #   required_fields - Fields that are always required for a request to be
   #       valid.
+  #   request_object_method - Turns on or off the generation of a method whose
+  #       sole parameter is a request object. Not all languages will generate
+  #       this method.
+  #   resource_name_treatment - An enum that specifies how to treat the
+  #       resource name formats defined in the field_name_patterns
+  #       and response_field_name_patterns fields.
+  #       UNSET: default value
+  #       NONE: the collection configs will not be used by the generated code.
+  #       VALIDATE: string fields will be validated by the client against the
+  #           specified resource name formats.
+  #       STATIC_TYPES: the client will use generated types for resource names.
   #   page_streaming - Specifies the configuration for paging.
   #       Describes information for generating a method which transforms a
   #       paging list RPC into a stream of resources.
@@ -1202,13 +1374,15 @@ interfaces:
     # TODO: Configure which fields are required.
     required_fields:
     - project
+    request_object_method: true
+    resource_name_treatment: STATIC_TYPES
     page_streaming:
       request:
         page_size_field: maxResults
         token_field: pageToken
       response:
         token_field: nextPageToken
-        resources_field: items
+        resources_field: DiskTypeAggregatedList
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: idempotent
     # TODO: Configure the retryable params for this method.
@@ -1227,12 +1401,14 @@ interfaces:
     # TODO: Configure which fields are required.
     required_fields:
     - diskType
+    request_object_method: true
+    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      diskType: projectZoneDiskType
+      diskType: diskType
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
   - name: compute.diskTypes.list
@@ -1245,22 +1421,24 @@ interfaces:
     # TODO: Configure which fields are required.
     required_fields:
     - zone
+    request_object_method: true
+    resource_name_treatment: STATIC_TYPES
     page_streaming:
       request:
         page_size_field: maxResults
         token_field: pageToken
       response:
         token_field: nextPageToken
-        resources_field: items
+        resources_field: DiskTypeList
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      zone: projectZone
+      zone: zone
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
-# The fully qualified name of the API interface.
+  # The fully qualified name of the API interface.
 - name: google.compute.v1.Disks
   # A list of resource collection configurations.
   # Consists of a name_pattern and an entity_name.
@@ -1273,20 +1451,20 @@ interfaces:
   # The entity_name is the name to be used as a basis for generated methods and
   # classes.
   collections:
-  - name_pattern: '{project}'
+  - name_pattern: projects/{project}
     entity_name: project
-  - name_pattern: '{project}/zones/{zone}'
-    entity_name: projectZone
-  - name_pattern: '{project}/zones/{zone}/disks/{disk}'
-    entity_name: projectZoneDisk
-  - name_pattern: '{project}/zones/{zone}/disks/{resource}'
-    entity_name: projectZoneDiskResource
+  - name_pattern: projects/{project}/zones/{zone}
+    entity_name: zone
+  - name_pattern: projects/{project}/zones/{zone}/disks/{disk}
+    entity_name: disk
+  - name_pattern: projects/{project}/zones/{zone}/disks/{resource}
+    entity_name: disksResource
   # Definition for retryable codes.
   retry_codes_def:
   - name: idempotent
     retry_codes:
-    - UNAVAILABLE
-    - DEADLINE_EXCEEDED
+    - SC_SERVICE_UNAVAILABLE
+    - SC_GATEWAY_TIMEOUT
   - name: non_idempotent
     retry_codes: []
   # Definition for retry/backoff parameters.
@@ -1312,6 +1490,17 @@ interfaces:
   #       message.
   #   required_fields - Fields that are always required for a request to be
   #       valid.
+  #   request_object_method - Turns on or off the generation of a method whose
+  #       sole parameter is a request object. Not all languages will generate
+  #       this method.
+  #   resource_name_treatment - An enum that specifies how to treat the
+  #       resource name formats defined in the field_name_patterns
+  #       and response_field_name_patterns fields.
+  #       UNSET: default value
+  #       NONE: the collection configs will not be used by the generated code.
+  #       VALIDATE: string fields will be validated by the client against the
+  #           specified resource name formats.
+  #       STATIC_TYPES: the client will use generated types for resource names.
   #   page_streaming - Specifies the configuration for paging.
   #       Describes information for generating a method which transforms a
   #       paging list RPC into a stream of resources.
@@ -1339,6 +1528,30 @@ interfaces:
   #   timeout_millis - Specifies the default timeout for a non-retrying call. If
   #       the call is retrying, refer to retry_params_name instead.
   methods:
+  - name: compute.disks.addResourcePolicies
+    # TODO: Configure which groups of fields should be flattened into method
+    # params.
+    flattening:
+      groups:
+      - parameters:
+        - disk
+        - requestId
+        - disksAddResourcePoliciesRequestResource
+    # TODO: Configure which fields are required.
+    required_fields:
+    - disk
+    - requestId
+    - disksAddResourcePoliciesRequestResource
+    request_object_method: true
+    resource_name_treatment: STATIC_TYPES
+    # TODO: Configure the retryable codes for this method.
+    retry_codes_name: non_idempotent
+    # TODO: Configure the retryable params for this method.
+    retry_params_name: default
+    field_name_patterns:
+      disk: disk
+    # TODO: Configure the default timeout for a non-retrying call.
+    timeout_millis: 60000
   - name: compute.disks.aggregatedList
     # TODO: Configure which groups of fields should be flattened into method
     # params.
@@ -1349,13 +1562,15 @@ interfaces:
     # TODO: Configure which fields are required.
     required_fields:
     - project
+    request_object_method: true
+    resource_name_treatment: STATIC_TYPES
     page_streaming:
       request:
         page_size_field: maxResults
         token_field: pageToken
       response:
         token_field: nextPageToken
-        resources_field: items
+        resources_field: DiskAggregatedList
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: idempotent
     # TODO: Configure the retryable params for this method.
@@ -1371,19 +1586,23 @@ interfaces:
       groups:
       - parameters:
         - disk
+        - requestId
         - guestFlush
         - snapshotResource
     # TODO: Configure which fields are required.
     required_fields:
     - disk
+    - requestId
     - guestFlush
     - snapshotResource
+    request_object_method: true
+    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: non_idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      disk: projectZoneDisk
+      disk: disk
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
   - name: compute.disks.delete
@@ -1393,15 +1612,19 @@ interfaces:
       groups:
       - parameters:
         - disk
+        - requestId
     # TODO: Configure which fields are required.
     required_fields:
     - disk
+    - requestId
+    request_object_method: true
+    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      disk: projectZoneDisk
+      disk: disk
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
   - name: compute.disks.get
@@ -1414,12 +1637,14 @@ interfaces:
     # TODO: Configure which fields are required.
     required_fields:
     - disk
+    request_object_method: true
+    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      disk: projectZoneDisk
+      disk: disk
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
   - name: compute.disks.getIamPolicy
@@ -1432,12 +1657,14 @@ interfaces:
     # TODO: Configure which fields are required.
     required_fields:
     - resource
+    request_object_method: true
+    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      resource: projectZoneDiskResource
+      resource: disksResource
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
   - name: compute.disks.insert
@@ -1447,17 +1674,23 @@ interfaces:
       groups:
       - parameters:
         - zone
+        - requestId
+        - sourceImage
         - diskResource
     # TODO: Configure which fields are required.
     required_fields:
     - zone
+    - requestId
+    - sourceImage
     - diskResource
+    request_object_method: true
+    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: non_idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      zone: projectZone
+      zone: zone
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
   - name: compute.disks.list
@@ -1470,19 +1703,45 @@ interfaces:
     # TODO: Configure which fields are required.
     required_fields:
     - zone
+    request_object_method: true
+    resource_name_treatment: STATIC_TYPES
     page_streaming:
       request:
         page_size_field: maxResults
         token_field: pageToken
       response:
         token_field: nextPageToken
-        resources_field: items
+        resources_field: DiskList
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      zone: projectZone
+      zone: zone
+    # TODO: Configure the default timeout for a non-retrying call.
+    timeout_millis: 60000
+  - name: compute.disks.removeResourcePolicies
+    # TODO: Configure which groups of fields should be flattened into method
+    # params.
+    flattening:
+      groups:
+      - parameters:
+        - disk
+        - requestId
+        - disksRemoveResourcePoliciesRequestResource
+    # TODO: Configure which fields are required.
+    required_fields:
+    - disk
+    - requestId
+    - disksRemoveResourcePoliciesRequestResource
+    request_object_method: true
+    resource_name_treatment: STATIC_TYPES
+    # TODO: Configure the retryable codes for this method.
+    retry_codes_name: non_idempotent
+    # TODO: Configure the retryable params for this method.
+    retry_params_name: default
+    field_name_patterns:
+      disk: disk
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
   - name: compute.disks.resize
@@ -1492,17 +1751,21 @@ interfaces:
       groups:
       - parameters:
         - disk
+        - requestId
         - disksResizeRequestResource
     # TODO: Configure which fields are required.
     required_fields:
     - disk
+    - requestId
     - disksResizeRequestResource
+    request_object_method: true
+    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: non_idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      disk: projectZoneDisk
+      disk: disk
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
   - name: compute.disks.setIamPolicy
@@ -1517,12 +1780,14 @@ interfaces:
     required_fields:
     - resource
     - zoneSetPolicyRequestResource
+    request_object_method: true
+    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: non_idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      resource: projectZoneDiskResource
+      resource: disksResource
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
   - name: compute.disks.setLabels
@@ -1532,17 +1797,21 @@ interfaces:
       groups:
       - parameters:
         - resource
+        - requestId
         - zoneSetLabelsRequestResource
     # TODO: Configure which fields are required.
     required_fields:
     - resource
+    - requestId
     - zoneSetLabelsRequestResource
+    request_object_method: true
+    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: non_idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      resource: projectZoneDiskResource
+      resource: disksResource
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
   - name: compute.disks.testIamPermissions
@@ -1557,15 +1826,17 @@ interfaces:
     required_fields:
     - resource
     - testPermissionsRequestResource
+    request_object_method: true
+    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: non_idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      resource: projectZoneDiskResource
+      resource: disksResource
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
-# The fully qualified name of the API interface.
+  # The fully qualified name of the API interface.
 - name: google.compute.v1.Firewalls
   # A list of resource collection configurations.
   # Consists of a name_pattern and an entity_name.
@@ -1578,16 +1849,16 @@ interfaces:
   # The entity_name is the name to be used as a basis for generated methods and
   # classes.
   collections:
-  - name_pattern: '{project}'
+  - name_pattern: projects/{project}
     entity_name: project
-  - name_pattern: '{project}/global/firewalls/{firewall}'
-    entity_name: projectGlobalFirewall
+  - name_pattern: projects/{project}/firewalls/{firewall}
+    entity_name: firewall
   # Definition for retryable codes.
   retry_codes_def:
   - name: idempotent
     retry_codes:
-    - UNAVAILABLE
-    - DEADLINE_EXCEEDED
+    - SC_SERVICE_UNAVAILABLE
+    - SC_GATEWAY_TIMEOUT
   - name: non_idempotent
     retry_codes: []
   # Definition for retry/backoff parameters.
@@ -1613,6 +1884,17 @@ interfaces:
   #       message.
   #   required_fields - Fields that are always required for a request to be
   #       valid.
+  #   request_object_method - Turns on or off the generation of a method whose
+  #       sole parameter is a request object. Not all languages will generate
+  #       this method.
+  #   resource_name_treatment - An enum that specifies how to treat the
+  #       resource name formats defined in the field_name_patterns
+  #       and response_field_name_patterns fields.
+  #       UNSET: default value
+  #       NONE: the collection configs will not be used by the generated code.
+  #       VALIDATE: string fields will be validated by the client against the
+  #           specified resource name formats.
+  #       STATIC_TYPES: the client will use generated types for resource names.
   #   page_streaming - Specifies the configuration for paging.
   #       Describes information for generating a method which transforms a
   #       paging list RPC into a stream of resources.
@@ -1647,15 +1929,19 @@ interfaces:
       groups:
       - parameters:
         - firewall
+        - requestId
     # TODO: Configure which fields are required.
     required_fields:
     - firewall
+    - requestId
+    request_object_method: true
+    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      firewall: projectGlobalFirewall
+      firewall: firewall
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
   - name: compute.firewalls.get
@@ -1668,12 +1954,14 @@ interfaces:
     # TODO: Configure which fields are required.
     required_fields:
     - firewall
+    request_object_method: true
+    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      firewall: projectGlobalFirewall
+      firewall: firewall
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
   - name: compute.firewalls.insert
@@ -1682,12 +1970,16 @@ interfaces:
     flattening:
       groups:
       - parameters:
+        - requestId
         - project
         - firewallResource
     # TODO: Configure which fields are required.
     required_fields:
+    - requestId
     - project
     - firewallResource
+    request_object_method: true
+    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: non_idempotent
     # TODO: Configure the retryable params for this method.
@@ -1706,13 +1998,15 @@ interfaces:
     # TODO: Configure which fields are required.
     required_fields:
     - project
+    request_object_method: true
+    resource_name_treatment: STATIC_TYPES
     page_streaming:
       request:
         page_size_field: maxResults
         token_field: pageToken
       response:
         token_field: nextPageToken
-        resources_field: items
+        resources_field: FirewallList
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: idempotent
     # TODO: Configure the retryable params for this method.
@@ -1728,17 +2022,21 @@ interfaces:
       groups:
       - parameters:
         - firewall
+        - requestId
         - firewallResource
     # TODO: Configure which fields are required.
     required_fields:
     - firewall
+    - requestId
     - firewallResource
+    request_object_method: true
+    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: non_idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      firewall: projectGlobalFirewall
+      firewall: firewall
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
   - name: compute.firewalls.update
@@ -1748,20 +2046,24 @@ interfaces:
       groups:
       - parameters:
         - firewall
+        - requestId
         - firewallResource
     # TODO: Configure which fields are required.
     required_fields:
     - firewall
+    - requestId
     - firewallResource
+    request_object_method: true
+    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      firewall: projectGlobalFirewall
+      firewall: firewall
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
-# The fully qualified name of the API interface.
+  # The fully qualified name of the API interface.
 - name: google.compute.v1.ForwardingRules
   # A list of resource collection configurations.
   # Consists of a name_pattern and an entity_name.
@@ -1774,18 +2076,18 @@ interfaces:
   # The entity_name is the name to be used as a basis for generated methods and
   # classes.
   collections:
-  - name_pattern: '{project}'
+  - name_pattern: projects/{project}
     entity_name: project
-  - name_pattern: '{project}/regions/{region}'
-    entity_name: projectRegion
-  - name_pattern: '{project}/regions/{region}/forwardingRules/{forwardingRule}'
-    entity_name: projectRegionForwardingRule
+  - name_pattern: projects/{project}/regions/{region}
+    entity_name: region
+  - name_pattern: projects/{project}/regions/{region}/forwardingRules/{forwardingRule}
+    entity_name: forwardingRule
   # Definition for retryable codes.
   retry_codes_def:
   - name: idempotent
     retry_codes:
-    - UNAVAILABLE
-    - DEADLINE_EXCEEDED
+    - SC_SERVICE_UNAVAILABLE
+    - SC_GATEWAY_TIMEOUT
   - name: non_idempotent
     retry_codes: []
   # Definition for retry/backoff parameters.
@@ -1811,6 +2113,17 @@ interfaces:
   #       message.
   #   required_fields - Fields that are always required for a request to be
   #       valid.
+  #   request_object_method - Turns on or off the generation of a method whose
+  #       sole parameter is a request object. Not all languages will generate
+  #       this method.
+  #   resource_name_treatment - An enum that specifies how to treat the
+  #       resource name formats defined in the field_name_patterns
+  #       and response_field_name_patterns fields.
+  #       UNSET: default value
+  #       NONE: the collection configs will not be used by the generated code.
+  #       VALIDATE: string fields will be validated by the client against the
+  #           specified resource name formats.
+  #       STATIC_TYPES: the client will use generated types for resource names.
   #   page_streaming - Specifies the configuration for paging.
   #       Describes information for generating a method which transforms a
   #       paging list RPC into a stream of resources.
@@ -1848,13 +2161,15 @@ interfaces:
     # TODO: Configure which fields are required.
     required_fields:
     - project
+    request_object_method: true
+    resource_name_treatment: STATIC_TYPES
     page_streaming:
       request:
         page_size_field: maxResults
         token_field: pageToken
       response:
         token_field: nextPageToken
-        resources_field: items
+        resources_field: ForwardingRuleAggregatedList
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: idempotent
     # TODO: Configure the retryable params for this method.
@@ -1869,16 +2184,20 @@ interfaces:
     flattening:
       groups:
       - parameters:
+        - requestId
         - forwardingRule
     # TODO: Configure which fields are required.
     required_fields:
+    - requestId
     - forwardingRule
+    request_object_method: true
+    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      forwardingRule: projectRegionForwardingRule
+      forwardingRule: forwardingRule
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
   - name: compute.forwardingRules.get
@@ -1891,12 +2210,14 @@ interfaces:
     # TODO: Configure which fields are required.
     required_fields:
     - forwardingRule
+    request_object_method: true
+    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      forwardingRule: projectRegionForwardingRule
+      forwardingRule: forwardingRule
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
   - name: compute.forwardingRules.insert
@@ -1905,18 +2226,22 @@ interfaces:
     flattening:
       groups:
       - parameters:
+        - requestId
         - region
         - forwardingRuleResource
     # TODO: Configure which fields are required.
     required_fields:
+    - requestId
     - region
     - forwardingRuleResource
+    request_object_method: true
+    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: non_idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      region: projectRegion
+      region: region
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
   - name: compute.forwardingRules.list
@@ -1929,19 +2254,21 @@ interfaces:
     # TODO: Configure which fields are required.
     required_fields:
     - region
+    request_object_method: true
+    resource_name_treatment: STATIC_TYPES
     page_streaming:
       request:
         page_size_field: maxResults
         token_field: pageToken
       response:
         token_field: nextPageToken
-        resources_field: items
+        resources_field: ForwardingRuleList
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      region: projectRegion
+      region: region
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
   - name: compute.forwardingRules.setTarget
@@ -1950,21 +2277,25 @@ interfaces:
     flattening:
       groups:
       - parameters:
+        - requestId
         - forwardingRule
         - targetReferenceResource
     # TODO: Configure which fields are required.
     required_fields:
+    - requestId
     - forwardingRule
     - targetReferenceResource
+    request_object_method: true
+    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: non_idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      forwardingRule: projectRegionForwardingRule
+      forwardingRule: forwardingRule
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
-# The fully qualified name of the API interface.
+  # The fully qualified name of the API interface.
 - name: google.compute.v1.GlobalAddresses
   # A list of resource collection configurations.
   # Consists of a name_pattern and an entity_name.
@@ -1977,16 +2308,16 @@ interfaces:
   # The entity_name is the name to be used as a basis for generated methods and
   # classes.
   collections:
-  - name_pattern: '{project}'
+  - name_pattern: projects/{project}
     entity_name: project
-  - name_pattern: '{project}/global/addresses/{address}'
-    entity_name: projectGlobalAddress
+  - name_pattern: projects/{project}/addresses/{address}
+    entity_name: globalAddressesAddress
   # Definition for retryable codes.
   retry_codes_def:
   - name: idempotent
     retry_codes:
-    - UNAVAILABLE
-    - DEADLINE_EXCEEDED
+    - SC_SERVICE_UNAVAILABLE
+    - SC_GATEWAY_TIMEOUT
   - name: non_idempotent
     retry_codes: []
   # Definition for retry/backoff parameters.
@@ -2012,6 +2343,17 @@ interfaces:
   #       message.
   #   required_fields - Fields that are always required for a request to be
   #       valid.
+  #   request_object_method - Turns on or off the generation of a method whose
+  #       sole parameter is a request object. Not all languages will generate
+  #       this method.
+  #   resource_name_treatment - An enum that specifies how to treat the
+  #       resource name formats defined in the field_name_patterns
+  #       and response_field_name_patterns fields.
+  #       UNSET: default value
+  #       NONE: the collection configs will not be used by the generated code.
+  #       VALIDATE: string fields will be validated by the client against the
+  #           specified resource name formats.
+  #       STATIC_TYPES: the client will use generated types for resource names.
   #   page_streaming - Specifies the configuration for paging.
   #       Describes information for generating a method which transforms a
   #       paging list RPC into a stream of resources.
@@ -2046,15 +2388,19 @@ interfaces:
       groups:
       - parameters:
         - address
+        - requestId
     # TODO: Configure which fields are required.
     required_fields:
     - address
+    - requestId
+    request_object_method: true
+    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      address: projectGlobalAddress
+      address: globalAddressesAddress
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
   - name: compute.globalAddresses.get
@@ -2067,12 +2413,14 @@ interfaces:
     # TODO: Configure which fields are required.
     required_fields:
     - address
+    request_object_method: true
+    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      address: projectGlobalAddress
+      address: globalAddressesAddress
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
   - name: compute.globalAddresses.insert
@@ -2081,12 +2429,16 @@ interfaces:
     flattening:
       groups:
       - parameters:
+        - requestId
         - project
         - addressResource
     # TODO: Configure which fields are required.
     required_fields:
+    - requestId
     - project
     - addressResource
+    request_object_method: true
+    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: non_idempotent
     # TODO: Configure the retryable params for this method.
@@ -2105,13 +2457,15 @@ interfaces:
     # TODO: Configure which fields are required.
     required_fields:
     - project
+    request_object_method: true
+    resource_name_treatment: STATIC_TYPES
     page_streaming:
       request:
         page_size_field: maxResults
         token_field: pageToken
       response:
         token_field: nextPageToken
-        resources_field: items
+        resources_field: AddressList
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: idempotent
     # TODO: Configure the retryable params for this method.
@@ -2120,7 +2474,7 @@ interfaces:
       project: project
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
-# The fully qualified name of the API interface.
+  # The fully qualified name of the API interface.
 - name: google.compute.v1.GlobalForwardingRules
   # A list of resource collection configurations.
   # Consists of a name_pattern and an entity_name.
@@ -2133,16 +2487,16 @@ interfaces:
   # The entity_name is the name to be used as a basis for generated methods and
   # classes.
   collections:
-  - name_pattern: '{project}'
+  - name_pattern: projects/{project}
     entity_name: project
-  - name_pattern: '{project}/global/forwardingRules/{forwardingRule}'
-    entity_name: projectGlobalForwardingRule
+  - name_pattern: projects/{project}/forwardingRules/{forwardingRule}
+    entity_name: globalForwardingRulesForwardingRule
   # Definition for retryable codes.
   retry_codes_def:
   - name: idempotent
     retry_codes:
-    - UNAVAILABLE
-    - DEADLINE_EXCEEDED
+    - SC_SERVICE_UNAVAILABLE
+    - SC_GATEWAY_TIMEOUT
   - name: non_idempotent
     retry_codes: []
   # Definition for retry/backoff parameters.
@@ -2168,6 +2522,17 @@ interfaces:
   #       message.
   #   required_fields - Fields that are always required for a request to be
   #       valid.
+  #   request_object_method - Turns on or off the generation of a method whose
+  #       sole parameter is a request object. Not all languages will generate
+  #       this method.
+  #   resource_name_treatment - An enum that specifies how to treat the
+  #       resource name formats defined in the field_name_patterns
+  #       and response_field_name_patterns fields.
+  #       UNSET: default value
+  #       NONE: the collection configs will not be used by the generated code.
+  #       VALIDATE: string fields will be validated by the client against the
+  #           specified resource name formats.
+  #       STATIC_TYPES: the client will use generated types for resource names.
   #   page_streaming - Specifies the configuration for paging.
   #       Describes information for generating a method which transforms a
   #       paging list RPC into a stream of resources.
@@ -2201,16 +2566,20 @@ interfaces:
     flattening:
       groups:
       - parameters:
+        - requestId
         - forwardingRule
     # TODO: Configure which fields are required.
     required_fields:
+    - requestId
     - forwardingRule
+    request_object_method: true
+    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      forwardingRule: projectGlobalForwardingRule
+      forwardingRule: globalForwardingRulesForwardingRule
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
   - name: compute.globalForwardingRules.get
@@ -2223,12 +2592,14 @@ interfaces:
     # TODO: Configure which fields are required.
     required_fields:
     - forwardingRule
+    request_object_method: true
+    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      forwardingRule: projectGlobalForwardingRule
+      forwardingRule: globalForwardingRulesForwardingRule
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
   - name: compute.globalForwardingRules.insert
@@ -2237,12 +2608,16 @@ interfaces:
     flattening:
       groups:
       - parameters:
+        - requestId
         - project
         - forwardingRuleResource
     # TODO: Configure which fields are required.
     required_fields:
+    - requestId
     - project
     - forwardingRuleResource
+    request_object_method: true
+    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: non_idempotent
     # TODO: Configure the retryable params for this method.
@@ -2261,13 +2636,15 @@ interfaces:
     # TODO: Configure which fields are required.
     required_fields:
     - project
+    request_object_method: true
+    resource_name_treatment: STATIC_TYPES
     page_streaming:
       request:
         page_size_field: maxResults
         token_field: pageToken
       response:
         token_field: nextPageToken
-        resources_field: items
+        resources_field: ForwardingRuleList
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: idempotent
     # TODO: Configure the retryable params for this method.
@@ -2282,21 +2659,25 @@ interfaces:
     flattening:
       groups:
       - parameters:
+        - requestId
         - forwardingRule
         - targetReferenceResource
     # TODO: Configure which fields are required.
     required_fields:
+    - requestId
     - forwardingRule
     - targetReferenceResource
+    request_object_method: true
+    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: non_idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      forwardingRule: projectGlobalForwardingRule
+      forwardingRule: globalForwardingRulesForwardingRule
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
-# The fully qualified name of the API interface.
+  # The fully qualified name of the API interface.
 - name: google.compute.v1.GlobalOperations
   # A list of resource collection configurations.
   # Consists of a name_pattern and an entity_name.
@@ -2309,16 +2690,16 @@ interfaces:
   # The entity_name is the name to be used as a basis for generated methods and
   # classes.
   collections:
-  - name_pattern: '{project}'
+  - name_pattern: projects/{project}
     entity_name: project
-  - name_pattern: '{project}/global/operations/{operation}'
-    entity_name: projectGlobalOperation
+  - name_pattern: projects/{project}/operations/{operation}
+    entity_name: globalOperationsOperation
   # Definition for retryable codes.
   retry_codes_def:
   - name: idempotent
     retry_codes:
-    - UNAVAILABLE
-    - DEADLINE_EXCEEDED
+    - SC_SERVICE_UNAVAILABLE
+    - SC_GATEWAY_TIMEOUT
   - name: non_idempotent
     retry_codes: []
   # Definition for retry/backoff parameters.
@@ -2344,6 +2725,17 @@ interfaces:
   #       message.
   #   required_fields - Fields that are always required for a request to be
   #       valid.
+  #   request_object_method - Turns on or off the generation of a method whose
+  #       sole parameter is a request object. Not all languages will generate
+  #       this method.
+  #   resource_name_treatment - An enum that specifies how to treat the
+  #       resource name formats defined in the field_name_patterns
+  #       and response_field_name_patterns fields.
+  #       UNSET: default value
+  #       NONE: the collection configs will not be used by the generated code.
+  #       VALIDATE: string fields will be validated by the client against the
+  #           specified resource name formats.
+  #       STATIC_TYPES: the client will use generated types for resource names.
   #   page_streaming - Specifies the configuration for paging.
   #       Describes information for generating a method which transforms a
   #       paging list RPC into a stream of resources.
@@ -2381,13 +2773,15 @@ interfaces:
     # TODO: Configure which fields are required.
     required_fields:
     - project
+    request_object_method: true
+    resource_name_treatment: STATIC_TYPES
     page_streaming:
       request:
         page_size_field: maxResults
         token_field: pageToken
       response:
         token_field: nextPageToken
-        resources_field: items
+        resources_field: OperationAggregatedList
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: idempotent
     # TODO: Configure the retryable params for this method.
@@ -2406,12 +2800,14 @@ interfaces:
     # TODO: Configure which fields are required.
     required_fields:
     - operation
+    request_object_method: true
+    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      operation: projectGlobalOperation
+      operation: globalOperationsOperation
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
   - name: compute.globalOperations.get
@@ -2424,12 +2820,14 @@ interfaces:
     # TODO: Configure which fields are required.
     required_fields:
     - operation
+    request_object_method: true
+    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      operation: projectGlobalOperation
+      operation: globalOperationsOperation
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
   - name: compute.globalOperations.list
@@ -2442,13 +2840,15 @@ interfaces:
     # TODO: Configure which fields are required.
     required_fields:
     - project
+    request_object_method: true
+    resource_name_treatment: STATIC_TYPES
     page_streaming:
       request:
         page_size_field: maxResults
         token_field: pageToken
       response:
         token_field: nextPageToken
-        resources_field: items
+        resources_field: OperationList
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: idempotent
     # TODO: Configure the retryable params for this method.
@@ -2457,7 +2857,7 @@ interfaces:
       project: project
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
-# The fully qualified name of the API interface.
+  # The fully qualified name of the API interface.
 - name: google.compute.v1.HealthChecks
   # A list of resource collection configurations.
   # Consists of a name_pattern and an entity_name.
@@ -2470,16 +2870,16 @@ interfaces:
   # The entity_name is the name to be used as a basis for generated methods and
   # classes.
   collections:
-  - name_pattern: '{project}'
+  - name_pattern: projects/{project}
     entity_name: project
-  - name_pattern: '{project}/global/healthChecks/{healthCheck}'
-    entity_name: projectGlobalHealthCheck
+  - name_pattern: projects/{project}/healthChecks/{healthCheck}
+    entity_name: healthCheck
   # Definition for retryable codes.
   retry_codes_def:
   - name: idempotent
     retry_codes:
-    - UNAVAILABLE
-    - DEADLINE_EXCEEDED
+    - SC_SERVICE_UNAVAILABLE
+    - SC_GATEWAY_TIMEOUT
   - name: non_idempotent
     retry_codes: []
   # Definition for retry/backoff parameters.
@@ -2505,6 +2905,17 @@ interfaces:
   #       message.
   #   required_fields - Fields that are always required for a request to be
   #       valid.
+  #   request_object_method - Turns on or off the generation of a method whose
+  #       sole parameter is a request object. Not all languages will generate
+  #       this method.
+  #   resource_name_treatment - An enum that specifies how to treat the
+  #       resource name formats defined in the field_name_patterns
+  #       and response_field_name_patterns fields.
+  #       UNSET: default value
+  #       NONE: the collection configs will not be used by the generated code.
+  #       VALIDATE: string fields will be validated by the client against the
+  #           specified resource name formats.
+  #       STATIC_TYPES: the client will use generated types for resource names.
   #   page_streaming - Specifies the configuration for paging.
   #       Describes information for generating a method which transforms a
   #       paging list RPC into a stream of resources.
@@ -2538,16 +2949,20 @@ interfaces:
     flattening:
       groups:
       - parameters:
+        - requestId
         - healthCheck
     # TODO: Configure which fields are required.
     required_fields:
+    - requestId
     - healthCheck
+    request_object_method: true
+    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      healthCheck: projectGlobalHealthCheck
+      healthCheck: healthCheck
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
   - name: compute.healthChecks.get
@@ -2560,12 +2975,14 @@ interfaces:
     # TODO: Configure which fields are required.
     required_fields:
     - healthCheck
+    request_object_method: true
+    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      healthCheck: projectGlobalHealthCheck
+      healthCheck: healthCheck
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
   - name: compute.healthChecks.insert
@@ -2574,12 +2991,16 @@ interfaces:
     flattening:
       groups:
       - parameters:
+        - requestId
         - project
         - healthCheckResource
     # TODO: Configure which fields are required.
     required_fields:
+    - requestId
     - project
     - healthCheckResource
+    request_object_method: true
+    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: non_idempotent
     # TODO: Configure the retryable params for this method.
@@ -2598,13 +3019,15 @@ interfaces:
     # TODO: Configure which fields are required.
     required_fields:
     - project
+    request_object_method: true
+    resource_name_treatment: STATIC_TYPES
     page_streaming:
       request:
         page_size_field: maxResults
         token_field: pageToken
       response:
         token_field: nextPageToken
-        resources_field: items
+        resources_field: HealthCheckList
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: idempotent
     # TODO: Configure the retryable params for this method.
@@ -2619,18 +3042,22 @@ interfaces:
     flattening:
       groups:
       - parameters:
+        - requestId
         - healthCheck
         - healthCheckResource
     # TODO: Configure which fields are required.
     required_fields:
+    - requestId
     - healthCheck
     - healthCheckResource
+    request_object_method: true
+    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: non_idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      healthCheck: projectGlobalHealthCheck
+      healthCheck: healthCheck
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
   - name: compute.healthChecks.update
@@ -2639,21 +3066,25 @@ interfaces:
     flattening:
       groups:
       - parameters:
+        - requestId
         - healthCheck
         - healthCheckResource
     # TODO: Configure which fields are required.
     required_fields:
+    - requestId
     - healthCheck
     - healthCheckResource
+    request_object_method: true
+    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      healthCheck: projectGlobalHealthCheck
+      healthCheck: healthCheck
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
-# The fully qualified name of the API interface.
+  # The fully qualified name of the API interface.
 - name: google.compute.v1.HttpHealthChecks
   # A list of resource collection configurations.
   # Consists of a name_pattern and an entity_name.
@@ -2666,16 +3097,16 @@ interfaces:
   # The entity_name is the name to be used as a basis for generated methods and
   # classes.
   collections:
-  - name_pattern: '{project}'
+  - name_pattern: projects/{project}
     entity_name: project
-  - name_pattern: '{project}/global/httpHealthChecks/{httpHealthCheck}'
-    entity_name: projectGlobalHttpHealthCheck
+  - name_pattern: projects/{project}/httpHealthChecks/{httpHealthCheck}
+    entity_name: httpHealthCheck
   # Definition for retryable codes.
   retry_codes_def:
   - name: idempotent
     retry_codes:
-    - UNAVAILABLE
-    - DEADLINE_EXCEEDED
+    - SC_SERVICE_UNAVAILABLE
+    - SC_GATEWAY_TIMEOUT
   - name: non_idempotent
     retry_codes: []
   # Definition for retry/backoff parameters.
@@ -2701,6 +3132,17 @@ interfaces:
   #       message.
   #   required_fields - Fields that are always required for a request to be
   #       valid.
+  #   request_object_method - Turns on or off the generation of a method whose
+  #       sole parameter is a request object. Not all languages will generate
+  #       this method.
+  #   resource_name_treatment - An enum that specifies how to treat the
+  #       resource name formats defined in the field_name_patterns
+  #       and response_field_name_patterns fields.
+  #       UNSET: default value
+  #       NONE: the collection configs will not be used by the generated code.
+  #       VALIDATE: string fields will be validated by the client against the
+  #           specified resource name formats.
+  #       STATIC_TYPES: the client will use generated types for resource names.
   #   page_streaming - Specifies the configuration for paging.
   #       Describes information for generating a method which transforms a
   #       paging list RPC into a stream of resources.
@@ -2734,16 +3176,20 @@ interfaces:
     flattening:
       groups:
       - parameters:
+        - requestId
         - httpHealthCheck
     # TODO: Configure which fields are required.
     required_fields:
+    - requestId
     - httpHealthCheck
+    request_object_method: true
+    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      httpHealthCheck: projectGlobalHttpHealthCheck
+      httpHealthCheck: httpHealthCheck
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
   - name: compute.httpHealthChecks.get
@@ -2756,12 +3202,14 @@ interfaces:
     # TODO: Configure which fields are required.
     required_fields:
     - httpHealthCheck
+    request_object_method: true
+    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      httpHealthCheck: projectGlobalHttpHealthCheck
+      httpHealthCheck: httpHealthCheck
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
   - name: compute.httpHealthChecks.insert
@@ -2770,12 +3218,16 @@ interfaces:
     flattening:
       groups:
       - parameters:
+        - requestId
         - project
         - httpHealthCheckResource
     # TODO: Configure which fields are required.
     required_fields:
+    - requestId
     - project
     - httpHealthCheckResource
+    request_object_method: true
+    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: non_idempotent
     # TODO: Configure the retryable params for this method.
@@ -2794,13 +3246,15 @@ interfaces:
     # TODO: Configure which fields are required.
     required_fields:
     - project
+    request_object_method: true
+    resource_name_treatment: STATIC_TYPES
     page_streaming:
       request:
         page_size_field: maxResults
         token_field: pageToken
       response:
         token_field: nextPageToken
-        resources_field: items
+        resources_field: HttpHealthCheckList
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: idempotent
     # TODO: Configure the retryable params for this method.
@@ -2815,18 +3269,22 @@ interfaces:
     flattening:
       groups:
       - parameters:
+        - requestId
         - httpHealthCheck
         - httpHealthCheckResource
     # TODO: Configure which fields are required.
     required_fields:
+    - requestId
     - httpHealthCheck
     - httpHealthCheckResource
+    request_object_method: true
+    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: non_idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      httpHealthCheck: projectGlobalHttpHealthCheck
+      httpHealthCheck: httpHealthCheck
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
   - name: compute.httpHealthChecks.update
@@ -2835,21 +3293,25 @@ interfaces:
     flattening:
       groups:
       - parameters:
+        - requestId
         - httpHealthCheck
         - httpHealthCheckResource
     # TODO: Configure which fields are required.
     required_fields:
+    - requestId
     - httpHealthCheck
     - httpHealthCheckResource
+    request_object_method: true
+    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      httpHealthCheck: projectGlobalHttpHealthCheck
+      httpHealthCheck: httpHealthCheck
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
-# The fully qualified name of the API interface.
+  # The fully qualified name of the API interface.
 - name: google.compute.v1.HttpsHealthChecks
   # A list of resource collection configurations.
   # Consists of a name_pattern and an entity_name.
@@ -2862,16 +3324,16 @@ interfaces:
   # The entity_name is the name to be used as a basis for generated methods and
   # classes.
   collections:
-  - name_pattern: '{project}'
+  - name_pattern: projects/{project}
     entity_name: project
-  - name_pattern: '{project}/global/httpsHealthChecks/{httpsHealthCheck}'
-    entity_name: projectGlobalHttpsHealthCheck
+  - name_pattern: projects/{project}/httpsHealthChecks/{httpsHealthCheck}
+    entity_name: httpsHealthCheck
   # Definition for retryable codes.
   retry_codes_def:
   - name: idempotent
     retry_codes:
-    - UNAVAILABLE
-    - DEADLINE_EXCEEDED
+    - SC_SERVICE_UNAVAILABLE
+    - SC_GATEWAY_TIMEOUT
   - name: non_idempotent
     retry_codes: []
   # Definition for retry/backoff parameters.
@@ -2897,6 +3359,17 @@ interfaces:
   #       message.
   #   required_fields - Fields that are always required for a request to be
   #       valid.
+  #   request_object_method - Turns on or off the generation of a method whose
+  #       sole parameter is a request object. Not all languages will generate
+  #       this method.
+  #   resource_name_treatment - An enum that specifies how to treat the
+  #       resource name formats defined in the field_name_patterns
+  #       and response_field_name_patterns fields.
+  #       UNSET: default value
+  #       NONE: the collection configs will not be used by the generated code.
+  #       VALIDATE: string fields will be validated by the client against the
+  #           specified resource name formats.
+  #       STATIC_TYPES: the client will use generated types for resource names.
   #   page_streaming - Specifies the configuration for paging.
   #       Describes information for generating a method which transforms a
   #       paging list RPC into a stream of resources.
@@ -2931,15 +3404,19 @@ interfaces:
       groups:
       - parameters:
         - httpsHealthCheck
+        - requestId
     # TODO: Configure which fields are required.
     required_fields:
     - httpsHealthCheck
+    - requestId
+    request_object_method: true
+    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      httpsHealthCheck: projectGlobalHttpsHealthCheck
+      httpsHealthCheck: httpsHealthCheck
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
   - name: compute.httpsHealthChecks.get
@@ -2952,12 +3429,14 @@ interfaces:
     # TODO: Configure which fields are required.
     required_fields:
     - httpsHealthCheck
+    request_object_method: true
+    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      httpsHealthCheck: projectGlobalHttpsHealthCheck
+      httpsHealthCheck: httpsHealthCheck
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
   - name: compute.httpsHealthChecks.insert
@@ -2966,12 +3445,16 @@ interfaces:
     flattening:
       groups:
       - parameters:
+        - requestId
         - project
         - httpsHealthCheckResource
     # TODO: Configure which fields are required.
     required_fields:
+    - requestId
     - project
     - httpsHealthCheckResource
+    request_object_method: true
+    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: non_idempotent
     # TODO: Configure the retryable params for this method.
@@ -2990,13 +3473,15 @@ interfaces:
     # TODO: Configure which fields are required.
     required_fields:
     - project
+    request_object_method: true
+    resource_name_treatment: STATIC_TYPES
     page_streaming:
       request:
         page_size_field: maxResults
         token_field: pageToken
       response:
         token_field: nextPageToken
-        resources_field: items
+        resources_field: HttpsHealthCheckList
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: idempotent
     # TODO: Configure the retryable params for this method.
@@ -3012,17 +3497,21 @@ interfaces:
       groups:
       - parameters:
         - httpsHealthCheck
+        - requestId
         - httpsHealthCheckResource
     # TODO: Configure which fields are required.
     required_fields:
     - httpsHealthCheck
+    - requestId
     - httpsHealthCheckResource
+    request_object_method: true
+    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: non_idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      httpsHealthCheck: projectGlobalHttpsHealthCheck
+      httpsHealthCheck: httpsHealthCheck
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
   - name: compute.httpsHealthChecks.update
@@ -3032,20 +3521,24 @@ interfaces:
       groups:
       - parameters:
         - httpsHealthCheck
+        - requestId
         - httpsHealthCheckResource
     # TODO: Configure which fields are required.
     required_fields:
     - httpsHealthCheck
+    - requestId
     - httpsHealthCheckResource
+    request_object_method: true
+    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      httpsHealthCheck: projectGlobalHttpsHealthCheck
+      httpsHealthCheck: httpsHealthCheck
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
-# The fully qualified name of the API interface.
+  # The fully qualified name of the API interface.
 - name: google.compute.v1.Images
   # A list of resource collection configurations.
   # Consists of a name_pattern and an entity_name.
@@ -3058,20 +3551,20 @@ interfaces:
   # The entity_name is the name to be used as a basis for generated methods and
   # classes.
   collections:
-  - name_pattern: '{project}'
+  - name_pattern: projects/{project}
     entity_name: project
-  - name_pattern: '{project}/global/images/family/{family}'
-    entity_name: projectGlobalImageFamily
-  - name_pattern: '{project}/global/images/{image}'
-    entity_name: projectGlobalImage
-  - name_pattern: '{project}/global/images/{resource}'
-    entity_name: projectGlobalImageResource
+  - name_pattern: projects/{project}/family/{family}
+    entity_name: family
+  - name_pattern: projects/{project}/images/{image}
+    entity_name: image
+  - name_pattern: projects/{project}/images/{resource}
+    entity_name: imagesResource
   # Definition for retryable codes.
   retry_codes_def:
   - name: idempotent
     retry_codes:
-    - UNAVAILABLE
-    - DEADLINE_EXCEEDED
+    - SC_SERVICE_UNAVAILABLE
+    - SC_GATEWAY_TIMEOUT
   - name: non_idempotent
     retry_codes: []
   # Definition for retry/backoff parameters.
@@ -3097,6 +3590,17 @@ interfaces:
   #       message.
   #   required_fields - Fields that are always required for a request to be
   #       valid.
+  #   request_object_method - Turns on or off the generation of a method whose
+  #       sole parameter is a request object. Not all languages will generate
+  #       this method.
+  #   resource_name_treatment - An enum that specifies how to treat the
+  #       resource name formats defined in the field_name_patterns
+  #       and response_field_name_patterns fields.
+  #       UNSET: default value
+  #       NONE: the collection configs will not be used by the generated code.
+  #       VALIDATE: string fields will be validated by the client against the
+  #           specified resource name formats.
+  #       STATIC_TYPES: the client will use generated types for resource names.
   #   page_streaming - Specifies the configuration for paging.
   #       Describes information for generating a method which transforms a
   #       paging list RPC into a stream of resources.
@@ -3131,15 +3635,19 @@ interfaces:
       groups:
       - parameters:
         - image
+        - requestId
     # TODO: Configure which fields are required.
     required_fields:
     - image
+    - requestId
+    request_object_method: true
+    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      image: projectGlobalImage
+      image: image
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
   - name: compute.images.deprecate
@@ -3149,17 +3657,21 @@ interfaces:
       groups:
       - parameters:
         - image
+        - requestId
         - deprecationStatusResource
     # TODO: Configure which fields are required.
     required_fields:
     - image
+    - requestId
     - deprecationStatusResource
+    request_object_method: true
+    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: non_idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      image: projectGlobalImage
+      image: image
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
   - name: compute.images.get
@@ -3172,12 +3684,14 @@ interfaces:
     # TODO: Configure which fields are required.
     required_fields:
     - image
+    request_object_method: true
+    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      image: projectGlobalImage
+      image: image
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
   - name: compute.images.getFromFamily
@@ -3190,12 +3704,14 @@ interfaces:
     # TODO: Configure which fields are required.
     required_fields:
     - family
+    request_object_method: true
+    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      family: projectGlobalImageFamily
+      family: family
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
   - name: compute.images.getIamPolicy
@@ -3208,12 +3724,14 @@ interfaces:
     # TODO: Configure which fields are required.
     required_fields:
     - resource
+    request_object_method: true
+    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      resource: projectGlobalImageResource
+      resource: imagesResource
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
   - name: compute.images.insert
@@ -3223,13 +3741,17 @@ interfaces:
       groups:
       - parameters:
         - forceCreate
+        - requestId
         - project
         - imageResource
     # TODO: Configure which fields are required.
     required_fields:
     - forceCreate
+    - requestId
     - project
     - imageResource
+    request_object_method: true
+    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: non_idempotent
     # TODO: Configure the retryable params for this method.
@@ -3248,13 +3770,15 @@ interfaces:
     # TODO: Configure which fields are required.
     required_fields:
     - project
+    request_object_method: true
+    resource_name_treatment: STATIC_TYPES
     page_streaming:
       request:
         page_size_field: maxResults
         token_field: pageToken
       response:
         token_field: nextPageToken
-        resources_field: items
+        resources_field: ImageList
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: idempotent
     # TODO: Configure the retryable params for this method.
@@ -3275,12 +3799,14 @@ interfaces:
     required_fields:
     - resource
     - globalSetPolicyRequestResource
+    request_object_method: true
+    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: non_idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      resource: projectGlobalImageResource
+      resource: imagesResource
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
   - name: compute.images.setLabels
@@ -3295,12 +3821,14 @@ interfaces:
     required_fields:
     - resource
     - globalSetLabelsRequestResource
+    request_object_method: true
+    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: non_idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      resource: projectGlobalImageResource
+      resource: imagesResource
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
   - name: compute.images.testIamPermissions
@@ -3315,15 +3843,17 @@ interfaces:
     required_fields:
     - resource
     - testPermissionsRequestResource
+    request_object_method: true
+    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: non_idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      resource: projectGlobalImageResource
+      resource: imagesResource
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
-# The fully qualified name of the API interface.
+  # The fully qualified name of the API interface.
 - name: google.compute.v1.InstanceGroupManagers
   # A list of resource collection configurations.
   # Consists of a name_pattern and an entity_name.
@@ -3336,18 +3866,18 @@ interfaces:
   # The entity_name is the name to be used as a basis for generated methods and
   # classes.
   collections:
-  - name_pattern: '{project}'
+  - name_pattern: projects/{project}
     entity_name: project
-  - name_pattern: '{project}/zones/{zone}'
-    entity_name: projectZone
-  - name_pattern: '{project}/zones/{zone}/instanceGroupManagers/{instanceGroupManager}'
-    entity_name: projectZoneInstanceGroupManager
+  - name_pattern: projects/{project}/zones/{zone}
+    entity_name: zone
+  - name_pattern: projects/{project}/zones/{zone}/instanceGroupManagers/{instanceGroupManager}
+    entity_name: instanceGroupManager
   # Definition for retryable codes.
   retry_codes_def:
   - name: idempotent
     retry_codes:
-    - UNAVAILABLE
-    - DEADLINE_EXCEEDED
+    - SC_SERVICE_UNAVAILABLE
+    - SC_GATEWAY_TIMEOUT
   - name: non_idempotent
     retry_codes: []
   # Definition for retry/backoff parameters.
@@ -3373,6 +3903,17 @@ interfaces:
   #       message.
   #   required_fields - Fields that are always required for a request to be
   #       valid.
+  #   request_object_method - Turns on or off the generation of a method whose
+  #       sole parameter is a request object. Not all languages will generate
+  #       this method.
+  #   resource_name_treatment - An enum that specifies how to treat the
+  #       resource name formats defined in the field_name_patterns
+  #       and response_field_name_patterns fields.
+  #       UNSET: default value
+  #       NONE: the collection configs will not be used by the generated code.
+  #       VALIDATE: string fields will be validated by the client against the
+  #           specified resource name formats.
+  #       STATIC_TYPES: the client will use generated types for resource names.
   #   page_streaming - Specifies the configuration for paging.
   #       Describes information for generating a method which transforms a
   #       paging list RPC into a stream of resources.
@@ -3406,18 +3947,22 @@ interfaces:
     flattening:
       groups:
       - parameters:
+        - requestId
         - instanceGroupManager
         - instanceGroupManagersAbandonInstancesRequestResource
     # TODO: Configure which fields are required.
     required_fields:
+    - requestId
     - instanceGroupManager
     - instanceGroupManagersAbandonInstancesRequestResource
+    request_object_method: true
+    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: non_idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      instanceGroupManager: projectZoneInstanceGroupManager
+      instanceGroupManager: instanceGroupManager
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
   - name: compute.instanceGroupManagers.aggregatedList
@@ -3430,13 +3975,15 @@ interfaces:
     # TODO: Configure which fields are required.
     required_fields:
     - project
+    request_object_method: true
+    resource_name_treatment: STATIC_TYPES
     page_streaming:
       request:
         page_size_field: maxResults
         token_field: pageToken
       response:
         token_field: nextPageToken
-        resources_field: items
+        resources_field: InstanceGroupManagerAggregatedList
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: idempotent
     # TODO: Configure the retryable params for this method.
@@ -3451,16 +3998,20 @@ interfaces:
     flattening:
       groups:
       - parameters:
+        - requestId
         - instanceGroupManager
     # TODO: Configure which fields are required.
     required_fields:
+    - requestId
     - instanceGroupManager
+    request_object_method: true
+    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      instanceGroupManager: projectZoneInstanceGroupManager
+      instanceGroupManager: instanceGroupManager
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
   - name: compute.instanceGroupManagers.deleteInstances
@@ -3469,18 +4020,22 @@ interfaces:
     flattening:
       groups:
       - parameters:
+        - requestId
         - instanceGroupManager
         - instanceGroupManagersDeleteInstancesRequestResource
     # TODO: Configure which fields are required.
     required_fields:
+    - requestId
     - instanceGroupManager
     - instanceGroupManagersDeleteInstancesRequestResource
+    request_object_method: true
+    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: non_idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      instanceGroupManager: projectZoneInstanceGroupManager
+      instanceGroupManager: instanceGroupManager
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
   - name: compute.instanceGroupManagers.get
@@ -3493,12 +4048,14 @@ interfaces:
     # TODO: Configure which fields are required.
     required_fields:
     - instanceGroupManager
+    request_object_method: true
+    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      instanceGroupManager: projectZoneInstanceGroupManager
+      instanceGroupManager: instanceGroupManager
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
   - name: compute.instanceGroupManagers.insert
@@ -3508,17 +4065,21 @@ interfaces:
       groups:
       - parameters:
         - zone
+        - requestId
         - instanceGroupManagerResource
     # TODO: Configure which fields are required.
     required_fields:
     - zone
+    - requestId
     - instanceGroupManagerResource
+    request_object_method: true
+    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: non_idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      zone: projectZone
+      zone: zone
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
   - name: compute.instanceGroupManagers.list
@@ -3531,19 +4092,21 @@ interfaces:
     # TODO: Configure which fields are required.
     required_fields:
     - zone
+    request_object_method: true
+    resource_name_treatment: STATIC_TYPES
     page_streaming:
       request:
         page_size_field: maxResults
         token_field: pageToken
       response:
         token_field: nextPageToken
-        resources_field: items
+        resources_field: InstanceGroupManagerList
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      zone: projectZone
+      zone: zone
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
   - name: compute.instanceGroupManagers.listManagedInstances
@@ -3556,12 +4119,14 @@ interfaces:
     # TODO: Configure which fields are required.
     required_fields:
     - instanceGroupManager
+    request_object_method: true
+    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: non_idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      instanceGroupManager: projectZoneInstanceGroupManager
+      instanceGroupManager: instanceGroupManager
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
   - name: compute.instanceGroupManagers.patch
@@ -3570,18 +4135,22 @@ interfaces:
     flattening:
       groups:
       - parameters:
+        - requestId
         - instanceGroupManager
         - instanceGroupManagerResource
     # TODO: Configure which fields are required.
     required_fields:
+    - requestId
     - instanceGroupManager
     - instanceGroupManagerResource
+    request_object_method: true
+    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: non_idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      instanceGroupManager: projectZoneInstanceGroupManager
+      instanceGroupManager: instanceGroupManager
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
   - name: compute.instanceGroupManagers.recreateInstances
@@ -3590,18 +4159,22 @@ interfaces:
     flattening:
       groups:
       - parameters:
+        - requestId
         - instanceGroupManager
         - instanceGroupManagersRecreateInstancesRequestResource
     # TODO: Configure which fields are required.
     required_fields:
+    - requestId
     - instanceGroupManager
     - instanceGroupManagersRecreateInstancesRequestResource
+    request_object_method: true
+    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: non_idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      instanceGroupManager: projectZoneInstanceGroupManager
+      instanceGroupManager: instanceGroupManager
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
   - name: compute.instanceGroupManagers.resize
@@ -3611,17 +4184,21 @@ interfaces:
       groups:
       - parameters:
         - size
+        - requestId
         - instanceGroupManager
     # TODO: Configure which fields are required.
     required_fields:
     - size
+    - requestId
     - instanceGroupManager
+    request_object_method: true
+    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: non_idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      instanceGroupManager: projectZoneInstanceGroupManager
+      instanceGroupManager: instanceGroupManager
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
   - name: compute.instanceGroupManagers.setInstanceTemplate
@@ -3630,18 +4207,22 @@ interfaces:
     flattening:
       groups:
       - parameters:
+        - requestId
         - instanceGroupManager
         - instanceGroupManagersSetInstanceTemplateRequestResource
     # TODO: Configure which fields are required.
     required_fields:
+    - requestId
     - instanceGroupManager
     - instanceGroupManagersSetInstanceTemplateRequestResource
+    request_object_method: true
+    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: non_idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      instanceGroupManager: projectZoneInstanceGroupManager
+      instanceGroupManager: instanceGroupManager
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
   - name: compute.instanceGroupManagers.setTargetPools
@@ -3650,21 +4231,25 @@ interfaces:
     flattening:
       groups:
       - parameters:
+        - requestId
         - instanceGroupManager
         - instanceGroupManagersSetTargetPoolsRequestResource
     # TODO: Configure which fields are required.
     required_fields:
+    - requestId
     - instanceGroupManager
     - instanceGroupManagersSetTargetPoolsRequestResource
+    request_object_method: true
+    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: non_idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      instanceGroupManager: projectZoneInstanceGroupManager
+      instanceGroupManager: instanceGroupManager
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
-# The fully qualified name of the API interface.
+  # The fully qualified name of the API interface.
 - name: google.compute.v1.InstanceGroups
   # A list of resource collection configurations.
   # Consists of a name_pattern and an entity_name.
@@ -3677,18 +4262,18 @@ interfaces:
   # The entity_name is the name to be used as a basis for generated methods and
   # classes.
   collections:
-  - name_pattern: '{project}'
+  - name_pattern: projects/{project}
     entity_name: project
-  - name_pattern: '{project}/zones/{zone}'
-    entity_name: projectZone
-  - name_pattern: '{project}/zones/{zone}/instanceGroups/{instanceGroup}'
-    entity_name: projectZoneInstanceGroup
+  - name_pattern: projects/{project}/zones/{zone}
+    entity_name: zone
+  - name_pattern: projects/{project}/zones/{zone}/instanceGroups/{instanceGroup}
+    entity_name: instanceGroup
   # Definition for retryable codes.
   retry_codes_def:
   - name: idempotent
     retry_codes:
-    - UNAVAILABLE
-    - DEADLINE_EXCEEDED
+    - SC_SERVICE_UNAVAILABLE
+    - SC_GATEWAY_TIMEOUT
   - name: non_idempotent
     retry_codes: []
   # Definition for retry/backoff parameters.
@@ -3714,6 +4299,17 @@ interfaces:
   #       message.
   #   required_fields - Fields that are always required for a request to be
   #       valid.
+  #   request_object_method - Turns on or off the generation of a method whose
+  #       sole parameter is a request object. Not all languages will generate
+  #       this method.
+  #   resource_name_treatment - An enum that specifies how to treat the
+  #       resource name formats defined in the field_name_patterns
+  #       and response_field_name_patterns fields.
+  #       UNSET: default value
+  #       NONE: the collection configs will not be used by the generated code.
+  #       VALIDATE: string fields will be validated by the client against the
+  #           specified resource name formats.
+  #       STATIC_TYPES: the client will use generated types for resource names.
   #   page_streaming - Specifies the configuration for paging.
   #       Describes information for generating a method which transforms a
   #       paging list RPC into a stream of resources.
@@ -3747,18 +4343,22 @@ interfaces:
     flattening:
       groups:
       - parameters:
+        - requestId
         - instanceGroup
         - instanceGroupsAddInstancesRequestResource
     # TODO: Configure which fields are required.
     required_fields:
+    - requestId
     - instanceGroup
     - instanceGroupsAddInstancesRequestResource
+    request_object_method: true
+    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: non_idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      instanceGroup: projectZoneInstanceGroup
+      instanceGroup: instanceGroup
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
   - name: compute.instanceGroups.aggregatedList
@@ -3771,13 +4371,15 @@ interfaces:
     # TODO: Configure which fields are required.
     required_fields:
     - project
+    request_object_method: true
+    resource_name_treatment: STATIC_TYPES
     page_streaming:
       request:
         page_size_field: maxResults
         token_field: pageToken
       response:
         token_field: nextPageToken
-        resources_field: items
+        resources_field: InstanceGroupAggregatedList
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: idempotent
     # TODO: Configure the retryable params for this method.
@@ -3792,16 +4394,20 @@ interfaces:
     flattening:
       groups:
       - parameters:
+        - requestId
         - instanceGroup
     # TODO: Configure which fields are required.
     required_fields:
+    - requestId
     - instanceGroup
+    request_object_method: true
+    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      instanceGroup: projectZoneInstanceGroup
+      instanceGroup: instanceGroup
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
   - name: compute.instanceGroups.get
@@ -3814,12 +4420,14 @@ interfaces:
     # TODO: Configure which fields are required.
     required_fields:
     - instanceGroup
+    request_object_method: true
+    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      instanceGroup: projectZoneInstanceGroup
+      instanceGroup: instanceGroup
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
   - name: compute.instanceGroups.insert
@@ -3829,17 +4437,21 @@ interfaces:
       groups:
       - parameters:
         - zone
+        - requestId
         - instanceGroupResource
     # TODO: Configure which fields are required.
     required_fields:
     - zone
+    - requestId
     - instanceGroupResource
+    request_object_method: true
+    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: non_idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      zone: projectZone
+      zone: zone
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
   - name: compute.instanceGroups.list
@@ -3852,19 +4464,21 @@ interfaces:
     # TODO: Configure which fields are required.
     required_fields:
     - zone
+    request_object_method: true
+    resource_name_treatment: STATIC_TYPES
     page_streaming:
       request:
         page_size_field: maxResults
         token_field: pageToken
       response:
         token_field: nextPageToken
-        resources_field: items
+        resources_field: InstanceGroupList
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      zone: projectZone
+      zone: zone
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
   - name: compute.instanceGroups.listInstances
@@ -3879,19 +4493,21 @@ interfaces:
     required_fields:
     - instanceGroup
     - instanceGroupsListInstancesRequestResource
+    request_object_method: true
+    resource_name_treatment: STATIC_TYPES
     page_streaming:
       request:
         page_size_field: maxResults
         token_field: pageToken
       response:
         token_field: nextPageToken
-        resources_field: items
+        resources_field: InstanceGroupsListInstances
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: non_idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      instanceGroup: projectZoneInstanceGroup
+      instanceGroup: instanceGroup
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
   - name: compute.instanceGroups.removeInstances
@@ -3900,18 +4516,22 @@ interfaces:
     flattening:
       groups:
       - parameters:
+        - requestId
         - instanceGroup
         - instanceGroupsRemoveInstancesRequestResource
     # TODO: Configure which fields are required.
     required_fields:
+    - requestId
     - instanceGroup
     - instanceGroupsRemoveInstancesRequestResource
+    request_object_method: true
+    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: non_idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      instanceGroup: projectZoneInstanceGroup
+      instanceGroup: instanceGroup
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
   - name: compute.instanceGroups.setNamedPorts
@@ -3920,21 +4540,25 @@ interfaces:
     flattening:
       groups:
       - parameters:
+        - requestId
         - instanceGroup
         - instanceGroupsSetNamedPortsRequestResource
     # TODO: Configure which fields are required.
     required_fields:
+    - requestId
     - instanceGroup
     - instanceGroupsSetNamedPortsRequestResource
+    request_object_method: true
+    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: non_idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      instanceGroup: projectZoneInstanceGroup
+      instanceGroup: instanceGroup
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
-# The fully qualified name of the API interface.
+  # The fully qualified name of the API interface.
 - name: google.compute.v1.InstanceTemplates
   # A list of resource collection configurations.
   # Consists of a name_pattern and an entity_name.
@@ -3947,18 +4571,18 @@ interfaces:
   # The entity_name is the name to be used as a basis for generated methods and
   # classes.
   collections:
-  - name_pattern: '{project}'
+  - name_pattern: projects/{project}
     entity_name: project
-  - name_pattern: '{project}/global/instanceTemplates/{instanceTemplate}'
-    entity_name: projectGlobalInstanceTemplate
-  - name_pattern: '{project}/global/instanceTemplates/{resource}'
-    entity_name: projectGlobalInstanceTemplateResource
+  - name_pattern: projects/{project}/instanceTemplates/{instanceTemplate}
+    entity_name: instanceTemplate
+  - name_pattern: projects/{project}/instanceTemplates/{resource}
+    entity_name: instanceTemplatesResource
   # Definition for retryable codes.
   retry_codes_def:
   - name: idempotent
     retry_codes:
-    - UNAVAILABLE
-    - DEADLINE_EXCEEDED
+    - SC_SERVICE_UNAVAILABLE
+    - SC_GATEWAY_TIMEOUT
   - name: non_idempotent
     retry_codes: []
   # Definition for retry/backoff parameters.
@@ -3984,6 +4608,17 @@ interfaces:
   #       message.
   #   required_fields - Fields that are always required for a request to be
   #       valid.
+  #   request_object_method - Turns on or off the generation of a method whose
+  #       sole parameter is a request object. Not all languages will generate
+  #       this method.
+  #   resource_name_treatment - An enum that specifies how to treat the
+  #       resource name formats defined in the field_name_patterns
+  #       and response_field_name_patterns fields.
+  #       UNSET: default value
+  #       NONE: the collection configs will not be used by the generated code.
+  #       VALIDATE: string fields will be validated by the client against the
+  #           specified resource name formats.
+  #       STATIC_TYPES: the client will use generated types for resource names.
   #   page_streaming - Specifies the configuration for paging.
   #       Describes information for generating a method which transforms a
   #       paging list RPC into a stream of resources.
@@ -4018,15 +4653,19 @@ interfaces:
       groups:
       - parameters:
         - instanceTemplate
+        - requestId
     # TODO: Configure which fields are required.
     required_fields:
     - instanceTemplate
+    - requestId
+    request_object_method: true
+    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      instanceTemplate: projectGlobalInstanceTemplate
+      instanceTemplate: instanceTemplate
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
   - name: compute.instanceTemplates.get
@@ -4039,12 +4678,14 @@ interfaces:
     # TODO: Configure which fields are required.
     required_fields:
     - instanceTemplate
+    request_object_method: true
+    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      instanceTemplate: projectGlobalInstanceTemplate
+      instanceTemplate: instanceTemplate
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
   - name: compute.instanceTemplates.getIamPolicy
@@ -4057,12 +4698,14 @@ interfaces:
     # TODO: Configure which fields are required.
     required_fields:
     - resource
+    request_object_method: true
+    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      resource: projectGlobalInstanceTemplateResource
+      resource: instanceTemplatesResource
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
   - name: compute.instanceTemplates.insert
@@ -4071,12 +4714,16 @@ interfaces:
     flattening:
       groups:
       - parameters:
+        - requestId
         - project
         - instanceTemplateResource
     # TODO: Configure which fields are required.
     required_fields:
+    - requestId
     - project
     - instanceTemplateResource
+    request_object_method: true
+    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: non_idempotent
     # TODO: Configure the retryable params for this method.
@@ -4095,13 +4742,15 @@ interfaces:
     # TODO: Configure which fields are required.
     required_fields:
     - project
+    request_object_method: true
+    resource_name_treatment: STATIC_TYPES
     page_streaming:
       request:
         page_size_field: maxResults
         token_field: pageToken
       response:
         token_field: nextPageToken
-        resources_field: items
+        resources_field: InstanceTemplateList
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: idempotent
     # TODO: Configure the retryable params for this method.
@@ -4122,12 +4771,14 @@ interfaces:
     required_fields:
     - resource
     - globalSetPolicyRequestResource
+    request_object_method: true
+    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: non_idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      resource: projectGlobalInstanceTemplateResource
+      resource: instanceTemplatesResource
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
   - name: compute.instanceTemplates.testIamPermissions
@@ -4142,15 +4793,17 @@ interfaces:
     required_fields:
     - resource
     - testPermissionsRequestResource
+    request_object_method: true
+    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: non_idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      resource: projectGlobalInstanceTemplateResource
+      resource: instanceTemplatesResource
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
-# The fully qualified name of the API interface.
+  # The fully qualified name of the API interface.
 - name: google.compute.v1.Instances
   # A list of resource collection configurations.
   # Consists of a name_pattern and an entity_name.
@@ -4163,20 +4816,20 @@ interfaces:
   # The entity_name is the name to be used as a basis for generated methods and
   # classes.
   collections:
-  - name_pattern: '{project}'
+  - name_pattern: projects/{project}
     entity_name: project
-  - name_pattern: '{project}/zones/{zone}'
-    entity_name: projectZone
-  - name_pattern: '{project}/zones/{zone}/instances/{instance}'
-    entity_name: projectZoneInstance
-  - name_pattern: '{project}/zones/{zone}/instances/{resource}'
-    entity_name: projectZoneInstanceResource
+  - name_pattern: projects/{project}/zones/{zone}
+    entity_name: zone
+  - name_pattern: projects/{project}/zones/{zone}/instances/{instance}
+    entity_name: instance
+  - name_pattern: projects/{project}/zones/{zone}/instances/{resource}
+    entity_name: instancesResource
   # Definition for retryable codes.
   retry_codes_def:
   - name: idempotent
     retry_codes:
-    - UNAVAILABLE
-    - DEADLINE_EXCEEDED
+    - SC_SERVICE_UNAVAILABLE
+    - SC_GATEWAY_TIMEOUT
   - name: non_idempotent
     retry_codes: []
   # Definition for retry/backoff parameters.
@@ -4202,6 +4855,17 @@ interfaces:
   #       message.
   #   required_fields - Fields that are always required for a request to be
   #       valid.
+  #   request_object_method - Turns on or off the generation of a method whose
+  #       sole parameter is a request object. Not all languages will generate
+  #       this method.
+  #   resource_name_treatment - An enum that specifies how to treat the
+  #       resource name formats defined in the field_name_patterns
+  #       and response_field_name_patterns fields.
+  #       UNSET: default value
+  #       NONE: the collection configs will not be used by the generated code.
+  #       VALIDATE: string fields will be validated by the client against the
+  #           specified resource name formats.
+  #       STATIC_TYPES: the client will use generated types for resource names.
   #   page_streaming - Specifies the configuration for paging.
   #       Describes information for generating a method which transforms a
   #       paging list RPC into a stream of resources.
@@ -4237,18 +4901,22 @@ interfaces:
       - parameters:
         - instance
         - networkInterface
+        - requestId
         - accessConfigResource
     # TODO: Configure which fields are required.
     required_fields:
     - instance
     - networkInterface
+    - requestId
     - accessConfigResource
+    request_object_method: true
+    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: non_idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      instance: projectZoneInstance
+      instance: instance
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
   - name: compute.instances.aggregatedList
@@ -4261,13 +4929,15 @@ interfaces:
     # TODO: Configure which fields are required.
     required_fields:
     - project
+    request_object_method: true
+    resource_name_treatment: STATIC_TYPES
     page_streaming:
       request:
         page_size_field: maxResults
         token_field: pageToken
       response:
         token_field: nextPageToken
-        resources_field: items
+        resources_field: InstanceAggregatedList
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: idempotent
     # TODO: Configure the retryable params for this method.
@@ -4283,19 +4953,23 @@ interfaces:
       groups:
       - parameters:
         - instance
+        - requestId
         - forceAttach
         - attachedDiskResource
     # TODO: Configure which fields are required.
     required_fields:
     - instance
+    - requestId
     - forceAttach
     - attachedDiskResource
+    request_object_method: true
+    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: non_idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      instance: projectZoneInstance
+      instance: instance
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
   - name: compute.instances.delete
@@ -4305,15 +4979,19 @@ interfaces:
       groups:
       - parameters:
         - instance
+        - requestId
     # TODO: Configure which fields are required.
     required_fields:
     - instance
+    - requestId
+    request_object_method: true
+    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      instance: projectZoneInstance
+      instance: instance
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
   - name: compute.instances.deleteAccessConfig
@@ -4324,18 +5002,22 @@ interfaces:
       - parameters:
         - instance
         - networkInterface
+        - requestId
         - accessConfig
     # TODO: Configure which fields are required.
     required_fields:
     - instance
     - networkInterface
+    - requestId
     - accessConfig
+    request_object_method: true
+    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: non_idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      instance: projectZoneInstance
+      instance: instance
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
   - name: compute.instances.detachDisk
@@ -4345,17 +5027,21 @@ interfaces:
       groups:
       - parameters:
         - instance
+        - requestId
         - deviceName
     # TODO: Configure which fields are required.
     required_fields:
     - instance
+    - requestId
     - deviceName
+    request_object_method: true
+    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: non_idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      instance: projectZoneInstance
+      instance: instance
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
   - name: compute.instances.get
@@ -4368,12 +5054,38 @@ interfaces:
     # TODO: Configure which fields are required.
     required_fields:
     - instance
+    request_object_method: true
+    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      instance: projectZoneInstance
+      instance: instance
+    # TODO: Configure the default timeout for a non-retrying call.
+    timeout_millis: 60000
+  - name: compute.instances.getGuestAttributes
+    # TODO: Configure which groups of fields should be flattened into method
+    # params.
+    flattening:
+      groups:
+      - parameters:
+        - instance
+        - queryPath
+        - variableKey
+    # TODO: Configure which fields are required.
+    required_fields:
+    - instance
+    - queryPath
+    - variableKey
+    request_object_method: true
+    resource_name_treatment: STATIC_TYPES
+    # TODO: Configure the retryable codes for this method.
+    retry_codes_name: idempotent
+    # TODO: Configure the retryable params for this method.
+    retry_params_name: default
+    field_name_patterns:
+      instance: instance
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
   - name: compute.instances.getIamPolicy
@@ -4386,12 +5098,14 @@ interfaces:
     # TODO: Configure which fields are required.
     required_fields:
     - resource
+    request_object_method: true
+    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      resource: projectZoneInstanceResource
+      resource: instancesResource
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
   - name: compute.instances.getSerialPortOutput
@@ -4408,12 +5122,14 @@ interfaces:
     - instance
     - port
     - start
+    request_object_method: true
+    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      instance: projectZoneInstance
+      instance: instance
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
   - name: compute.instances.getShieldedInstanceIdentity
@@ -4426,12 +5142,14 @@ interfaces:
     # TODO: Configure which fields are required.
     required_fields:
     - instance
+    request_object_method: true
+    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      instance: projectZoneInstance
+      instance: instance
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
   - name: compute.instances.insert
@@ -4440,18 +5158,24 @@ interfaces:
     flattening:
       groups:
       - parameters:
+        - sourceInstanceTemplate
         - zone
+        - requestId
         - instanceResource
     # TODO: Configure which fields are required.
     required_fields:
+    - sourceInstanceTemplate
     - zone
+    - requestId
     - instanceResource
+    request_object_method: true
+    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: non_idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      zone: projectZone
+      zone: zone
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
   - name: compute.instances.list
@@ -4464,19 +5188,21 @@ interfaces:
     # TODO: Configure which fields are required.
     required_fields:
     - zone
+    request_object_method: true
+    resource_name_treatment: STATIC_TYPES
     page_streaming:
       request:
         page_size_field: maxResults
         token_field: pageToken
       response:
         token_field: nextPageToken
-        resources_field: items
+        resources_field: InstanceList
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      zone: projectZone
+      zone: zone
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
   - name: compute.instances.listReferrers
@@ -4489,19 +5215,21 @@ interfaces:
     # TODO: Configure which fields are required.
     required_fields:
     - instance
+    request_object_method: true
+    resource_name_treatment: STATIC_TYPES
     page_streaming:
       request:
         page_size_field: maxResults
         token_field: pageToken
       response:
         token_field: nextPageToken
-        resources_field: items
+        resources_field: InstanceListReferrers
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      instance: projectZoneInstance
+      instance: instance
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
   - name: compute.instances.reset
@@ -4511,15 +5239,19 @@ interfaces:
       groups:
       - parameters:
         - instance
+        - requestId
     # TODO: Configure which fields are required.
     required_fields:
     - instance
+    - requestId
+    request_object_method: true
+    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: non_idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      instance: projectZoneInstance
+      instance: instance
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
   - name: compute.instances.setDeletionProtection
@@ -4529,17 +5261,21 @@ interfaces:
       groups:
       - parameters:
         - resource
+        - requestId
         - deletionProtection
     # TODO: Configure which fields are required.
     required_fields:
     - resource
+    - requestId
     - deletionProtection
+    request_object_method: true
+    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: non_idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      resource: projectZoneInstanceResource
+      resource: instancesResource
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
   - name: compute.instances.setDiskAutoDelete
@@ -4549,19 +5285,23 @@ interfaces:
       groups:
       - parameters:
         - instance
+        - requestId
         - autoDelete
         - deviceName
     # TODO: Configure which fields are required.
     required_fields:
     - instance
+    - requestId
     - autoDelete
     - deviceName
+    request_object_method: true
+    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: non_idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      instance: projectZoneInstance
+      instance: instance
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
   - name: compute.instances.setIamPolicy
@@ -4576,12 +5316,14 @@ interfaces:
     required_fields:
     - resource
     - zoneSetPolicyRequestResource
+    request_object_method: true
+    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: non_idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      resource: projectZoneInstanceResource
+      resource: instancesResource
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
   - name: compute.instances.setLabels
@@ -4591,17 +5333,21 @@ interfaces:
       groups:
       - parameters:
         - instance
+        - requestId
         - instancesSetLabelsRequestResource
     # TODO: Configure which fields are required.
     required_fields:
     - instance
+    - requestId
     - instancesSetLabelsRequestResource
+    request_object_method: true
+    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: non_idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      instance: projectZoneInstance
+      instance: instance
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
   - name: compute.instances.setMachineResources
@@ -4611,17 +5357,21 @@ interfaces:
       groups:
       - parameters:
         - instance
+        - requestId
         - instancesSetMachineResourcesRequestResource
     # TODO: Configure which fields are required.
     required_fields:
     - instance
+    - requestId
     - instancesSetMachineResourcesRequestResource
+    request_object_method: true
+    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: non_idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      instance: projectZoneInstance
+      instance: instance
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
   - name: compute.instances.setMachineType
@@ -4631,17 +5381,21 @@ interfaces:
       groups:
       - parameters:
         - instance
+        - requestId
         - instancesSetMachineTypeRequestResource
     # TODO: Configure which fields are required.
     required_fields:
     - instance
+    - requestId
     - instancesSetMachineTypeRequestResource
+    request_object_method: true
+    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: non_idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      instance: projectZoneInstance
+      instance: instance
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
   - name: compute.instances.setMetadata
@@ -4651,17 +5405,21 @@ interfaces:
       groups:
       - parameters:
         - instance
+        - requestId
         - metadataResource
     # TODO: Configure which fields are required.
     required_fields:
     - instance
+    - requestId
     - metadataResource
+    request_object_method: true
+    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: non_idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      instance: projectZoneInstance
+      instance: instance
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
   - name: compute.instances.setMinCpuPlatform
@@ -4671,17 +5429,21 @@ interfaces:
       groups:
       - parameters:
         - instance
+        - requestId
         - instancesSetMinCpuPlatformRequestResource
     # TODO: Configure which fields are required.
     required_fields:
     - instance
+    - requestId
     - instancesSetMinCpuPlatformRequestResource
+    request_object_method: true
+    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: non_idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      instance: projectZoneInstance
+      instance: instance
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
   - name: compute.instances.setScheduling
@@ -4691,17 +5453,21 @@ interfaces:
       groups:
       - parameters:
         - instance
+        - requestId
         - schedulingResource
     # TODO: Configure which fields are required.
     required_fields:
     - instance
+    - requestId
     - schedulingResource
+    request_object_method: true
+    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: non_idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      instance: projectZoneInstance
+      instance: instance
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
   - name: compute.instances.setServiceAccount
@@ -4711,17 +5477,21 @@ interfaces:
       groups:
       - parameters:
         - instance
+        - requestId
         - instancesSetServiceAccountRequestResource
     # TODO: Configure which fields are required.
     required_fields:
     - instance
+    - requestId
     - instancesSetServiceAccountRequestResource
+    request_object_method: true
+    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: non_idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      instance: projectZoneInstance
+      instance: instance
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
   - name: compute.instances.setShieldedInstanceIntegrityPolicy
@@ -4731,17 +5501,21 @@ interfaces:
       groups:
       - parameters:
         - instance
+        - requestId
         - shieldedInstanceIntegrityPolicyResource
     # TODO: Configure which fields are required.
     required_fields:
     - instance
+    - requestId
     - shieldedInstanceIntegrityPolicyResource
+    request_object_method: true
+    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: non_idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      instance: projectZoneInstance
+      instance: instance
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
   - name: compute.instances.setTags
@@ -4751,17 +5525,21 @@ interfaces:
       groups:
       - parameters:
         - instance
+        - requestId
         - tagsResource
     # TODO: Configure which fields are required.
     required_fields:
     - instance
+    - requestId
     - tagsResource
+    request_object_method: true
+    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: non_idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      instance: projectZoneInstance
+      instance: instance
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
   - name: compute.instances.simulateMaintenanceEvent
@@ -4774,12 +5552,14 @@ interfaces:
     # TODO: Configure which fields are required.
     required_fields:
     - instance
+    request_object_method: true
+    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: non_idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      instance: projectZoneInstance
+      instance: instance
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
   - name: compute.instances.start
@@ -4789,15 +5569,19 @@ interfaces:
       groups:
       - parameters:
         - instance
+        - requestId
     # TODO: Configure which fields are required.
     required_fields:
     - instance
+    - requestId
+    request_object_method: true
+    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: non_idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      instance: projectZoneInstance
+      instance: instance
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
   - name: compute.instances.startWithEncryptionKey
@@ -4807,17 +5591,21 @@ interfaces:
       groups:
       - parameters:
         - instance
+        - requestId
         - instancesStartWithEncryptionKeyRequestResource
     # TODO: Configure which fields are required.
     required_fields:
     - instance
+    - requestId
     - instancesStartWithEncryptionKeyRequestResource
+    request_object_method: true
+    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: non_idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      instance: projectZoneInstance
+      instance: instance
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
   - name: compute.instances.stop
@@ -4827,15 +5615,19 @@ interfaces:
       groups:
       - parameters:
         - instance
+        - requestId
     # TODO: Configure which fields are required.
     required_fields:
     - instance
+    - requestId
+    request_object_method: true
+    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: non_idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      instance: projectZoneInstance
+      instance: instance
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
   - name: compute.instances.testIamPermissions
@@ -4850,12 +5642,14 @@ interfaces:
     required_fields:
     - resource
     - testPermissionsRequestResource
+    request_object_method: true
+    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: non_idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      resource: projectZoneInstanceResource
+      resource: instancesResource
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
   - name: compute.instances.updateAccessConfig
@@ -4866,18 +5660,22 @@ interfaces:
       - parameters:
         - instance
         - networkInterface
+        - requestId
         - accessConfigResource
     # TODO: Configure which fields are required.
     required_fields:
     - instance
     - networkInterface
+    - requestId
     - accessConfigResource
+    request_object_method: true
+    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: non_idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      instance: projectZoneInstance
+      instance: instance
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
   - name: compute.instances.updateNetworkInterface
@@ -4888,18 +5686,22 @@ interfaces:
       - parameters:
         - instance
         - networkInterface
+        - requestId
         - networkInterfaceResource
     # TODO: Configure which fields are required.
     required_fields:
     - instance
     - networkInterface
+    - requestId
     - networkInterfaceResource
+    request_object_method: true
+    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: non_idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      instance: projectZoneInstance
+      instance: instance
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
   - name: compute.instances.updateShieldedInstanceConfig
@@ -4909,20 +5711,24 @@ interfaces:
       groups:
       - parameters:
         - instance
+        - requestId
         - shieldedInstanceConfigResource
     # TODO: Configure which fields are required.
     required_fields:
     - instance
+    - requestId
     - shieldedInstanceConfigResource
+    request_object_method: true
+    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: non_idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      instance: projectZoneInstance
+      instance: instance
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
-# The fully qualified name of the API interface.
+  # The fully qualified name of the API interface.
 - name: google.compute.v1.InterconnectAttachments
   # A list of resource collection configurations.
   # Consists of a name_pattern and an entity_name.
@@ -4935,18 +5741,18 @@ interfaces:
   # The entity_name is the name to be used as a basis for generated methods and
   # classes.
   collections:
-  - name_pattern: '{project}'
+  - name_pattern: projects/{project}
     entity_name: project
-  - name_pattern: '{project}/regions/{region}'
-    entity_name: projectRegion
-  - name_pattern: '{project}/regions/{region}/interconnectAttachments/{interconnectAttachment}'
-    entity_name: projectRegionInterconnectAttachment
+  - name_pattern: projects/{project}/regions/{region}
+    entity_name: region
+  - name_pattern: projects/{project}/regions/{region}/interconnectAttachments/{interconnectAttachment}
+    entity_name: interconnectAttachment
   # Definition for retryable codes.
   retry_codes_def:
   - name: idempotent
     retry_codes:
-    - UNAVAILABLE
-    - DEADLINE_EXCEEDED
+    - SC_SERVICE_UNAVAILABLE
+    - SC_GATEWAY_TIMEOUT
   - name: non_idempotent
     retry_codes: []
   # Definition for retry/backoff parameters.
@@ -4972,6 +5778,17 @@ interfaces:
   #       message.
   #   required_fields - Fields that are always required for a request to be
   #       valid.
+  #   request_object_method - Turns on or off the generation of a method whose
+  #       sole parameter is a request object. Not all languages will generate
+  #       this method.
+  #   resource_name_treatment - An enum that specifies how to treat the
+  #       resource name formats defined in the field_name_patterns
+  #       and response_field_name_patterns fields.
+  #       UNSET: default value
+  #       NONE: the collection configs will not be used by the generated code.
+  #       VALIDATE: string fields will be validated by the client against the
+  #           specified resource name formats.
+  #       STATIC_TYPES: the client will use generated types for resource names.
   #   page_streaming - Specifies the configuration for paging.
   #       Describes information for generating a method which transforms a
   #       paging list RPC into a stream of resources.
@@ -5009,13 +5826,15 @@ interfaces:
     # TODO: Configure which fields are required.
     required_fields:
     - project
+    request_object_method: true
+    resource_name_treatment: STATIC_TYPES
     page_streaming:
       request:
         page_size_field: maxResults
         token_field: pageToken
       response:
         token_field: nextPageToken
-        resources_field: items
+        resources_field: InterconnectAttachmentAggregatedList
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: idempotent
     # TODO: Configure the retryable params for this method.
@@ -5030,16 +5849,20 @@ interfaces:
     flattening:
       groups:
       - parameters:
+        - requestId
         - interconnectAttachment
     # TODO: Configure which fields are required.
     required_fields:
+    - requestId
     - interconnectAttachment
+    request_object_method: true
+    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      interconnectAttachment: projectRegionInterconnectAttachment
+      interconnectAttachment: interconnectAttachment
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
   - name: compute.interconnectAttachments.get
@@ -5052,12 +5875,14 @@ interfaces:
     # TODO: Configure which fields are required.
     required_fields:
     - interconnectAttachment
+    request_object_method: true
+    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      interconnectAttachment: projectRegionInterconnectAttachment
+      interconnectAttachment: interconnectAttachment
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
   - name: compute.interconnectAttachments.insert
@@ -5066,18 +5891,22 @@ interfaces:
     flattening:
       groups:
       - parameters:
+        - requestId
         - region
         - interconnectAttachmentResource
     # TODO: Configure which fields are required.
     required_fields:
+    - requestId
     - region
     - interconnectAttachmentResource
+    request_object_method: true
+    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: non_idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      region: projectRegion
+      region: region
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
   - name: compute.interconnectAttachments.list
@@ -5090,19 +5919,21 @@ interfaces:
     # TODO: Configure which fields are required.
     required_fields:
     - region
+    request_object_method: true
+    resource_name_treatment: STATIC_TYPES
     page_streaming:
       request:
         page_size_field: maxResults
         token_field: pageToken
       response:
         token_field: nextPageToken
-        resources_field: items
+        resources_field: InterconnectAttachmentList
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      region: projectRegion
+      region: region
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
   - name: compute.interconnectAttachments.patch
@@ -5111,21 +5942,25 @@ interfaces:
     flattening:
       groups:
       - parameters:
+        - requestId
         - interconnectAttachment
         - interconnectAttachmentResource
     # TODO: Configure which fields are required.
     required_fields:
+    - requestId
     - interconnectAttachment
     - interconnectAttachmentResource
+    request_object_method: true
+    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: non_idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      interconnectAttachment: projectRegionInterconnectAttachment
+      interconnectAttachment: interconnectAttachment
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
-# The fully qualified name of the API interface.
+  # The fully qualified name of the API interface.
 - name: google.compute.v1.InterconnectLocations
   # A list of resource collection configurations.
   # Consists of a name_pattern and an entity_name.
@@ -5138,16 +5973,16 @@ interfaces:
   # The entity_name is the name to be used as a basis for generated methods and
   # classes.
   collections:
-  - name_pattern: '{project}'
+  - name_pattern: projects/{project}
     entity_name: project
-  - name_pattern: '{project}/global/interconnectLocations/{interconnectLocation}'
-    entity_name: projectGlobalInterconnectLocation
+  - name_pattern: projects/{project}/interconnectLocations/{interconnectLocation}
+    entity_name: interconnectLocation
   # Definition for retryable codes.
   retry_codes_def:
   - name: idempotent
     retry_codes:
-    - UNAVAILABLE
-    - DEADLINE_EXCEEDED
+    - SC_SERVICE_UNAVAILABLE
+    - SC_GATEWAY_TIMEOUT
   - name: non_idempotent
     retry_codes: []
   # Definition for retry/backoff parameters.
@@ -5173,6 +6008,17 @@ interfaces:
   #       message.
   #   required_fields - Fields that are always required for a request to be
   #       valid.
+  #   request_object_method - Turns on or off the generation of a method whose
+  #       sole parameter is a request object. Not all languages will generate
+  #       this method.
+  #   resource_name_treatment - An enum that specifies how to treat the
+  #       resource name formats defined in the field_name_patterns
+  #       and response_field_name_patterns fields.
+  #       UNSET: default value
+  #       NONE: the collection configs will not be used by the generated code.
+  #       VALIDATE: string fields will be validated by the client against the
+  #           specified resource name formats.
+  #       STATIC_TYPES: the client will use generated types for resource names.
   #   page_streaming - Specifies the configuration for paging.
   #       Describes information for generating a method which transforms a
   #       paging list RPC into a stream of resources.
@@ -5210,12 +6056,14 @@ interfaces:
     # TODO: Configure which fields are required.
     required_fields:
     - interconnectLocation
+    request_object_method: true
+    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      interconnectLocation: projectGlobalInterconnectLocation
+      interconnectLocation: interconnectLocation
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
   - name: compute.interconnectLocations.list
@@ -5228,13 +6076,15 @@ interfaces:
     # TODO: Configure which fields are required.
     required_fields:
     - project
+    request_object_method: true
+    resource_name_treatment: STATIC_TYPES
     page_streaming:
       request:
         page_size_field: maxResults
         token_field: pageToken
       response:
         token_field: nextPageToken
-        resources_field: items
+        resources_field: InterconnectLocationList
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: idempotent
     # TODO: Configure the retryable params for this method.
@@ -5243,7 +6093,7 @@ interfaces:
       project: project
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
-# The fully qualified name of the API interface.
+  # The fully qualified name of the API interface.
 - name: google.compute.v1.Interconnects
   # A list of resource collection configurations.
   # Consists of a name_pattern and an entity_name.
@@ -5256,16 +6106,16 @@ interfaces:
   # The entity_name is the name to be used as a basis for generated methods and
   # classes.
   collections:
-  - name_pattern: '{project}'
+  - name_pattern: projects/{project}
     entity_name: project
-  - name_pattern: '{project}/global/interconnects/{interconnect}'
-    entity_name: projectGlobalInterconnect
+  - name_pattern: projects/{project}/interconnects/{interconnect}
+    entity_name: interconnect
   # Definition for retryable codes.
   retry_codes_def:
   - name: idempotent
     retry_codes:
-    - UNAVAILABLE
-    - DEADLINE_EXCEEDED
+    - SC_SERVICE_UNAVAILABLE
+    - SC_GATEWAY_TIMEOUT
   - name: non_idempotent
     retry_codes: []
   # Definition for retry/backoff parameters.
@@ -5291,6 +6141,17 @@ interfaces:
   #       message.
   #   required_fields - Fields that are always required for a request to be
   #       valid.
+  #   request_object_method - Turns on or off the generation of a method whose
+  #       sole parameter is a request object. Not all languages will generate
+  #       this method.
+  #   resource_name_treatment - An enum that specifies how to treat the
+  #       resource name formats defined in the field_name_patterns
+  #       and response_field_name_patterns fields.
+  #       UNSET: default value
+  #       NONE: the collection configs will not be used by the generated code.
+  #       VALIDATE: string fields will be validated by the client against the
+  #           specified resource name formats.
+  #       STATIC_TYPES: the client will use generated types for resource names.
   #   page_streaming - Specifies the configuration for paging.
   #       Describes information for generating a method which transforms a
   #       paging list RPC into a stream of resources.
@@ -5324,16 +6185,20 @@ interfaces:
     flattening:
       groups:
       - parameters:
+        - requestId
         - interconnect
     # TODO: Configure which fields are required.
     required_fields:
+    - requestId
     - interconnect
+    request_object_method: true
+    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      interconnect: projectGlobalInterconnect
+      interconnect: interconnect
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
   - name: compute.interconnects.get
@@ -5346,12 +6211,14 @@ interfaces:
     # TODO: Configure which fields are required.
     required_fields:
     - interconnect
+    request_object_method: true
+    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      interconnect: projectGlobalInterconnect
+      interconnect: interconnect
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
   - name: compute.interconnects.getDiagnostics
@@ -5364,12 +6231,14 @@ interfaces:
     # TODO: Configure which fields are required.
     required_fields:
     - interconnect
+    request_object_method: true
+    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      interconnect: projectGlobalInterconnect
+      interconnect: interconnect
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
   - name: compute.interconnects.insert
@@ -5378,12 +6247,16 @@ interfaces:
     flattening:
       groups:
       - parameters:
+        - requestId
         - project
         - interconnectResource
     # TODO: Configure which fields are required.
     required_fields:
+    - requestId
     - project
     - interconnectResource
+    request_object_method: true
+    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: non_idempotent
     # TODO: Configure the retryable params for this method.
@@ -5402,13 +6275,15 @@ interfaces:
     # TODO: Configure which fields are required.
     required_fields:
     - project
+    request_object_method: true
+    resource_name_treatment: STATIC_TYPES
     page_streaming:
       request:
         page_size_field: maxResults
         token_field: pageToken
       response:
         token_field: nextPageToken
-        resources_field: items
+        resources_field: InterconnectList
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: idempotent
     # TODO: Configure the retryable params for this method.
@@ -5423,21 +6298,25 @@ interfaces:
     flattening:
       groups:
       - parameters:
+        - requestId
         - interconnect
         - interconnectResource
     # TODO: Configure which fields are required.
     required_fields:
+    - requestId
     - interconnect
     - interconnectResource
+    request_object_method: true
+    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: non_idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      interconnect: projectGlobalInterconnect
+      interconnect: interconnect
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
-# The fully qualified name of the API interface.
+  # The fully qualified name of the API interface.
 - name: google.compute.v1.LicenseCodes
   # A list of resource collection configurations.
   # Consists of a name_pattern and an entity_name.
@@ -5450,16 +6329,16 @@ interfaces:
   # The entity_name is the name to be used as a basis for generated methods and
   # classes.
   collections:
-  - name_pattern: '{project}/global/licenseCodes/{licenseCode}'
-    entity_name: projectGlobalLicenseCode
-  - name_pattern: '{project}/global/licenseCodes/{resource}'
-    entity_name: projectGlobalLicenseCodeResource
+  - name_pattern: projects/{project}/licenseCodes/{licenseCode}
+    entity_name: licenseCode
+  - name_pattern: projects/{project}/licenseCodes/{resource}
+    entity_name: licenseCodesResource
   # Definition for retryable codes.
   retry_codes_def:
   - name: idempotent
     retry_codes:
-    - UNAVAILABLE
-    - DEADLINE_EXCEEDED
+    - SC_SERVICE_UNAVAILABLE
+    - SC_GATEWAY_TIMEOUT
   - name: non_idempotent
     retry_codes: []
   # Definition for retry/backoff parameters.
@@ -5485,6 +6364,17 @@ interfaces:
   #       message.
   #   required_fields - Fields that are always required for a request to be
   #       valid.
+  #   request_object_method - Turns on or off the generation of a method whose
+  #       sole parameter is a request object. Not all languages will generate
+  #       this method.
+  #   resource_name_treatment - An enum that specifies how to treat the
+  #       resource name formats defined in the field_name_patterns
+  #       and response_field_name_patterns fields.
+  #       UNSET: default value
+  #       NONE: the collection configs will not be used by the generated code.
+  #       VALIDATE: string fields will be validated by the client against the
+  #           specified resource name formats.
+  #       STATIC_TYPES: the client will use generated types for resource names.
   #   page_streaming - Specifies the configuration for paging.
   #       Describes information for generating a method which transforms a
   #       paging list RPC into a stream of resources.
@@ -5522,12 +6412,14 @@ interfaces:
     # TODO: Configure which fields are required.
     required_fields:
     - licenseCode
+    request_object_method: true
+    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      licenseCode: projectGlobalLicenseCode
+      licenseCode: licenseCode
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
   - name: compute.licenseCodes.testIamPermissions
@@ -5542,15 +6434,17 @@ interfaces:
     required_fields:
     - resource
     - testPermissionsRequestResource
+    request_object_method: true
+    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: non_idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      resource: projectGlobalLicenseCodeResource
+      resource: licenseCodesResource
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
-# The fully qualified name of the API interface.
+  # The fully qualified name of the API interface.
 - name: google.compute.v1.Licenses
   # A list of resource collection configurations.
   # Consists of a name_pattern and an entity_name.
@@ -5563,18 +6457,18 @@ interfaces:
   # The entity_name is the name to be used as a basis for generated methods and
   # classes.
   collections:
-  - name_pattern: '{project}'
+  - name_pattern: projects/{project}
     entity_name: project
-  - name_pattern: '{project}/global/licenses/{license}'
-    entity_name: projectGlobalLicense
-  - name_pattern: '{project}/global/licenses/{resource}'
-    entity_name: projectGlobalLicenseResource
+  - name_pattern: projects/{project}/licenses/{license}
+    entity_name: license
+  - name_pattern: projects/{project}/licenses/{resource}
+    entity_name: licensesResource
   # Definition for retryable codes.
   retry_codes_def:
   - name: idempotent
     retry_codes:
-    - UNAVAILABLE
-    - DEADLINE_EXCEEDED
+    - SC_SERVICE_UNAVAILABLE
+    - SC_GATEWAY_TIMEOUT
   - name: non_idempotent
     retry_codes: []
   # Definition for retry/backoff parameters.
@@ -5600,6 +6494,17 @@ interfaces:
   #       message.
   #   required_fields - Fields that are always required for a request to be
   #       valid.
+  #   request_object_method - Turns on or off the generation of a method whose
+  #       sole parameter is a request object. Not all languages will generate
+  #       this method.
+  #   resource_name_treatment - An enum that specifies how to treat the
+  #       resource name formats defined in the field_name_patterns
+  #       and response_field_name_patterns fields.
+  #       UNSET: default value
+  #       NONE: the collection configs will not be used by the generated code.
+  #       VALIDATE: string fields will be validated by the client against the
+  #           specified resource name formats.
+  #       STATIC_TYPES: the client will use generated types for resource names.
   #   page_streaming - Specifies the configuration for paging.
   #       Describes information for generating a method which transforms a
   #       paging list RPC into a stream of resources.
@@ -5634,15 +6539,19 @@ interfaces:
       groups:
       - parameters:
         - license
+        - requestId
     # TODO: Configure which fields are required.
     required_fields:
     - license
+    - requestId
+    request_object_method: true
+    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      license: projectGlobalLicense
+      license: license
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
   - name: compute.licenses.get
@@ -5655,12 +6564,14 @@ interfaces:
     # TODO: Configure which fields are required.
     required_fields:
     - license
+    request_object_method: true
+    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      license: projectGlobalLicense
+      license: license
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
   - name: compute.licenses.getIamPolicy
@@ -5673,12 +6584,14 @@ interfaces:
     # TODO: Configure which fields are required.
     required_fields:
     - resource
+    request_object_method: true
+    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      resource: projectGlobalLicenseResource
+      resource: licensesResource
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
   - name: compute.licenses.insert
@@ -5687,12 +6600,16 @@ interfaces:
     flattening:
       groups:
       - parameters:
+        - requestId
         - project
         - licenseResource
     # TODO: Configure which fields are required.
     required_fields:
+    - requestId
     - project
     - licenseResource
+    request_object_method: true
+    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: non_idempotent
     # TODO: Configure the retryable params for this method.
@@ -5711,13 +6628,15 @@ interfaces:
     # TODO: Configure which fields are required.
     required_fields:
     - project
+    request_object_method: true
+    resource_name_treatment: STATIC_TYPES
     page_streaming:
       request:
         page_size_field: maxResults
         token_field: pageToken
       response:
         token_field: nextPageToken
-        resources_field: items
+        resources_field: LicensesListResponse
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: idempotent
     # TODO: Configure the retryable params for this method.
@@ -5738,12 +6657,14 @@ interfaces:
     required_fields:
     - resource
     - globalSetPolicyRequestResource
+    request_object_method: true
+    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: non_idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      resource: projectGlobalLicenseResource
+      resource: licensesResource
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
   - name: compute.licenses.testIamPermissions
@@ -5758,15 +6679,17 @@ interfaces:
     required_fields:
     - resource
     - testPermissionsRequestResource
+    request_object_method: true
+    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: non_idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      resource: projectGlobalLicenseResource
+      resource: licensesResource
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
-# The fully qualified name of the API interface.
+  # The fully qualified name of the API interface.
 - name: google.compute.v1.MachineTypes
   # A list of resource collection configurations.
   # Consists of a name_pattern and an entity_name.
@@ -5779,18 +6702,18 @@ interfaces:
   # The entity_name is the name to be used as a basis for generated methods and
   # classes.
   collections:
-  - name_pattern: '{project}'
+  - name_pattern: projects/{project}
     entity_name: project
-  - name_pattern: '{project}/zones/{zone}'
-    entity_name: projectZone
-  - name_pattern: '{project}/zones/{zone}/machineTypes/{machineType}'
-    entity_name: projectZoneMachineType
+  - name_pattern: projects/{project}/zones/{zone}
+    entity_name: zone
+  - name_pattern: projects/{project}/zones/{zone}/machineTypes/{machineType}
+    entity_name: machineType
   # Definition for retryable codes.
   retry_codes_def:
   - name: idempotent
     retry_codes:
-    - UNAVAILABLE
-    - DEADLINE_EXCEEDED
+    - SC_SERVICE_UNAVAILABLE
+    - SC_GATEWAY_TIMEOUT
   - name: non_idempotent
     retry_codes: []
   # Definition for retry/backoff parameters.
@@ -5816,6 +6739,17 @@ interfaces:
   #       message.
   #   required_fields - Fields that are always required for a request to be
   #       valid.
+  #   request_object_method - Turns on or off the generation of a method whose
+  #       sole parameter is a request object. Not all languages will generate
+  #       this method.
+  #   resource_name_treatment - An enum that specifies how to treat the
+  #       resource name formats defined in the field_name_patterns
+  #       and response_field_name_patterns fields.
+  #       UNSET: default value
+  #       NONE: the collection configs will not be used by the generated code.
+  #       VALIDATE: string fields will be validated by the client against the
+  #           specified resource name formats.
+  #       STATIC_TYPES: the client will use generated types for resource names.
   #   page_streaming - Specifies the configuration for paging.
   #       Describes information for generating a method which transforms a
   #       paging list RPC into a stream of resources.
@@ -5853,13 +6787,15 @@ interfaces:
     # TODO: Configure which fields are required.
     required_fields:
     - project
+    request_object_method: true
+    resource_name_treatment: STATIC_TYPES
     page_streaming:
       request:
         page_size_field: maxResults
         token_field: pageToken
       response:
         token_field: nextPageToken
-        resources_field: items
+        resources_field: MachineTypeAggregatedList
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: idempotent
     # TODO: Configure the retryable params for this method.
@@ -5878,12 +6814,14 @@ interfaces:
     # TODO: Configure which fields are required.
     required_fields:
     - machineType
+    request_object_method: true
+    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      machineType: projectZoneMachineType
+      machineType: machineType
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
   - name: compute.machineTypes.list
@@ -5896,22 +6834,24 @@ interfaces:
     # TODO: Configure which fields are required.
     required_fields:
     - zone
+    request_object_method: true
+    resource_name_treatment: STATIC_TYPES
     page_streaming:
       request:
         page_size_field: maxResults
         token_field: pageToken
       response:
         token_field: nextPageToken
-        resources_field: items
+        resources_field: MachineTypeList
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      zone: projectZone
+      zone: zone
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
-# The fully qualified name of the API interface.
+  # The fully qualified name of the API interface.
 - name: google.compute.v1.NetworkEndpointGroups
   # A list of resource collection configurations.
   # Consists of a name_pattern and an entity_name.
@@ -5924,20 +6864,20 @@ interfaces:
   # The entity_name is the name to be used as a basis for generated methods and
   # classes.
   collections:
-  - name_pattern: '{project}'
+  - name_pattern: projects/{project}
     entity_name: project
-  - name_pattern: '{project}/zones/{zone}'
-    entity_name: projectZone
-  - name_pattern: '{project}/zones/{zone}/networkEndpointGroups/{networkEndpointGroup}'
-    entity_name: projectZoneNetworkEndpointGroup
-  - name_pattern: '{project}/zones/{zone}/networkEndpointGroups/{resource}'
-    entity_name: projectZoneNetworkEndpointGroupResource
+  - name_pattern: projects/{project}/zones/{zone}
+    entity_name: zone
+  - name_pattern: projects/{project}/zones/{zone}/networkEndpointGroups/{networkEndpointGroup}
+    entity_name: networkEndpointGroup
+  - name_pattern: projects/{project}/zones/{zone}/networkEndpointGroups/{resource}
+    entity_name: networkEndpointGroupsResource
   # Definition for retryable codes.
   retry_codes_def:
   - name: idempotent
     retry_codes:
-    - UNAVAILABLE
-    - DEADLINE_EXCEEDED
+    - SC_SERVICE_UNAVAILABLE
+    - SC_GATEWAY_TIMEOUT
   - name: non_idempotent
     retry_codes: []
   # Definition for retry/backoff parameters.
@@ -5963,6 +6903,17 @@ interfaces:
   #       message.
   #   required_fields - Fields that are always required for a request to be
   #       valid.
+  #   request_object_method - Turns on or off the generation of a method whose
+  #       sole parameter is a request object. Not all languages will generate
+  #       this method.
+  #   resource_name_treatment - An enum that specifies how to treat the
+  #       resource name formats defined in the field_name_patterns
+  #       and response_field_name_patterns fields.
+  #       UNSET: default value
+  #       NONE: the collection configs will not be used by the generated code.
+  #       VALIDATE: string fields will be validated by the client against the
+  #           specified resource name formats.
+  #       STATIC_TYPES: the client will use generated types for resource names.
   #   page_streaming - Specifies the configuration for paging.
   #       Describes information for generating a method which transforms a
   #       paging list RPC into a stream of resources.
@@ -6000,13 +6951,15 @@ interfaces:
     # TODO: Configure which fields are required.
     required_fields:
     - project
+    request_object_method: true
+    resource_name_treatment: STATIC_TYPES
     page_streaming:
       request:
         page_size_field: maxResults
         token_field: pageToken
       response:
         token_field: nextPageToken
-        resources_field: items
+        resources_field: NetworkEndpointGroupAggregatedList
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: idempotent
     # TODO: Configure the retryable params for this method.
@@ -6022,17 +6975,21 @@ interfaces:
       groups:
       - parameters:
         - networkEndpointGroup
+        - requestId
         - networkEndpointGroupsAttachEndpointsRequestResource
     # TODO: Configure which fields are required.
     required_fields:
     - networkEndpointGroup
+    - requestId
     - networkEndpointGroupsAttachEndpointsRequestResource
+    request_object_method: true
+    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: non_idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      networkEndpointGroup: projectZoneNetworkEndpointGroup
+      networkEndpointGroup: networkEndpointGroup
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
   - name: compute.networkEndpointGroups.delete
@@ -6042,15 +6999,19 @@ interfaces:
       groups:
       - parameters:
         - networkEndpointGroup
+        - requestId
     # TODO: Configure which fields are required.
     required_fields:
     - networkEndpointGroup
+    - requestId
+    request_object_method: true
+    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      networkEndpointGroup: projectZoneNetworkEndpointGroup
+      networkEndpointGroup: networkEndpointGroup
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
   - name: compute.networkEndpointGroups.detachNetworkEndpoints
@@ -6060,17 +7021,21 @@ interfaces:
       groups:
       - parameters:
         - networkEndpointGroup
+        - requestId
         - networkEndpointGroupsDetachEndpointsRequestResource
     # TODO: Configure which fields are required.
     required_fields:
     - networkEndpointGroup
+    - requestId
     - networkEndpointGroupsDetachEndpointsRequestResource
+    request_object_method: true
+    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: non_idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      networkEndpointGroup: projectZoneNetworkEndpointGroup
+      networkEndpointGroup: networkEndpointGroup
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
   - name: compute.networkEndpointGroups.get
@@ -6083,12 +7048,14 @@ interfaces:
     # TODO: Configure which fields are required.
     required_fields:
     - networkEndpointGroup
+    request_object_method: true
+    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      networkEndpointGroup: projectZoneNetworkEndpointGroup
+      networkEndpointGroup: networkEndpointGroup
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
   - name: compute.networkEndpointGroups.insert
@@ -6098,17 +7065,21 @@ interfaces:
       groups:
       - parameters:
         - zone
+        - requestId
         - networkEndpointGroupResource
     # TODO: Configure which fields are required.
     required_fields:
     - zone
+    - requestId
     - networkEndpointGroupResource
+    request_object_method: true
+    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: non_idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      zone: projectZone
+      zone: zone
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
   - name: compute.networkEndpointGroups.list
@@ -6121,19 +7092,21 @@ interfaces:
     # TODO: Configure which fields are required.
     required_fields:
     - zone
+    request_object_method: true
+    resource_name_treatment: STATIC_TYPES
     page_streaming:
       request:
         page_size_field: maxResults
         token_field: pageToken
       response:
         token_field: nextPageToken
-        resources_field: items
+        resources_field: NetworkEndpointGroupList
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      zone: projectZone
+      zone: zone
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
   - name: compute.networkEndpointGroups.listNetworkEndpoints
@@ -6148,19 +7121,21 @@ interfaces:
     required_fields:
     - networkEndpointGroup
     - networkEndpointGroupsListEndpointsRequestResource
+    request_object_method: true
+    resource_name_treatment: STATIC_TYPES
     page_streaming:
       request:
         page_size_field: maxResults
         token_field: pageToken
       response:
         token_field: nextPageToken
-        resources_field: items
+        resources_field: NetworkEndpointGroupsListNetworkEndpoints
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: non_idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      networkEndpointGroup: projectZoneNetworkEndpointGroup
+      networkEndpointGroup: networkEndpointGroup
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
   - name: compute.networkEndpointGroups.testIamPermissions
@@ -6175,15 +7150,17 @@ interfaces:
     required_fields:
     - resource
     - testPermissionsRequestResource
+    request_object_method: true
+    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: non_idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      resource: projectZoneNetworkEndpointGroupResource
+      resource: networkEndpointGroupsResource
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
-# The fully qualified name of the API interface.
+  # The fully qualified name of the API interface.
 - name: google.compute.v1.Networks
   # A list of resource collection configurations.
   # Consists of a name_pattern and an entity_name.
@@ -6196,16 +7173,16 @@ interfaces:
   # The entity_name is the name to be used as a basis for generated methods and
   # classes.
   collections:
-  - name_pattern: '{project}'
+  - name_pattern: projects/{project}
     entity_name: project
-  - name_pattern: '{project}/global/networks/{network}'
-    entity_name: projectGlobalNetwork
+  - name_pattern: projects/{project}/networks/{network}
+    entity_name: network
   # Definition for retryable codes.
   retry_codes_def:
   - name: idempotent
     retry_codes:
-    - UNAVAILABLE
-    - DEADLINE_EXCEEDED
+    - SC_SERVICE_UNAVAILABLE
+    - SC_GATEWAY_TIMEOUT
   - name: non_idempotent
     retry_codes: []
   # Definition for retry/backoff parameters.
@@ -6231,6 +7208,17 @@ interfaces:
   #       message.
   #   required_fields - Fields that are always required for a request to be
   #       valid.
+  #   request_object_method - Turns on or off the generation of a method whose
+  #       sole parameter is a request object. Not all languages will generate
+  #       this method.
+  #   resource_name_treatment - An enum that specifies how to treat the
+  #       resource name formats defined in the field_name_patterns
+  #       and response_field_name_patterns fields.
+  #       UNSET: default value
+  #       NONE: the collection configs will not be used by the generated code.
+  #       VALIDATE: string fields will be validated by the client against the
+  #           specified resource name formats.
+  #       STATIC_TYPES: the client will use generated types for resource names.
   #   page_streaming - Specifies the configuration for paging.
   #       Describes information for generating a method which transforms a
   #       paging list RPC into a stream of resources.
@@ -6264,18 +7252,22 @@ interfaces:
     flattening:
       groups:
       - parameters:
+        - requestId
         - network
         - networksAddPeeringRequestResource
     # TODO: Configure which fields are required.
     required_fields:
+    - requestId
     - network
     - networksAddPeeringRequestResource
+    request_object_method: true
+    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: non_idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      network: projectGlobalNetwork
+      network: network
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
   - name: compute.networks.delete
@@ -6284,16 +7276,20 @@ interfaces:
     flattening:
       groups:
       - parameters:
+        - requestId
         - network
     # TODO: Configure which fields are required.
     required_fields:
+    - requestId
     - network
+    request_object_method: true
+    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      network: projectGlobalNetwork
+      network: network
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
   - name: compute.networks.get
@@ -6306,12 +7302,14 @@ interfaces:
     # TODO: Configure which fields are required.
     required_fields:
     - network
+    request_object_method: true
+    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      network: projectGlobalNetwork
+      network: network
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
   - name: compute.networks.insert
@@ -6320,12 +7318,16 @@ interfaces:
     flattening:
       groups:
       - parameters:
+        - requestId
         - project
         - networkResource
     # TODO: Configure which fields are required.
     required_fields:
+    - requestId
     - project
     - networkResource
+    request_object_method: true
+    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: non_idempotent
     # TODO: Configure the retryable params for this method.
@@ -6344,13 +7346,15 @@ interfaces:
     # TODO: Configure which fields are required.
     required_fields:
     - project
+    request_object_method: true
+    resource_name_treatment: STATIC_TYPES
     page_streaming:
       request:
         page_size_field: maxResults
         token_field: pageToken
       response:
         token_field: nextPageToken
-        resources_field: items
+        resources_field: NetworkList
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: idempotent
     # TODO: Configure the retryable params for this method.
@@ -6365,18 +7369,22 @@ interfaces:
     flattening:
       groups:
       - parameters:
+        - requestId
         - network
         - networkResource
     # TODO: Configure which fields are required.
     required_fields:
+    - requestId
     - network
     - networkResource
+    request_object_method: true
+    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: non_idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      network: projectGlobalNetwork
+      network: network
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
   - name: compute.networks.removePeering
@@ -6385,18 +7393,22 @@ interfaces:
     flattening:
       groups:
       - parameters:
+        - requestId
         - network
         - networksRemovePeeringRequestResource
     # TODO: Configure which fields are required.
     required_fields:
+    - requestId
     - network
     - networksRemovePeeringRequestResource
+    request_object_method: true
+    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: non_idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      network: projectGlobalNetwork
+      network: network
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
   - name: compute.networks.switchToCustomMode
@@ -6405,19 +7417,23 @@ interfaces:
     flattening:
       groups:
       - parameters:
+        - requestId
         - network
     # TODO: Configure which fields are required.
     required_fields:
+    - requestId
     - network
+    request_object_method: true
+    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: non_idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      network: projectGlobalNetwork
+      network: network
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
-# The fully qualified name of the API interface.
+  # The fully qualified name of the API interface.
 - name: google.compute.v1.NodeGroups
   # A list of resource collection configurations.
   # Consists of a name_pattern and an entity_name.
@@ -6430,20 +7446,20 @@ interfaces:
   # The entity_name is the name to be used as a basis for generated methods and
   # classes.
   collections:
-  - name_pattern: '{project}'
+  - name_pattern: projects/{project}
     entity_name: project
-  - name_pattern: '{project}/zones/{zone}'
-    entity_name: projectZone
-  - name_pattern: '{project}/zones/{zone}/nodeGroups/{nodeGroup}'
-    entity_name: projectZoneNodeGroup
-  - name_pattern: '{project}/zones/{zone}/nodeGroups/{resource}'
-    entity_name: projectZoneNodeGroupResource
+  - name_pattern: projects/{project}/zones/{zone}
+    entity_name: zone
+  - name_pattern: projects/{project}/zones/{zone}/nodeGroups/{nodeGroup}
+    entity_name: nodeGroup
+  - name_pattern: projects/{project}/zones/{zone}/nodeGroups/{resource}
+    entity_name: nodeGroupsResource
   # Definition for retryable codes.
   retry_codes_def:
   - name: idempotent
     retry_codes:
-    - UNAVAILABLE
-    - DEADLINE_EXCEEDED
+    - SC_SERVICE_UNAVAILABLE
+    - SC_GATEWAY_TIMEOUT
   - name: non_idempotent
     retry_codes: []
   # Definition for retry/backoff parameters.
@@ -6469,6 +7485,17 @@ interfaces:
   #       message.
   #   required_fields - Fields that are always required for a request to be
   #       valid.
+  #   request_object_method - Turns on or off the generation of a method whose
+  #       sole parameter is a request object. Not all languages will generate
+  #       this method.
+  #   resource_name_treatment - An enum that specifies how to treat the
+  #       resource name formats defined in the field_name_patterns
+  #       and response_field_name_patterns fields.
+  #       UNSET: default value
+  #       NONE: the collection configs will not be used by the generated code.
+  #       VALIDATE: string fields will be validated by the client against the
+  #           specified resource name formats.
+  #       STATIC_TYPES: the client will use generated types for resource names.
   #   page_streaming - Specifies the configuration for paging.
   #       Describes information for generating a method which transforms a
   #       paging list RPC into a stream of resources.
@@ -6502,18 +7529,22 @@ interfaces:
     flattening:
       groups:
       - parameters:
+        - requestId
         - nodeGroup
         - nodeGroupsAddNodesRequestResource
     # TODO: Configure which fields are required.
     required_fields:
+    - requestId
     - nodeGroup
     - nodeGroupsAddNodesRequestResource
+    request_object_method: true
+    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: non_idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      nodeGroup: projectZoneNodeGroup
+      nodeGroup: nodeGroup
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
   - name: compute.nodeGroups.aggregatedList
@@ -6526,13 +7557,15 @@ interfaces:
     # TODO: Configure which fields are required.
     required_fields:
     - project
+    request_object_method: true
+    resource_name_treatment: STATIC_TYPES
     page_streaming:
       request:
         page_size_field: maxResults
         token_field: pageToken
       response:
         token_field: nextPageToken
-        resources_field: items
+        resources_field: NodeGroupAggregatedList
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: idempotent
     # TODO: Configure the retryable params for this method.
@@ -6547,16 +7580,20 @@ interfaces:
     flattening:
       groups:
       - parameters:
+        - requestId
         - nodeGroup
     # TODO: Configure which fields are required.
     required_fields:
+    - requestId
     - nodeGroup
+    request_object_method: true
+    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      nodeGroup: projectZoneNodeGroup
+      nodeGroup: nodeGroup
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
   - name: compute.nodeGroups.deleteNodes
@@ -6565,18 +7602,22 @@ interfaces:
     flattening:
       groups:
       - parameters:
+        - requestId
         - nodeGroup
         - nodeGroupsDeleteNodesRequestResource
     # TODO: Configure which fields are required.
     required_fields:
+    - requestId
     - nodeGroup
     - nodeGroupsDeleteNodesRequestResource
+    request_object_method: true
+    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: non_idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      nodeGroup: projectZoneNodeGroup
+      nodeGroup: nodeGroup
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
   - name: compute.nodeGroups.get
@@ -6589,12 +7630,14 @@ interfaces:
     # TODO: Configure which fields are required.
     required_fields:
     - nodeGroup
+    request_object_method: true
+    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      nodeGroup: projectZoneNodeGroup
+      nodeGroup: nodeGroup
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
   - name: compute.nodeGroups.getIamPolicy
@@ -6607,12 +7650,14 @@ interfaces:
     # TODO: Configure which fields are required.
     required_fields:
     - resource
+    request_object_method: true
+    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      resource: projectZoneNodeGroupResource
+      resource: nodeGroupsResource
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
   - name: compute.nodeGroups.insert
@@ -6623,18 +7668,22 @@ interfaces:
       - parameters:
         - initialNodeCount
         - zone
+        - requestId
         - nodeGroupResource
     # TODO: Configure which fields are required.
     required_fields:
     - initialNodeCount
     - zone
+    - requestId
     - nodeGroupResource
+    request_object_method: true
+    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: non_idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      zone: projectZone
+      zone: zone
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
   - name: compute.nodeGroups.list
@@ -6647,19 +7696,21 @@ interfaces:
     # TODO: Configure which fields are required.
     required_fields:
     - zone
+    request_object_method: true
+    resource_name_treatment: STATIC_TYPES
     page_streaming:
       request:
         page_size_field: maxResults
         token_field: pageToken
       response:
         token_field: nextPageToken
-        resources_field: items
+        resources_field: NodeGroupList
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      zone: projectZone
+      zone: zone
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
   - name: compute.nodeGroups.listNodes
@@ -6672,19 +7723,21 @@ interfaces:
     # TODO: Configure which fields are required.
     required_fields:
     - nodeGroup
+    request_object_method: true
+    resource_name_treatment: STATIC_TYPES
     page_streaming:
       request:
         page_size_field: maxResults
         token_field: pageToken
       response:
         token_field: nextPageToken
-        resources_field: items
+        resources_field: NodeGroupsListNodes
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: non_idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      nodeGroup: projectZoneNodeGroup
+      nodeGroup: nodeGroup
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
   - name: compute.nodeGroups.setIamPolicy
@@ -6699,12 +7752,14 @@ interfaces:
     required_fields:
     - resource
     - zoneSetPolicyRequestResource
+    request_object_method: true
+    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: non_idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      resource: projectZoneNodeGroupResource
+      resource: nodeGroupsResource
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
   - name: compute.nodeGroups.setNodeTemplate
@@ -6713,18 +7768,22 @@ interfaces:
     flattening:
       groups:
       - parameters:
+        - requestId
         - nodeGroup
         - nodeGroupsSetNodeTemplateRequestResource
     # TODO: Configure which fields are required.
     required_fields:
+    - requestId
     - nodeGroup
     - nodeGroupsSetNodeTemplateRequestResource
+    request_object_method: true
+    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: non_idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      nodeGroup: projectZoneNodeGroup
+      nodeGroup: nodeGroup
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
   - name: compute.nodeGroups.testIamPermissions
@@ -6739,15 +7798,17 @@ interfaces:
     required_fields:
     - resource
     - testPermissionsRequestResource
+    request_object_method: true
+    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: non_idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      resource: projectZoneNodeGroupResource
+      resource: nodeGroupsResource
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
-# The fully qualified name of the API interface.
+  # The fully qualified name of the API interface.
 - name: google.compute.v1.NodeTemplates
   # A list of resource collection configurations.
   # Consists of a name_pattern and an entity_name.
@@ -6760,20 +7821,20 @@ interfaces:
   # The entity_name is the name to be used as a basis for generated methods and
   # classes.
   collections:
-  - name_pattern: '{project}'
+  - name_pattern: projects/{project}
     entity_name: project
-  - name_pattern: '{project}/regions/{region}'
-    entity_name: projectRegion
-  - name_pattern: '{project}/regions/{region}/nodeTemplates/{nodeTemplate}'
-    entity_name: projectRegionNodeTemplate
-  - name_pattern: '{project}/regions/{region}/nodeTemplates/{resource}'
-    entity_name: projectRegionNodeTemplateResource
+  - name_pattern: projects/{project}/regions/{region}
+    entity_name: region
+  - name_pattern: projects/{project}/regions/{region}/nodeTemplates/{nodeTemplate}
+    entity_name: nodeTemplate
+  - name_pattern: projects/{project}/regions/{region}/nodeTemplates/{resource}
+    entity_name: nodeTemplatesResource
   # Definition for retryable codes.
   retry_codes_def:
   - name: idempotent
     retry_codes:
-    - UNAVAILABLE
-    - DEADLINE_EXCEEDED
+    - SC_SERVICE_UNAVAILABLE
+    - SC_GATEWAY_TIMEOUT
   - name: non_idempotent
     retry_codes: []
   # Definition for retry/backoff parameters.
@@ -6799,6 +7860,17 @@ interfaces:
   #       message.
   #   required_fields - Fields that are always required for a request to be
   #       valid.
+  #   request_object_method - Turns on or off the generation of a method whose
+  #       sole parameter is a request object. Not all languages will generate
+  #       this method.
+  #   resource_name_treatment - An enum that specifies how to treat the
+  #       resource name formats defined in the field_name_patterns
+  #       and response_field_name_patterns fields.
+  #       UNSET: default value
+  #       NONE: the collection configs will not be used by the generated code.
+  #       VALIDATE: string fields will be validated by the client against the
+  #           specified resource name formats.
+  #       STATIC_TYPES: the client will use generated types for resource names.
   #   page_streaming - Specifies the configuration for paging.
   #       Describes information for generating a method which transforms a
   #       paging list RPC into a stream of resources.
@@ -6836,13 +7908,15 @@ interfaces:
     # TODO: Configure which fields are required.
     required_fields:
     - project
+    request_object_method: true
+    resource_name_treatment: STATIC_TYPES
     page_streaming:
       request:
         page_size_field: maxResults
         token_field: pageToken
       response:
         token_field: nextPageToken
-        resources_field: items
+        resources_field: NodeTemplateAggregatedList
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: idempotent
     # TODO: Configure the retryable params for this method.
@@ -6857,16 +7931,20 @@ interfaces:
     flattening:
       groups:
       - parameters:
+        - requestId
         - nodeTemplate
     # TODO: Configure which fields are required.
     required_fields:
+    - requestId
     - nodeTemplate
+    request_object_method: true
+    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      nodeTemplate: projectRegionNodeTemplate
+      nodeTemplate: nodeTemplate
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
   - name: compute.nodeTemplates.get
@@ -6879,12 +7957,14 @@ interfaces:
     # TODO: Configure which fields are required.
     required_fields:
     - nodeTemplate
+    request_object_method: true
+    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      nodeTemplate: projectRegionNodeTemplate
+      nodeTemplate: nodeTemplate
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
   - name: compute.nodeTemplates.getIamPolicy
@@ -6897,12 +7977,14 @@ interfaces:
     # TODO: Configure which fields are required.
     required_fields:
     - resource
+    request_object_method: true
+    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      resource: projectRegionNodeTemplateResource
+      resource: nodeTemplatesResource
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
   - name: compute.nodeTemplates.insert
@@ -6911,18 +7993,22 @@ interfaces:
     flattening:
       groups:
       - parameters:
+        - requestId
         - region
         - nodeTemplateResource
     # TODO: Configure which fields are required.
     required_fields:
+    - requestId
     - region
     - nodeTemplateResource
+    request_object_method: true
+    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: non_idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      region: projectRegion
+      region: region
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
   - name: compute.nodeTemplates.list
@@ -6935,19 +8021,21 @@ interfaces:
     # TODO: Configure which fields are required.
     required_fields:
     - region
+    request_object_method: true
+    resource_name_treatment: STATIC_TYPES
     page_streaming:
       request:
         page_size_field: maxResults
         token_field: pageToken
       response:
         token_field: nextPageToken
-        resources_field: items
+        resources_field: NodeTemplateList
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      region: projectRegion
+      region: region
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
   - name: compute.nodeTemplates.setIamPolicy
@@ -6962,12 +8050,14 @@ interfaces:
     required_fields:
     - resource
     - regionSetPolicyRequestResource
+    request_object_method: true
+    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: non_idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      resource: projectRegionNodeTemplateResource
+      resource: nodeTemplatesResource
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
   - name: compute.nodeTemplates.testIamPermissions
@@ -6982,15 +8072,17 @@ interfaces:
     required_fields:
     - resource
     - testPermissionsRequestResource
+    request_object_method: true
+    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: non_idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      resource: projectRegionNodeTemplateResource
+      resource: nodeTemplatesResource
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
-# The fully qualified name of the API interface.
+  # The fully qualified name of the API interface.
 - name: google.compute.v1.NodeTypes
   # A list of resource collection configurations.
   # Consists of a name_pattern and an entity_name.
@@ -7003,18 +8095,18 @@ interfaces:
   # The entity_name is the name to be used as a basis for generated methods and
   # classes.
   collections:
-  - name_pattern: '{project}'
+  - name_pattern: projects/{project}
     entity_name: project
-  - name_pattern: '{project}/zones/{zone}'
-    entity_name: projectZone
-  - name_pattern: '{project}/zones/{zone}/nodeTypes/{nodeType}'
-    entity_name: projectZoneNodeType
+  - name_pattern: projects/{project}/zones/{zone}
+    entity_name: zone
+  - name_pattern: projects/{project}/zones/{zone}/nodeTypes/{nodeType}
+    entity_name: nodeType
   # Definition for retryable codes.
   retry_codes_def:
   - name: idempotent
     retry_codes:
-    - UNAVAILABLE
-    - DEADLINE_EXCEEDED
+    - SC_SERVICE_UNAVAILABLE
+    - SC_GATEWAY_TIMEOUT
   - name: non_idempotent
     retry_codes: []
   # Definition for retry/backoff parameters.
@@ -7040,6 +8132,17 @@ interfaces:
   #       message.
   #   required_fields - Fields that are always required for a request to be
   #       valid.
+  #   request_object_method - Turns on or off the generation of a method whose
+  #       sole parameter is a request object. Not all languages will generate
+  #       this method.
+  #   resource_name_treatment - An enum that specifies how to treat the
+  #       resource name formats defined in the field_name_patterns
+  #       and response_field_name_patterns fields.
+  #       UNSET: default value
+  #       NONE: the collection configs will not be used by the generated code.
+  #       VALIDATE: string fields will be validated by the client against the
+  #           specified resource name formats.
+  #       STATIC_TYPES: the client will use generated types for resource names.
   #   page_streaming - Specifies the configuration for paging.
   #       Describes information for generating a method which transforms a
   #       paging list RPC into a stream of resources.
@@ -7077,13 +8180,15 @@ interfaces:
     # TODO: Configure which fields are required.
     required_fields:
     - project
+    request_object_method: true
+    resource_name_treatment: STATIC_TYPES
     page_streaming:
       request:
         page_size_field: maxResults
         token_field: pageToken
       response:
         token_field: nextPageToken
-        resources_field: items
+        resources_field: NodeTypeAggregatedList
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: idempotent
     # TODO: Configure the retryable params for this method.
@@ -7102,12 +8207,14 @@ interfaces:
     # TODO: Configure which fields are required.
     required_fields:
     - nodeType
+    request_object_method: true
+    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      nodeType: projectZoneNodeType
+      nodeType: nodeType
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
   - name: compute.nodeTypes.list
@@ -7120,22 +8227,24 @@ interfaces:
     # TODO: Configure which fields are required.
     required_fields:
     - zone
+    request_object_method: true
+    resource_name_treatment: STATIC_TYPES
     page_streaming:
       request:
         page_size_field: maxResults
         token_field: pageToken
       response:
         token_field: nextPageToken
-        resources_field: items
+        resources_field: NodeTypeList
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      zone: projectZone
+      zone: zone
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
-# The fully qualified name of the API interface.
+  # The fully qualified name of the API interface.
 - name: google.compute.v1.Projects
   # A list of resource collection configurations.
   # Consists of a name_pattern and an entity_name.
@@ -7148,14 +8257,14 @@ interfaces:
   # The entity_name is the name to be used as a basis for generated methods and
   # classes.
   collections:
-  - name_pattern: '{project}'
+  - name_pattern: projects/{project}
     entity_name: project
   # Definition for retryable codes.
   retry_codes_def:
   - name: idempotent
     retry_codes:
-    - UNAVAILABLE
-    - DEADLINE_EXCEEDED
+    - SC_SERVICE_UNAVAILABLE
+    - SC_GATEWAY_TIMEOUT
   - name: non_idempotent
     retry_codes: []
   # Definition for retry/backoff parameters.
@@ -7181,6 +8290,17 @@ interfaces:
   #       message.
   #   required_fields - Fields that are always required for a request to be
   #       valid.
+  #   request_object_method - Turns on or off the generation of a method whose
+  #       sole parameter is a request object. Not all languages will generate
+  #       this method.
+  #   resource_name_treatment - An enum that specifies how to treat the
+  #       resource name formats defined in the field_name_patterns
+  #       and response_field_name_patterns fields.
+  #       UNSET: default value
+  #       NONE: the collection configs will not be used by the generated code.
+  #       VALIDATE: string fields will be validated by the client against the
+  #           specified resource name formats.
+  #       STATIC_TYPES: the client will use generated types for resource names.
   #   page_streaming - Specifies the configuration for paging.
   #       Describes information for generating a method which transforms a
   #       paging list RPC into a stream of resources.
@@ -7214,10 +8334,14 @@ interfaces:
     flattening:
       groups:
       - parameters:
+        - requestId
         - project
     # TODO: Configure which fields are required.
     required_fields:
+    - requestId
     - project
+    request_object_method: true
+    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: non_idempotent
     # TODO: Configure the retryable params for this method.
@@ -7232,12 +8356,16 @@ interfaces:
     flattening:
       groups:
       - parameters:
+        - requestId
         - project
         - projectsDisableXpnResourceRequestResource
     # TODO: Configure which fields are required.
     required_fields:
+    - requestId
     - project
     - projectsDisableXpnResourceRequestResource
+    request_object_method: true
+    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: non_idempotent
     # TODO: Configure the retryable params for this method.
@@ -7252,10 +8380,14 @@ interfaces:
     flattening:
       groups:
       - parameters:
+        - requestId
         - project
     # TODO: Configure which fields are required.
     required_fields:
+    - requestId
     - project
+    request_object_method: true
+    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: non_idempotent
     # TODO: Configure the retryable params for this method.
@@ -7270,12 +8402,16 @@ interfaces:
     flattening:
       groups:
       - parameters:
+        - requestId
         - project
         - projectsEnableXpnResourceRequestResource
     # TODO: Configure which fields are required.
     required_fields:
+    - requestId
     - project
     - projectsEnableXpnResourceRequestResource
+    request_object_method: true
+    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: non_idempotent
     # TODO: Configure the retryable params for this method.
@@ -7294,6 +8430,8 @@ interfaces:
     # TODO: Configure which fields are required.
     required_fields:
     - project
+    request_object_method: false
+    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: idempotent
     # TODO: Configure the retryable params for this method.
@@ -7312,6 +8450,8 @@ interfaces:
     # TODO: Configure which fields are required.
     required_fields:
     - project
+    request_object_method: false
+    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: idempotent
     # TODO: Configure the retryable params for this method.
@@ -7330,13 +8470,15 @@ interfaces:
     # TODO: Configure which fields are required.
     required_fields:
     - project
+    request_object_method: true
+    resource_name_treatment: STATIC_TYPES
     page_streaming:
       request:
         page_size_field: maxResults
         token_field: pageToken
       response:
         token_field: nextPageToken
-        resources_field: resources
+        resources_field: ProjectsGetXpnResources
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: idempotent
     # TODO: Configure the retryable params for this method.
@@ -7357,13 +8499,15 @@ interfaces:
     required_fields:
     - project
     - projectsListXpnHostsRequestResource
+    request_object_method: true
+    resource_name_treatment: STATIC_TYPES
     page_streaming:
       request:
         page_size_field: maxResults
         token_field: pageToken
       response:
         token_field: nextPageToken
-        resources_field: items
+        resources_field: XpnHostList
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: non_idempotent
     # TODO: Configure the retryable params for this method.
@@ -7378,12 +8522,16 @@ interfaces:
     flattening:
       groups:
       - parameters:
+        - requestId
         - project
         - diskMoveRequestResource
     # TODO: Configure which fields are required.
     required_fields:
+    - requestId
     - project
     - diskMoveRequestResource
+    request_object_method: true
+    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: non_idempotent
     # TODO: Configure the retryable params for this method.
@@ -7398,12 +8546,16 @@ interfaces:
     flattening:
       groups:
       - parameters:
+        - requestId
         - project
         - instanceMoveRequestResource
     # TODO: Configure which fields are required.
     required_fields:
+    - requestId
     - project
     - instanceMoveRequestResource
+    request_object_method: true
+    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: non_idempotent
     # TODO: Configure the retryable params for this method.
@@ -7418,12 +8570,16 @@ interfaces:
     flattening:
       groups:
       - parameters:
+        - requestId
         - project
         - metadataResource
     # TODO: Configure which fields are required.
     required_fields:
+    - requestId
     - project
     - metadataResource
+    request_object_method: true
+    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: non_idempotent
     # TODO: Configure the retryable params for this method.
@@ -7438,12 +8594,16 @@ interfaces:
     flattening:
       groups:
       - parameters:
+        - requestId
         - project
         - projectsSetDefaultNetworkTierRequestResource
     # TODO: Configure which fields are required.
     required_fields:
+    - requestId
     - project
     - projectsSetDefaultNetworkTierRequestResource
+    request_object_method: true
+    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: non_idempotent
     # TODO: Configure the retryable params for this method.
@@ -7458,12 +8618,16 @@ interfaces:
     flattening:
       groups:
       - parameters:
+        - requestId
         - project
         - usageExportLocationResource
     # TODO: Configure which fields are required.
     required_fields:
+    - requestId
     - project
     - usageExportLocationResource
+    request_object_method: true
+    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: non_idempotent
     # TODO: Configure the retryable params for this method.
@@ -7472,7 +8636,7 @@ interfaces:
       project: project
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
-# The fully qualified name of the API interface.
+  # The fully qualified name of the API interface.
 - name: google.compute.v1.RegionAutoscalers
   # A list of resource collection configurations.
   # Consists of a name_pattern and an entity_name.
@@ -7485,16 +8649,16 @@ interfaces:
   # The entity_name is the name to be used as a basis for generated methods and
   # classes.
   collections:
-  - name_pattern: '{project}/regions/{region}'
-    entity_name: projectRegion
-  - name_pattern: '{project}/regions/{region}/autoscalers/{autoscaler}'
-    entity_name: projectRegionAutoscaler
+  - name_pattern: projects/{project}/regions/{region}
+    entity_name: region
+  - name_pattern: projects/{project}/regions/{region}/autoscalers/{autoscaler}
+    entity_name: regionAutoscalersAutoscaler
   # Definition for retryable codes.
   retry_codes_def:
   - name: idempotent
     retry_codes:
-    - UNAVAILABLE
-    - DEADLINE_EXCEEDED
+    - SC_SERVICE_UNAVAILABLE
+    - SC_GATEWAY_TIMEOUT
   - name: non_idempotent
     retry_codes: []
   # Definition for retry/backoff parameters.
@@ -7520,6 +8684,17 @@ interfaces:
   #       message.
   #   required_fields - Fields that are always required for a request to be
   #       valid.
+  #   request_object_method - Turns on or off the generation of a method whose
+  #       sole parameter is a request object. Not all languages will generate
+  #       this method.
+  #   resource_name_treatment - An enum that specifies how to treat the
+  #       resource name formats defined in the field_name_patterns
+  #       and response_field_name_patterns fields.
+  #       UNSET: default value
+  #       NONE: the collection configs will not be used by the generated code.
+  #       VALIDATE: string fields will be validated by the client against the
+  #           specified resource name formats.
+  #       STATIC_TYPES: the client will use generated types for resource names.
   #   page_streaming - Specifies the configuration for paging.
   #       Describes information for generating a method which transforms a
   #       paging list RPC into a stream of resources.
@@ -7554,15 +8729,19 @@ interfaces:
       groups:
       - parameters:
         - autoscaler
+        - requestId
     # TODO: Configure which fields are required.
     required_fields:
     - autoscaler
+    - requestId
+    request_object_method: true
+    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      autoscaler: projectRegionAutoscaler
+      autoscaler: regionAutoscalersAutoscaler
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
   - name: compute.regionAutoscalers.get
@@ -7575,12 +8754,14 @@ interfaces:
     # TODO: Configure which fields are required.
     required_fields:
     - autoscaler
+    request_object_method: true
+    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      autoscaler: projectRegionAutoscaler
+      autoscaler: regionAutoscalersAutoscaler
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
   - name: compute.regionAutoscalers.insert
@@ -7589,18 +8770,22 @@ interfaces:
     flattening:
       groups:
       - parameters:
+        - requestId
         - region
         - autoscalerResource
     # TODO: Configure which fields are required.
     required_fields:
+    - requestId
     - region
     - autoscalerResource
+    request_object_method: true
+    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: non_idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      region: projectRegion
+      region: region
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
   - name: compute.regionAutoscalers.list
@@ -7613,19 +8798,21 @@ interfaces:
     # TODO: Configure which fields are required.
     required_fields:
     - region
+    request_object_method: true
+    resource_name_treatment: STATIC_TYPES
     page_streaming:
       request:
         page_size_field: maxResults
         token_field: pageToken
       response:
         token_field: nextPageToken
-        resources_field: items
+        resources_field: RegionAutoscalerList
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      region: projectRegion
+      region: region
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
   - name: compute.regionAutoscalers.patch
@@ -7635,19 +8822,23 @@ interfaces:
       groups:
       - parameters:
         - autoscaler
+        - requestId
         - region
         - autoscalerResource
     # TODO: Configure which fields are required.
     required_fields:
     - autoscaler
+    - requestId
     - region
     - autoscalerResource
+    request_object_method: true
+    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: non_idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      region: projectRegion
+      region: region
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
   - name: compute.regionAutoscalers.update
@@ -7657,22 +8848,26 @@ interfaces:
       groups:
       - parameters:
         - autoscaler
+        - requestId
         - region
         - autoscalerResource
     # TODO: Configure which fields are required.
     required_fields:
     - autoscaler
+    - requestId
     - region
     - autoscalerResource
+    request_object_method: true
+    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      region: projectRegion
+      region: region
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
-# The fully qualified name of the API interface.
+  # The fully qualified name of the API interface.
 - name: google.compute.v1.RegionBackendServices
   # A list of resource collection configurations.
   # Consists of a name_pattern and an entity_name.
@@ -7685,16 +8880,16 @@ interfaces:
   # The entity_name is the name to be used as a basis for generated methods and
   # classes.
   collections:
-  - name_pattern: '{project}/regions/{region}'
-    entity_name: projectRegion
-  - name_pattern: '{project}/regions/{region}/backendServices/{backendService}'
-    entity_name: projectRegionBackendService
+  - name_pattern: projects/{project}/regions/{region}
+    entity_name: region
+  - name_pattern: projects/{project}/regions/{region}/backendServices/{backendService}
+    entity_name: regionBackendServicesBackendService
   # Definition for retryable codes.
   retry_codes_def:
   - name: idempotent
     retry_codes:
-    - UNAVAILABLE
-    - DEADLINE_EXCEEDED
+    - SC_SERVICE_UNAVAILABLE
+    - SC_GATEWAY_TIMEOUT
   - name: non_idempotent
     retry_codes: []
   # Definition for retry/backoff parameters.
@@ -7720,6 +8915,17 @@ interfaces:
   #       message.
   #   required_fields - Fields that are always required for a request to be
   #       valid.
+  #   request_object_method - Turns on or off the generation of a method whose
+  #       sole parameter is a request object. Not all languages will generate
+  #       this method.
+  #   resource_name_treatment - An enum that specifies how to treat the
+  #       resource name formats defined in the field_name_patterns
+  #       and response_field_name_patterns fields.
+  #       UNSET: default value
+  #       NONE: the collection configs will not be used by the generated code.
+  #       VALIDATE: string fields will be validated by the client against the
+  #           specified resource name formats.
+  #       STATIC_TYPES: the client will use generated types for resource names.
   #   page_streaming - Specifies the configuration for paging.
   #       Describes information for generating a method which transforms a
   #       paging list RPC into a stream of resources.
@@ -7753,16 +8959,20 @@ interfaces:
     flattening:
       groups:
       - parameters:
+        - requestId
         - backendService
     # TODO: Configure which fields are required.
     required_fields:
+    - requestId
     - backendService
+    request_object_method: true
+    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      backendService: projectRegionBackendService
+      backendService: regionBackendServicesBackendService
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
   - name: compute.regionBackendServices.get
@@ -7775,12 +8985,14 @@ interfaces:
     # TODO: Configure which fields are required.
     required_fields:
     - backendService
+    request_object_method: true
+    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      backendService: projectRegionBackendService
+      backendService: regionBackendServicesBackendService
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
   - name: compute.regionBackendServices.getHealth
@@ -7795,12 +9007,14 @@ interfaces:
     required_fields:
     - backendService
     - resourceGroupReferenceResource
+    request_object_method: true
+    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: non_idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      backendService: projectRegionBackendService
+      backendService: regionBackendServicesBackendService
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
   - name: compute.regionBackendServices.insert
@@ -7809,18 +9023,22 @@ interfaces:
     flattening:
       groups:
       - parameters:
+        - requestId
         - region
         - backendServiceResource
     # TODO: Configure which fields are required.
     required_fields:
+    - requestId
     - region
     - backendServiceResource
+    request_object_method: true
+    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: non_idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      region: projectRegion
+      region: region
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
   - name: compute.regionBackendServices.list
@@ -7833,19 +9051,21 @@ interfaces:
     # TODO: Configure which fields are required.
     required_fields:
     - region
+    request_object_method: true
+    resource_name_treatment: STATIC_TYPES
     page_streaming:
       request:
         page_size_field: maxResults
         token_field: pageToken
       response:
         token_field: nextPageToken
-        resources_field: items
+        resources_field: BackendServiceList
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      region: projectRegion
+      region: region
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
   - name: compute.regionBackendServices.patch
@@ -7854,18 +9074,22 @@ interfaces:
     flattening:
       groups:
       - parameters:
+        - requestId
         - backendService
         - backendServiceResource
     # TODO: Configure which fields are required.
     required_fields:
+    - requestId
     - backendService
     - backendServiceResource
+    request_object_method: true
+    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: non_idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      backendService: projectRegionBackendService
+      backendService: regionBackendServicesBackendService
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
   - name: compute.regionBackendServices.update
@@ -7874,21 +9098,25 @@ interfaces:
     flattening:
       groups:
       - parameters:
+        - requestId
         - backendService
         - backendServiceResource
     # TODO: Configure which fields are required.
     required_fields:
+    - requestId
     - backendService
     - backendServiceResource
+    request_object_method: true
+    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      backendService: projectRegionBackendService
+      backendService: regionBackendServicesBackendService
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
-# The fully qualified name of the API interface.
+  # The fully qualified name of the API interface.
 - name: google.compute.v1.RegionCommitments
   # A list of resource collection configurations.
   # Consists of a name_pattern and an entity_name.
@@ -7901,18 +9129,18 @@ interfaces:
   # The entity_name is the name to be used as a basis for generated methods and
   # classes.
   collections:
-  - name_pattern: '{project}'
+  - name_pattern: projects/{project}
     entity_name: project
-  - name_pattern: '{project}/regions/{region}'
-    entity_name: projectRegion
-  - name_pattern: '{project}/regions/{region}/commitments/{commitment}'
-    entity_name: projectRegionCommitment
+  - name_pattern: projects/{project}/regions/{region}
+    entity_name: region
+  - name_pattern: projects/{project}/regions/{region}/commitments/{commitment}
+    entity_name: commitment
   # Definition for retryable codes.
   retry_codes_def:
   - name: idempotent
     retry_codes:
-    - UNAVAILABLE
-    - DEADLINE_EXCEEDED
+    - SC_SERVICE_UNAVAILABLE
+    - SC_GATEWAY_TIMEOUT
   - name: non_idempotent
     retry_codes: []
   # Definition for retry/backoff parameters.
@@ -7938,6 +9166,17 @@ interfaces:
   #       message.
   #   required_fields - Fields that are always required for a request to be
   #       valid.
+  #   request_object_method - Turns on or off the generation of a method whose
+  #       sole parameter is a request object. Not all languages will generate
+  #       this method.
+  #   resource_name_treatment - An enum that specifies how to treat the
+  #       resource name formats defined in the field_name_patterns
+  #       and response_field_name_patterns fields.
+  #       UNSET: default value
+  #       NONE: the collection configs will not be used by the generated code.
+  #       VALIDATE: string fields will be validated by the client against the
+  #           specified resource name formats.
+  #       STATIC_TYPES: the client will use generated types for resource names.
   #   page_streaming - Specifies the configuration for paging.
   #       Describes information for generating a method which transforms a
   #       paging list RPC into a stream of resources.
@@ -7975,13 +9214,15 @@ interfaces:
     # TODO: Configure which fields are required.
     required_fields:
     - project
+    request_object_method: true
+    resource_name_treatment: STATIC_TYPES
     page_streaming:
       request:
         page_size_field: maxResults
         token_field: pageToken
       response:
         token_field: nextPageToken
-        resources_field: items
+        resources_field: CommitmentAggregatedList
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: idempotent
     # TODO: Configure the retryable params for this method.
@@ -8000,12 +9241,14 @@ interfaces:
     # TODO: Configure which fields are required.
     required_fields:
     - commitment
+    request_object_method: true
+    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      commitment: projectRegionCommitment
+      commitment: commitment
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
   - name: compute.regionCommitments.insert
@@ -8014,18 +9257,22 @@ interfaces:
     flattening:
       groups:
       - parameters:
+        - requestId
         - region
         - commitmentResource
     # TODO: Configure which fields are required.
     required_fields:
+    - requestId
     - region
     - commitmentResource
+    request_object_method: true
+    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: non_idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      region: projectRegion
+      region: region
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
   - name: compute.regionCommitments.list
@@ -8038,22 +9285,24 @@ interfaces:
     # TODO: Configure which fields are required.
     required_fields:
     - region
+    request_object_method: true
+    resource_name_treatment: STATIC_TYPES
     page_streaming:
       request:
         page_size_field: maxResults
         token_field: pageToken
       response:
         token_field: nextPageToken
-        resources_field: items
+        resources_field: CommitmentList
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      region: projectRegion
+      region: region
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
-# The fully qualified name of the API interface.
+  # The fully qualified name of the API interface.
 - name: google.compute.v1.RegionDiskTypes
   # A list of resource collection configurations.
   # Consists of a name_pattern and an entity_name.
@@ -8066,16 +9315,16 @@ interfaces:
   # The entity_name is the name to be used as a basis for generated methods and
   # classes.
   collections:
-  - name_pattern: '{project}/regions/{region}'
-    entity_name: projectRegion
-  - name_pattern: '{project}/regions/{region}/diskTypes/{diskType}'
-    entity_name: projectRegionDiskType
+  - name_pattern: projects/{project}/regions/{region}
+    entity_name: region
+  - name_pattern: projects/{project}/regions/{region}/diskTypes/{diskType}
+    entity_name: regionDiskTypesDiskType
   # Definition for retryable codes.
   retry_codes_def:
   - name: idempotent
     retry_codes:
-    - UNAVAILABLE
-    - DEADLINE_EXCEEDED
+    - SC_SERVICE_UNAVAILABLE
+    - SC_GATEWAY_TIMEOUT
   - name: non_idempotent
     retry_codes: []
   # Definition for retry/backoff parameters.
@@ -8101,6 +9350,17 @@ interfaces:
   #       message.
   #   required_fields - Fields that are always required for a request to be
   #       valid.
+  #   request_object_method - Turns on or off the generation of a method whose
+  #       sole parameter is a request object. Not all languages will generate
+  #       this method.
+  #   resource_name_treatment - An enum that specifies how to treat the
+  #       resource name formats defined in the field_name_patterns
+  #       and response_field_name_patterns fields.
+  #       UNSET: default value
+  #       NONE: the collection configs will not be used by the generated code.
+  #       VALIDATE: string fields will be validated by the client against the
+  #           specified resource name formats.
+  #       STATIC_TYPES: the client will use generated types for resource names.
   #   page_streaming - Specifies the configuration for paging.
   #       Describes information for generating a method which transforms a
   #       paging list RPC into a stream of resources.
@@ -8138,12 +9398,14 @@ interfaces:
     # TODO: Configure which fields are required.
     required_fields:
     - diskType
+    request_object_method: true
+    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      diskType: projectRegionDiskType
+      diskType: regionDiskTypesDiskType
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
   - name: compute.regionDiskTypes.list
@@ -8156,22 +9418,24 @@ interfaces:
     # TODO: Configure which fields are required.
     required_fields:
     - region
+    request_object_method: true
+    resource_name_treatment: STATIC_TYPES
     page_streaming:
       request:
         page_size_field: maxResults
         token_field: pageToken
       response:
         token_field: nextPageToken
-        resources_field: items
+        resources_field: RegionDiskTypeList
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      region: projectRegion
+      region: region
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
-# The fully qualified name of the API interface.
+  # The fully qualified name of the API interface.
 - name: google.compute.v1.RegionDisks
   # A list of resource collection configurations.
   # Consists of a name_pattern and an entity_name.
@@ -8184,18 +9448,18 @@ interfaces:
   # The entity_name is the name to be used as a basis for generated methods and
   # classes.
   collections:
-  - name_pattern: '{project}/regions/{region}'
-    entity_name: projectRegion
-  - name_pattern: '{project}/regions/{region}/disks/{disk}'
-    entity_name: projectRegionDisk
-  - name_pattern: '{project}/regions/{region}/disks/{resource}'
-    entity_name: projectRegionDiskResource
+  - name_pattern: projects/{project}/regions/{region}
+    entity_name: region
+  - name_pattern: projects/{project}/regions/{region}/disks/{disk}
+    entity_name: regionDisksDisk
+  - name_pattern: projects/{project}/regions/{region}/disks/{resource}
+    entity_name: regionDisksResource
   # Definition for retryable codes.
   retry_codes_def:
   - name: idempotent
     retry_codes:
-    - UNAVAILABLE
-    - DEADLINE_EXCEEDED
+    - SC_SERVICE_UNAVAILABLE
+    - SC_GATEWAY_TIMEOUT
   - name: non_idempotent
     retry_codes: []
   # Definition for retry/backoff parameters.
@@ -8221,6 +9485,17 @@ interfaces:
   #       message.
   #   required_fields - Fields that are always required for a request to be
   #       valid.
+  #   request_object_method - Turns on or off the generation of a method whose
+  #       sole parameter is a request object. Not all languages will generate
+  #       this method.
+  #   resource_name_treatment - An enum that specifies how to treat the
+  #       resource name formats defined in the field_name_patterns
+  #       and response_field_name_patterns fields.
+  #       UNSET: default value
+  #       NONE: the collection configs will not be used by the generated code.
+  #       VALIDATE: string fields will be validated by the client against the
+  #           specified resource name formats.
+  #       STATIC_TYPES: the client will use generated types for resource names.
   #   page_streaming - Specifies the configuration for paging.
   #       Describes information for generating a method which transforms a
   #       paging list RPC into a stream of resources.
@@ -8248,6 +9523,30 @@ interfaces:
   #   timeout_millis - Specifies the default timeout for a non-retrying call. If
   #       the call is retrying, refer to retry_params_name instead.
   methods:
+  - name: compute.regionDisks.addResourcePolicies
+    # TODO: Configure which groups of fields should be flattened into method
+    # params.
+    flattening:
+      groups:
+      - parameters:
+        - disk
+        - requestId
+        - regionDisksAddResourcePoliciesRequestResource
+    # TODO: Configure which fields are required.
+    required_fields:
+    - disk
+    - requestId
+    - regionDisksAddResourcePoliciesRequestResource
+    request_object_method: true
+    resource_name_treatment: STATIC_TYPES
+    # TODO: Configure the retryable codes for this method.
+    retry_codes_name: non_idempotent
+    # TODO: Configure the retryable params for this method.
+    retry_params_name: default
+    field_name_patterns:
+      disk: regionDisksDisk
+    # TODO: Configure the default timeout for a non-retrying call.
+    timeout_millis: 60000
   - name: compute.regionDisks.createSnapshot
     # TODO: Configure which groups of fields should be flattened into method
     # params.
@@ -8255,17 +9554,21 @@ interfaces:
       groups:
       - parameters:
         - disk
+        - requestId
         - snapshotResource
     # TODO: Configure which fields are required.
     required_fields:
     - disk
+    - requestId
     - snapshotResource
+    request_object_method: true
+    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: non_idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      disk: projectRegionDisk
+      disk: regionDisksDisk
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
   - name: compute.regionDisks.delete
@@ -8275,15 +9578,19 @@ interfaces:
       groups:
       - parameters:
         - disk
+        - requestId
     # TODO: Configure which fields are required.
     required_fields:
     - disk
+    - requestId
+    request_object_method: true
+    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      disk: projectRegionDisk
+      disk: regionDisksDisk
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
   - name: compute.regionDisks.get
@@ -8296,12 +9603,14 @@ interfaces:
     # TODO: Configure which fields are required.
     required_fields:
     - disk
+    request_object_method: true
+    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      disk: projectRegionDisk
+      disk: regionDisksDisk
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
   - name: compute.regionDisks.insert
@@ -8310,18 +9619,24 @@ interfaces:
     flattening:
       groups:
       - parameters:
+        - requestId
+        - sourceImage
         - region
         - diskResource
     # TODO: Configure which fields are required.
     required_fields:
+    - requestId
+    - sourceImage
     - region
     - diskResource
+    request_object_method: true
+    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: non_idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      region: projectRegion
+      region: region
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
   - name: compute.regionDisks.list
@@ -8334,19 +9649,45 @@ interfaces:
     # TODO: Configure which fields are required.
     required_fields:
     - region
+    request_object_method: true
+    resource_name_treatment: STATIC_TYPES
     page_streaming:
       request:
         page_size_field: maxResults
         token_field: pageToken
       response:
         token_field: nextPageToken
-        resources_field: items
+        resources_field: DiskList
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      region: projectRegion
+      region: region
+    # TODO: Configure the default timeout for a non-retrying call.
+    timeout_millis: 60000
+  - name: compute.regionDisks.removeResourcePolicies
+    # TODO: Configure which groups of fields should be flattened into method
+    # params.
+    flattening:
+      groups:
+      - parameters:
+        - disk
+        - requestId
+        - regionDisksRemoveResourcePoliciesRequestResource
+    # TODO: Configure which fields are required.
+    required_fields:
+    - disk
+    - requestId
+    - regionDisksRemoveResourcePoliciesRequestResource
+    request_object_method: true
+    resource_name_treatment: STATIC_TYPES
+    # TODO: Configure the retryable codes for this method.
+    retry_codes_name: non_idempotent
+    # TODO: Configure the retryable params for this method.
+    retry_params_name: default
+    field_name_patterns:
+      disk: regionDisksDisk
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
   - name: compute.regionDisks.resize
@@ -8356,17 +9697,21 @@ interfaces:
       groups:
       - parameters:
         - disk
+        - requestId
         - regionDisksResizeRequestResource
     # TODO: Configure which fields are required.
     required_fields:
     - disk
+    - requestId
     - regionDisksResizeRequestResource
+    request_object_method: true
+    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: non_idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      disk: projectRegionDisk
+      disk: regionDisksDisk
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
   - name: compute.regionDisks.setLabels
@@ -8376,17 +9721,21 @@ interfaces:
       groups:
       - parameters:
         - resource
+        - requestId
         - regionSetLabelsRequestResource
     # TODO: Configure which fields are required.
     required_fields:
     - resource
+    - requestId
     - regionSetLabelsRequestResource
+    request_object_method: true
+    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: non_idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      resource: projectRegionDiskResource
+      resource: regionDisksResource
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
   - name: compute.regionDisks.testIamPermissions
@@ -8401,15 +9750,17 @@ interfaces:
     required_fields:
     - resource
     - testPermissionsRequestResource
+    request_object_method: true
+    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: non_idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      resource: projectRegionDiskResource
+      resource: regionDisksResource
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
-# The fully qualified name of the API interface.
+  # The fully qualified name of the API interface.
 - name: google.compute.v1.RegionInstanceGroupManagers
   # A list of resource collection configurations.
   # Consists of a name_pattern and an entity_name.
@@ -8422,16 +9773,16 @@ interfaces:
   # The entity_name is the name to be used as a basis for generated methods and
   # classes.
   collections:
-  - name_pattern: '{project}/regions/{region}'
-    entity_name: projectRegion
-  - name_pattern: '{project}/regions/{region}/instanceGroupManagers/{instanceGroupManager}'
-    entity_name: projectRegionInstanceGroupManager
+  - name_pattern: projects/{project}/regions/{region}
+    entity_name: region
+  - name_pattern: projects/{project}/regions/{region}/instanceGroupManagers/{instanceGroupManager}
+    entity_name: regionInstanceGroupManagersInstanceGroupManager
   # Definition for retryable codes.
   retry_codes_def:
   - name: idempotent
     retry_codes:
-    - UNAVAILABLE
-    - DEADLINE_EXCEEDED
+    - SC_SERVICE_UNAVAILABLE
+    - SC_GATEWAY_TIMEOUT
   - name: non_idempotent
     retry_codes: []
   # Definition for retry/backoff parameters.
@@ -8457,6 +9808,17 @@ interfaces:
   #       message.
   #   required_fields - Fields that are always required for a request to be
   #       valid.
+  #   request_object_method - Turns on or off the generation of a method whose
+  #       sole parameter is a request object. Not all languages will generate
+  #       this method.
+  #   resource_name_treatment - An enum that specifies how to treat the
+  #       resource name formats defined in the field_name_patterns
+  #       and response_field_name_patterns fields.
+  #       UNSET: default value
+  #       NONE: the collection configs will not be used by the generated code.
+  #       VALIDATE: string fields will be validated by the client against the
+  #           specified resource name formats.
+  #       STATIC_TYPES: the client will use generated types for resource names.
   #   page_streaming - Specifies the configuration for paging.
   #       Describes information for generating a method which transforms a
   #       paging list RPC into a stream of resources.
@@ -8490,18 +9852,22 @@ interfaces:
     flattening:
       groups:
       - parameters:
+        - requestId
         - instanceGroupManager
         - regionInstanceGroupManagersAbandonInstancesRequestResource
     # TODO: Configure which fields are required.
     required_fields:
+    - requestId
     - instanceGroupManager
     - regionInstanceGroupManagersAbandonInstancesRequestResource
+    request_object_method: true
+    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: non_idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      instanceGroupManager: projectRegionInstanceGroupManager
+      instanceGroupManager: regionInstanceGroupManagersInstanceGroupManager
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
   - name: compute.regionInstanceGroupManagers.delete
@@ -8510,16 +9876,20 @@ interfaces:
     flattening:
       groups:
       - parameters:
+        - requestId
         - instanceGroupManager
     # TODO: Configure which fields are required.
     required_fields:
+    - requestId
     - instanceGroupManager
+    request_object_method: true
+    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      instanceGroupManager: projectRegionInstanceGroupManager
+      instanceGroupManager: regionInstanceGroupManagersInstanceGroupManager
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
   - name: compute.regionInstanceGroupManagers.deleteInstances
@@ -8528,18 +9898,22 @@ interfaces:
     flattening:
       groups:
       - parameters:
+        - requestId
         - instanceGroupManager
         - regionInstanceGroupManagersDeleteInstancesRequestResource
     # TODO: Configure which fields are required.
     required_fields:
+    - requestId
     - instanceGroupManager
     - regionInstanceGroupManagersDeleteInstancesRequestResource
+    request_object_method: true
+    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: non_idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      instanceGroupManager: projectRegionInstanceGroupManager
+      instanceGroupManager: regionInstanceGroupManagersInstanceGroupManager
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
   - name: compute.regionInstanceGroupManagers.get
@@ -8552,12 +9926,14 @@ interfaces:
     # TODO: Configure which fields are required.
     required_fields:
     - instanceGroupManager
+    request_object_method: true
+    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      instanceGroupManager: projectRegionInstanceGroupManager
+      instanceGroupManager: regionInstanceGroupManagersInstanceGroupManager
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
   - name: compute.regionInstanceGroupManagers.insert
@@ -8566,18 +9942,22 @@ interfaces:
     flattening:
       groups:
       - parameters:
+        - requestId
         - region
         - instanceGroupManagerResource
     # TODO: Configure which fields are required.
     required_fields:
+    - requestId
     - region
     - instanceGroupManagerResource
+    request_object_method: true
+    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: non_idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      region: projectRegion
+      region: region
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
   - name: compute.regionInstanceGroupManagers.list
@@ -8590,19 +9970,21 @@ interfaces:
     # TODO: Configure which fields are required.
     required_fields:
     - region
+    request_object_method: true
+    resource_name_treatment: STATIC_TYPES
     page_streaming:
       request:
         page_size_field: maxResults
         token_field: pageToken
       response:
         token_field: nextPageToken
-        resources_field: items
+        resources_field: RegionInstanceGroupManagerList
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      region: projectRegion
+      region: region
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
   - name: compute.regionInstanceGroupManagers.listManagedInstances
@@ -8615,12 +9997,14 @@ interfaces:
     # TODO: Configure which fields are required.
     required_fields:
     - instanceGroupManager
+    request_object_method: true
+    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: non_idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      instanceGroupManager: projectRegionInstanceGroupManager
+      instanceGroupManager: regionInstanceGroupManagersInstanceGroupManager
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
   - name: compute.regionInstanceGroupManagers.patch
@@ -8629,18 +10013,22 @@ interfaces:
     flattening:
       groups:
       - parameters:
+        - requestId
         - instanceGroupManager
         - instanceGroupManagerResource
     # TODO: Configure which fields are required.
     required_fields:
+    - requestId
     - instanceGroupManager
     - instanceGroupManagerResource
+    request_object_method: true
+    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: non_idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      instanceGroupManager: projectRegionInstanceGroupManager
+      instanceGroupManager: regionInstanceGroupManagersInstanceGroupManager
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
   - name: compute.regionInstanceGroupManagers.recreateInstances
@@ -8649,18 +10037,22 @@ interfaces:
     flattening:
       groups:
       - parameters:
+        - requestId
         - instanceGroupManager
         - regionInstanceGroupManagersRecreateRequestResource
     # TODO: Configure which fields are required.
     required_fields:
+    - requestId
     - instanceGroupManager
     - regionInstanceGroupManagersRecreateRequestResource
+    request_object_method: true
+    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: non_idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      instanceGroupManager: projectRegionInstanceGroupManager
+      instanceGroupManager: regionInstanceGroupManagersInstanceGroupManager
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
   - name: compute.regionInstanceGroupManagers.resize
@@ -8670,17 +10062,21 @@ interfaces:
       groups:
       - parameters:
         - size
+        - requestId
         - instanceGroupManager
     # TODO: Configure which fields are required.
     required_fields:
     - size
+    - requestId
     - instanceGroupManager
+    request_object_method: true
+    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: non_idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      instanceGroupManager: projectRegionInstanceGroupManager
+      instanceGroupManager: regionInstanceGroupManagersInstanceGroupManager
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
   - name: compute.regionInstanceGroupManagers.setInstanceTemplate
@@ -8689,18 +10085,22 @@ interfaces:
     flattening:
       groups:
       - parameters:
+        - requestId
         - instanceGroupManager
         - regionInstanceGroupManagersSetTemplateRequestResource
     # TODO: Configure which fields are required.
     required_fields:
+    - requestId
     - instanceGroupManager
     - regionInstanceGroupManagersSetTemplateRequestResource
+    request_object_method: true
+    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: non_idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      instanceGroupManager: projectRegionInstanceGroupManager
+      instanceGroupManager: regionInstanceGroupManagersInstanceGroupManager
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
   - name: compute.regionInstanceGroupManagers.setTargetPools
@@ -8709,21 +10109,25 @@ interfaces:
     flattening:
       groups:
       - parameters:
+        - requestId
         - instanceGroupManager
         - regionInstanceGroupManagersSetTargetPoolsRequestResource
     # TODO: Configure which fields are required.
     required_fields:
+    - requestId
     - instanceGroupManager
     - regionInstanceGroupManagersSetTargetPoolsRequestResource
+    request_object_method: true
+    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: non_idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      instanceGroupManager: projectRegionInstanceGroupManager
+      instanceGroupManager: regionInstanceGroupManagersInstanceGroupManager
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
-# The fully qualified name of the API interface.
+  # The fully qualified name of the API interface.
 - name: google.compute.v1.RegionInstanceGroups
   # A list of resource collection configurations.
   # Consists of a name_pattern and an entity_name.
@@ -8736,16 +10140,16 @@ interfaces:
   # The entity_name is the name to be used as a basis for generated methods and
   # classes.
   collections:
-  - name_pattern: '{project}/regions/{region}'
-    entity_name: projectRegion
-  - name_pattern: '{project}/regions/{region}/instanceGroups/{instanceGroup}'
-    entity_name: projectRegionInstanceGroup
+  - name_pattern: projects/{project}/regions/{region}
+    entity_name: region
+  - name_pattern: projects/{project}/regions/{region}/instanceGroups/{instanceGroup}
+    entity_name: regionInstanceGroupsInstanceGroup
   # Definition for retryable codes.
   retry_codes_def:
   - name: idempotent
     retry_codes:
-    - UNAVAILABLE
-    - DEADLINE_EXCEEDED
+    - SC_SERVICE_UNAVAILABLE
+    - SC_GATEWAY_TIMEOUT
   - name: non_idempotent
     retry_codes: []
   # Definition for retry/backoff parameters.
@@ -8771,6 +10175,17 @@ interfaces:
   #       message.
   #   required_fields - Fields that are always required for a request to be
   #       valid.
+  #   request_object_method - Turns on or off the generation of a method whose
+  #       sole parameter is a request object. Not all languages will generate
+  #       this method.
+  #   resource_name_treatment - An enum that specifies how to treat the
+  #       resource name formats defined in the field_name_patterns
+  #       and response_field_name_patterns fields.
+  #       UNSET: default value
+  #       NONE: the collection configs will not be used by the generated code.
+  #       VALIDATE: string fields will be validated by the client against the
+  #           specified resource name formats.
+  #       STATIC_TYPES: the client will use generated types for resource names.
   #   page_streaming - Specifies the configuration for paging.
   #       Describes information for generating a method which transforms a
   #       paging list RPC into a stream of resources.
@@ -8808,12 +10223,14 @@ interfaces:
     # TODO: Configure which fields are required.
     required_fields:
     - instanceGroup
+    request_object_method: true
+    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      instanceGroup: projectRegionInstanceGroup
+      instanceGroup: regionInstanceGroupsInstanceGroup
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
   - name: compute.regionInstanceGroups.list
@@ -8826,19 +10243,21 @@ interfaces:
     # TODO: Configure which fields are required.
     required_fields:
     - region
+    request_object_method: true
+    resource_name_treatment: STATIC_TYPES
     page_streaming:
       request:
         page_size_field: maxResults
         token_field: pageToken
       response:
         token_field: nextPageToken
-        resources_field: items
+        resources_field: RegionInstanceGroupList
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      region: projectRegion
+      region: region
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
   - name: compute.regionInstanceGroups.listInstances
@@ -8853,19 +10272,21 @@ interfaces:
     required_fields:
     - instanceGroup
     - regionInstanceGroupsListInstancesRequestResource
+    request_object_method: true
+    resource_name_treatment: STATIC_TYPES
     page_streaming:
       request:
         page_size_field: maxResults
         token_field: pageToken
       response:
         token_field: nextPageToken
-        resources_field: items
+        resources_field: RegionInstanceGroupsListInstances
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: non_idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      instanceGroup: projectRegionInstanceGroup
+      instanceGroup: regionInstanceGroupsInstanceGroup
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
   - name: compute.regionInstanceGroups.setNamedPorts
@@ -8874,21 +10295,25 @@ interfaces:
     flattening:
       groups:
       - parameters:
+        - requestId
         - instanceGroup
         - regionInstanceGroupsSetNamedPortsRequestResource
     # TODO: Configure which fields are required.
     required_fields:
+    - requestId
     - instanceGroup
     - regionInstanceGroupsSetNamedPortsRequestResource
+    request_object_method: true
+    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: non_idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      instanceGroup: projectRegionInstanceGroup
+      instanceGroup: regionInstanceGroupsInstanceGroup
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
-# The fully qualified name of the API interface.
+  # The fully qualified name of the API interface.
 - name: google.compute.v1.RegionOperations
   # A list of resource collection configurations.
   # Consists of a name_pattern and an entity_name.
@@ -8901,16 +10326,16 @@ interfaces:
   # The entity_name is the name to be used as a basis for generated methods and
   # classes.
   collections:
-  - name_pattern: '{project}/regions/{region}'
-    entity_name: projectRegion
-  - name_pattern: '{project}/regions/{region}/operations/{operation}'
-    entity_name: projectRegionOperation
+  - name_pattern: projects/{project}/regions/{region}
+    entity_name: region
+  - name_pattern: projects/{project}/regions/{region}/operations/{operation}
+    entity_name: regionOperationsOperation
   # Definition for retryable codes.
   retry_codes_def:
   - name: idempotent
     retry_codes:
-    - UNAVAILABLE
-    - DEADLINE_EXCEEDED
+    - SC_SERVICE_UNAVAILABLE
+    - SC_GATEWAY_TIMEOUT
   - name: non_idempotent
     retry_codes: []
   # Definition for retry/backoff parameters.
@@ -8936,6 +10361,17 @@ interfaces:
   #       message.
   #   required_fields - Fields that are always required for a request to be
   #       valid.
+  #   request_object_method - Turns on or off the generation of a method whose
+  #       sole parameter is a request object. Not all languages will generate
+  #       this method.
+  #   resource_name_treatment - An enum that specifies how to treat the
+  #       resource name formats defined in the field_name_patterns
+  #       and response_field_name_patterns fields.
+  #       UNSET: default value
+  #       NONE: the collection configs will not be used by the generated code.
+  #       VALIDATE: string fields will be validated by the client against the
+  #           specified resource name formats.
+  #       STATIC_TYPES: the client will use generated types for resource names.
   #   page_streaming - Specifies the configuration for paging.
   #       Describes information for generating a method which transforms a
   #       paging list RPC into a stream of resources.
@@ -8973,12 +10409,14 @@ interfaces:
     # TODO: Configure which fields are required.
     required_fields:
     - operation
+    request_object_method: true
+    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      operation: projectRegionOperation
+      operation: regionOperationsOperation
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
   - name: compute.regionOperations.get
@@ -8991,12 +10429,14 @@ interfaces:
     # TODO: Configure which fields are required.
     required_fields:
     - operation
+    request_object_method: true
+    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      operation: projectRegionOperation
+      operation: regionOperationsOperation
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
   - name: compute.regionOperations.list
@@ -9009,22 +10449,24 @@ interfaces:
     # TODO: Configure which fields are required.
     required_fields:
     - region
+    request_object_method: true
+    resource_name_treatment: STATIC_TYPES
     page_streaming:
       request:
         page_size_field: maxResults
         token_field: pageToken
       response:
         token_field: nextPageToken
-        resources_field: items
+        resources_field: OperationList
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      region: projectRegion
+      region: region
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
-# The fully qualified name of the API interface.
+  # The fully qualified name of the API interface.
 - name: google.compute.v1.Regions
   # A list of resource collection configurations.
   # Consists of a name_pattern and an entity_name.
@@ -9037,16 +10479,16 @@ interfaces:
   # The entity_name is the name to be used as a basis for generated methods and
   # classes.
   collections:
-  - name_pattern: '{project}'
+  - name_pattern: projects/{project}
     entity_name: project
-  - name_pattern: '{project}/regions/{region}'
-    entity_name: projectRegion
+  - name_pattern: projects/{project}/regions/{region}
+    entity_name: region
   # Definition for retryable codes.
   retry_codes_def:
   - name: idempotent
     retry_codes:
-    - UNAVAILABLE
-    - DEADLINE_EXCEEDED
+    - SC_SERVICE_UNAVAILABLE
+    - SC_GATEWAY_TIMEOUT
   - name: non_idempotent
     retry_codes: []
   # Definition for retry/backoff parameters.
@@ -9072,6 +10514,17 @@ interfaces:
   #       message.
   #   required_fields - Fields that are always required for a request to be
   #       valid.
+  #   request_object_method - Turns on or off the generation of a method whose
+  #       sole parameter is a request object. Not all languages will generate
+  #       this method.
+  #   resource_name_treatment - An enum that specifies how to treat the
+  #       resource name formats defined in the field_name_patterns
+  #       and response_field_name_patterns fields.
+  #       UNSET: default value
+  #       NONE: the collection configs will not be used by the generated code.
+  #       VALIDATE: string fields will be validated by the client against the
+  #           specified resource name formats.
+  #       STATIC_TYPES: the client will use generated types for resource names.
   #   page_streaming - Specifies the configuration for paging.
   #       Describes information for generating a method which transforms a
   #       paging list RPC into a stream of resources.
@@ -9109,12 +10562,14 @@ interfaces:
     # TODO: Configure which fields are required.
     required_fields:
     - region
+    request_object_method: true
+    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      region: projectRegion
+      region: region
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
   - name: compute.regions.list
@@ -9127,13 +10582,15 @@ interfaces:
     # TODO: Configure which fields are required.
     required_fields:
     - project
+    request_object_method: true
+    resource_name_treatment: STATIC_TYPES
     page_streaming:
       request:
         page_size_field: maxResults
         token_field: pageToken
       response:
         token_field: nextPageToken
-        resources_field: items
+        resources_field: RegionList
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: idempotent
     # TODO: Configure the retryable params for this method.
@@ -9142,8 +10599,8 @@ interfaces:
       project: project
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
-# The fully qualified name of the API interface.
-- name: google.compute.v1.Routers
+  # The fully qualified name of the API interface.
+- name: google.compute.v1.Reservations
   # A list of resource collection configurations.
   # Consists of a name_pattern and an entity_name.
   # The name_pattern is a pattern to describe the names of the resources of this
@@ -9155,18 +10612,20 @@ interfaces:
   # The entity_name is the name to be used as a basis for generated methods and
   # classes.
   collections:
-  - name_pattern: '{project}'
+  - name_pattern: projects/{project}
     entity_name: project
-  - name_pattern: '{project}/regions/{region}'
-    entity_name: projectRegion
-  - name_pattern: '{project}/regions/{region}/routers/{router}'
-    entity_name: projectRegionRouter
+  - name_pattern: projects/{project}/zones/{zone}
+    entity_name: zone
+  - name_pattern: projects/{project}/zones/{zone}/reservations/{reservation}
+    entity_name: reservation
+  - name_pattern: projects/{project}/zones/{zone}/reservations/{resource}
+    entity_name: reservationsResource
   # Definition for retryable codes.
   retry_codes_def:
   - name: idempotent
     retry_codes:
-    - UNAVAILABLE
-    - DEADLINE_EXCEEDED
+    - SC_SERVICE_UNAVAILABLE
+    - SC_GATEWAY_TIMEOUT
   - name: non_idempotent
     retry_codes: []
   # Definition for retry/backoff parameters.
@@ -9192,6 +10651,587 @@ interfaces:
   #       message.
   #   required_fields - Fields that are always required for a request to be
   #       valid.
+  #   request_object_method - Turns on or off the generation of a method whose
+  #       sole parameter is a request object. Not all languages will generate
+  #       this method.
+  #   resource_name_treatment - An enum that specifies how to treat the
+  #       resource name formats defined in the field_name_patterns
+  #       and response_field_name_patterns fields.
+  #       UNSET: default value
+  #       NONE: the collection configs will not be used by the generated code.
+  #       VALIDATE: string fields will be validated by the client against the
+  #           specified resource name formats.
+  #       STATIC_TYPES: the client will use generated types for resource names.
+  #   page_streaming - Specifies the configuration for paging.
+  #       Describes information for generating a method which transforms a
+  #       paging list RPC into a stream of resources.
+  #       Consists of a request and a response.
+  #       The request specifies request information of the list method. It
+  #       defines which fields match the paging pattern in the request. The
+  #       request consists of a page_size_field and a token_field. The
+  #       page_size_field is the name of the optional field specifying the
+  #       maximum number of elements to be returned in the response. The
+  #       token_field is the name of the field in the request containing the
+  #       page token.
+  #       The response specifies response information of the list method. It
+  #       defines which fields match the paging pattern in the response. The
+  #       response consists of a token_field and a resources_field. The
+  #       token_field is the name of the field in the response containing the
+  #       next page token. The resources_field is the name of the field in the
+  #       response containing the list of resources belonging to the page.
+  #   retry_codes_name - Specifies the configuration for retryable codes. The
+  #       name must be defined in interfaces.retry_codes_def.
+  #   retry_params_name - Specifies the configuration for retry/backoff
+  #       parameters. The name must be defined in interfaces.retry_params_def.
+  #   field_name_patterns - Maps the field name of the request type to
+  #       entity_name of interfaces.collections.
+  #       Specifies the string pattern that the field must follow.
+  #   timeout_millis - Specifies the default timeout for a non-retrying call. If
+  #       the call is retrying, refer to retry_params_name instead.
+  methods:
+  - name: compute.reservations.aggregatedList
+    # TODO: Configure which groups of fields should be flattened into method
+    # params.
+    flattening:
+      groups:
+      - parameters:
+        - project
+    # TODO: Configure which fields are required.
+    required_fields:
+    - project
+    request_object_method: true
+    resource_name_treatment: STATIC_TYPES
+    page_streaming:
+      request:
+        page_size_field: maxResults
+        token_field: pageToken
+      response:
+        token_field: nextPageToken
+        resources_field: ReservationAggregatedList
+    # TODO: Configure the retryable codes for this method.
+    retry_codes_name: idempotent
+    # TODO: Configure the retryable params for this method.
+    retry_params_name: default
+    field_name_patterns:
+      project: project
+    # TODO: Configure the default timeout for a non-retrying call.
+    timeout_millis: 60000
+  - name: compute.reservations.delete
+    # TODO: Configure which groups of fields should be flattened into method
+    # params.
+    flattening:
+      groups:
+      - parameters:
+        - requestId
+        - reservation
+    # TODO: Configure which fields are required.
+    required_fields:
+    - requestId
+    - reservation
+    request_object_method: true
+    resource_name_treatment: STATIC_TYPES
+    # TODO: Configure the retryable codes for this method.
+    retry_codes_name: idempotent
+    # TODO: Configure the retryable params for this method.
+    retry_params_name: default
+    field_name_patterns:
+      reservation: reservation
+    # TODO: Configure the default timeout for a non-retrying call.
+    timeout_millis: 60000
+  - name: compute.reservations.get
+    # TODO: Configure which groups of fields should be flattened into method
+    # params.
+    flattening:
+      groups:
+      - parameters:
+        - reservation
+    # TODO: Configure which fields are required.
+    required_fields:
+    - reservation
+    request_object_method: true
+    resource_name_treatment: STATIC_TYPES
+    # TODO: Configure the retryable codes for this method.
+    retry_codes_name: idempotent
+    # TODO: Configure the retryable params for this method.
+    retry_params_name: default
+    field_name_patterns:
+      reservation: reservation
+    # TODO: Configure the default timeout for a non-retrying call.
+    timeout_millis: 60000
+  - name: compute.reservations.getIamPolicy
+    # TODO: Configure which groups of fields should be flattened into method
+    # params.
+    flattening:
+      groups:
+      - parameters:
+        - resource
+    # TODO: Configure which fields are required.
+    required_fields:
+    - resource
+    request_object_method: true
+    resource_name_treatment: STATIC_TYPES
+    # TODO: Configure the retryable codes for this method.
+    retry_codes_name: idempotent
+    # TODO: Configure the retryable params for this method.
+    retry_params_name: default
+    field_name_patterns:
+      resource: reservationsResource
+    # TODO: Configure the default timeout for a non-retrying call.
+    timeout_millis: 60000
+  - name: compute.reservations.insert
+    # TODO: Configure which groups of fields should be flattened into method
+    # params.
+    flattening:
+      groups:
+      - parameters:
+        - zone
+        - requestId
+        - reservationResource
+    # TODO: Configure which fields are required.
+    required_fields:
+    - zone
+    - requestId
+    - reservationResource
+    request_object_method: true
+    resource_name_treatment: STATIC_TYPES
+    # TODO: Configure the retryable codes for this method.
+    retry_codes_name: non_idempotent
+    # TODO: Configure the retryable params for this method.
+    retry_params_name: default
+    field_name_patterns:
+      zone: zone
+    # TODO: Configure the default timeout for a non-retrying call.
+    timeout_millis: 60000
+  - name: compute.reservations.list
+    # TODO: Configure which groups of fields should be flattened into method
+    # params.
+    flattening:
+      groups:
+      - parameters:
+        - zone
+    # TODO: Configure which fields are required.
+    required_fields:
+    - zone
+    request_object_method: true
+    resource_name_treatment: STATIC_TYPES
+    page_streaming:
+      request:
+        page_size_field: maxResults
+        token_field: pageToken
+      response:
+        token_field: nextPageToken
+        resources_field: ReservationList
+    # TODO: Configure the retryable codes for this method.
+    retry_codes_name: idempotent
+    # TODO: Configure the retryable params for this method.
+    retry_params_name: default
+    field_name_patterns:
+      zone: zone
+    # TODO: Configure the default timeout for a non-retrying call.
+    timeout_millis: 60000
+  - name: compute.reservations.resize
+    # TODO: Configure which groups of fields should be flattened into method
+    # params.
+    flattening:
+      groups:
+      - parameters:
+        - requestId
+        - reservation
+        - reservationsResizeRequestResource
+    # TODO: Configure which fields are required.
+    required_fields:
+    - requestId
+    - reservation
+    - reservationsResizeRequestResource
+    request_object_method: true
+    resource_name_treatment: STATIC_TYPES
+    # TODO: Configure the retryable codes for this method.
+    retry_codes_name: non_idempotent
+    # TODO: Configure the retryable params for this method.
+    retry_params_name: default
+    field_name_patterns:
+      reservation: reservation
+    # TODO: Configure the default timeout for a non-retrying call.
+    timeout_millis: 60000
+  - name: compute.reservations.setIamPolicy
+    # TODO: Configure which groups of fields should be flattened into method
+    # params.
+    flattening:
+      groups:
+      - parameters:
+        - resource
+        - zoneSetPolicyRequestResource
+    # TODO: Configure which fields are required.
+    required_fields:
+    - resource
+    - zoneSetPolicyRequestResource
+    request_object_method: true
+    resource_name_treatment: STATIC_TYPES
+    # TODO: Configure the retryable codes for this method.
+    retry_codes_name: non_idempotent
+    # TODO: Configure the retryable params for this method.
+    retry_params_name: default
+    field_name_patterns:
+      resource: reservationsResource
+    # TODO: Configure the default timeout for a non-retrying call.
+    timeout_millis: 60000
+  - name: compute.reservations.testIamPermissions
+    # TODO: Configure which groups of fields should be flattened into method
+    # params.
+    flattening:
+      groups:
+      - parameters:
+        - resource
+        - testPermissionsRequestResource
+    # TODO: Configure which fields are required.
+    required_fields:
+    - resource
+    - testPermissionsRequestResource
+    request_object_method: true
+    resource_name_treatment: STATIC_TYPES
+    # TODO: Configure the retryable codes for this method.
+    retry_codes_name: non_idempotent
+    # TODO: Configure the retryable params for this method.
+    retry_params_name: default
+    field_name_patterns:
+      resource: reservationsResource
+    # TODO: Configure the default timeout for a non-retrying call.
+    timeout_millis: 60000
+  # The fully qualified name of the API interface.
+- name: google.compute.v1.ResourcePolicies
+  # A list of resource collection configurations.
+  # Consists of a name_pattern and an entity_name.
+  # The name_pattern is a pattern to describe the names of the resources of this
+  # collection, using the platform's conventions for URI patterns. A generator
+  # may use this to generate methods to compose and decompose such names. The
+  # pattern should use named placeholders as in `shelves/{shelf}/books/{book}`;
+  # those will be taken as hints for the parameter names of the generated
+  # methods. If empty, no name methods are generated.
+  # The entity_name is the name to be used as a basis for generated methods and
+  # classes.
+  collections:
+  - name_pattern: projects/{project}
+    entity_name: project
+  - name_pattern: projects/{project}/regions/{region}
+    entity_name: region
+  - name_pattern: projects/{project}/regions/{region}/resourcePolicies/{resourcePolicy}
+    entity_name: resourcePolicy
+  - name_pattern: projects/{project}/regions/{region}/resourcePolicies/{resource}
+    entity_name: resourcePoliciesResource
+  # Definition for retryable codes.
+  retry_codes_def:
+  - name: idempotent
+    retry_codes:
+    - SC_SERVICE_UNAVAILABLE
+    - SC_GATEWAY_TIMEOUT
+  - name: non_idempotent
+    retry_codes: []
+  # Definition for retry/backoff parameters.
+  retry_params_def:
+  - name: default
+    initial_retry_delay_millis: 100
+    retry_delay_multiplier: 1.3
+    max_retry_delay_millis: 60000
+    initial_rpc_timeout_millis: 20000
+    rpc_timeout_multiplier: 1
+    max_rpc_timeout_millis: 20000
+    total_timeout_millis: 600000
+  # A list of method configurations.
+  # Common properties:
+  #   name - The simple name of the method.
+  #   flattening - Specifies the configuration for parameter flattening.
+  #       Describes the parameter groups for which a generator should produce
+  #       method overloads which allow a client to directly pass request message
+  #       fields as method parameters. This information may or may not be used,
+  #       depending on the target language.
+  #       Consists of groups, which each represent a list of parameters to be
+  #       flattened. Each parameter listed must be a field of the request
+  #       message.
+  #   required_fields - Fields that are always required for a request to be
+  #       valid.
+  #   request_object_method - Turns on or off the generation of a method whose
+  #       sole parameter is a request object. Not all languages will generate
+  #       this method.
+  #   resource_name_treatment - An enum that specifies how to treat the
+  #       resource name formats defined in the field_name_patterns
+  #       and response_field_name_patterns fields.
+  #       UNSET: default value
+  #       NONE: the collection configs will not be used by the generated code.
+  #       VALIDATE: string fields will be validated by the client against the
+  #           specified resource name formats.
+  #       STATIC_TYPES: the client will use generated types for resource names.
+  #   page_streaming - Specifies the configuration for paging.
+  #       Describes information for generating a method which transforms a
+  #       paging list RPC into a stream of resources.
+  #       Consists of a request and a response.
+  #       The request specifies request information of the list method. It
+  #       defines which fields match the paging pattern in the request. The
+  #       request consists of a page_size_field and a token_field. The
+  #       page_size_field is the name of the optional field specifying the
+  #       maximum number of elements to be returned in the response. The
+  #       token_field is the name of the field in the request containing the
+  #       page token.
+  #       The response specifies response information of the list method. It
+  #       defines which fields match the paging pattern in the response. The
+  #       response consists of a token_field and a resources_field. The
+  #       token_field is the name of the field in the response containing the
+  #       next page token. The resources_field is the name of the field in the
+  #       response containing the list of resources belonging to the page.
+  #   retry_codes_name - Specifies the configuration for retryable codes. The
+  #       name must be defined in interfaces.retry_codes_def.
+  #   retry_params_name - Specifies the configuration for retry/backoff
+  #       parameters. The name must be defined in interfaces.retry_params_def.
+  #   field_name_patterns - Maps the field name of the request type to
+  #       entity_name of interfaces.collections.
+  #       Specifies the string pattern that the field must follow.
+  #   timeout_millis - Specifies the default timeout for a non-retrying call. If
+  #       the call is retrying, refer to retry_params_name instead.
+  methods:
+  - name: compute.resourcePolicies.aggregatedList
+    # TODO: Configure which groups of fields should be flattened into method
+    # params.
+    flattening:
+      groups:
+      - parameters:
+        - project
+    # TODO: Configure which fields are required.
+    required_fields:
+    - project
+    request_object_method: true
+    resource_name_treatment: STATIC_TYPES
+    page_streaming:
+      request:
+        page_size_field: maxResults
+        token_field: pageToken
+      response:
+        token_field: nextPageToken
+        resources_field: ResourcePolicyAggregatedList
+    # TODO: Configure the retryable codes for this method.
+    retry_codes_name: idempotent
+    # TODO: Configure the retryable params for this method.
+    retry_params_name: default
+    field_name_patterns:
+      project: project
+    # TODO: Configure the default timeout for a non-retrying call.
+    timeout_millis: 60000
+  - name: compute.resourcePolicies.delete
+    # TODO: Configure which groups of fields should be flattened into method
+    # params.
+    flattening:
+      groups:
+      - parameters:
+        - resourcePolicy
+        - requestId
+    # TODO: Configure which fields are required.
+    required_fields:
+    - resourcePolicy
+    - requestId
+    request_object_method: true
+    resource_name_treatment: STATIC_TYPES
+    # TODO: Configure the retryable codes for this method.
+    retry_codes_name: idempotent
+    # TODO: Configure the retryable params for this method.
+    retry_params_name: default
+    field_name_patterns:
+      resourcePolicy: resourcePolicy
+    # TODO: Configure the default timeout for a non-retrying call.
+    timeout_millis: 60000
+  - name: compute.resourcePolicies.get
+    # TODO: Configure which groups of fields should be flattened into method
+    # params.
+    flattening:
+      groups:
+      - parameters:
+        - resourcePolicy
+    # TODO: Configure which fields are required.
+    required_fields:
+    - resourcePolicy
+    request_object_method: true
+    resource_name_treatment: STATIC_TYPES
+    # TODO: Configure the retryable codes for this method.
+    retry_codes_name: idempotent
+    # TODO: Configure the retryable params for this method.
+    retry_params_name: default
+    field_name_patterns:
+      resourcePolicy: resourcePolicy
+    # TODO: Configure the default timeout for a non-retrying call.
+    timeout_millis: 60000
+  - name: compute.resourcePolicies.getIamPolicy
+    # TODO: Configure which groups of fields should be flattened into method
+    # params.
+    flattening:
+      groups:
+      - parameters:
+        - resource
+    # TODO: Configure which fields are required.
+    required_fields:
+    - resource
+    request_object_method: true
+    resource_name_treatment: STATIC_TYPES
+    # TODO: Configure the retryable codes for this method.
+    retry_codes_name: idempotent
+    # TODO: Configure the retryable params for this method.
+    retry_params_name: default
+    field_name_patterns:
+      resource: resourcePoliciesResource
+    # TODO: Configure the default timeout for a non-retrying call.
+    timeout_millis: 60000
+  - name: compute.resourcePolicies.insert
+    # TODO: Configure which groups of fields should be flattened into method
+    # params.
+    flattening:
+      groups:
+      - parameters:
+        - requestId
+        - region
+        - resourcePolicyResource
+    # TODO: Configure which fields are required.
+    required_fields:
+    - requestId
+    - region
+    - resourcePolicyResource
+    request_object_method: true
+    resource_name_treatment: STATIC_TYPES
+    # TODO: Configure the retryable codes for this method.
+    retry_codes_name: non_idempotent
+    # TODO: Configure the retryable params for this method.
+    retry_params_name: default
+    field_name_patterns:
+      region: region
+    # TODO: Configure the default timeout for a non-retrying call.
+    timeout_millis: 60000
+  - name: compute.resourcePolicies.list
+    # TODO: Configure which groups of fields should be flattened into method
+    # params.
+    flattening:
+      groups:
+      - parameters:
+        - region
+    # TODO: Configure which fields are required.
+    required_fields:
+    - region
+    request_object_method: true
+    resource_name_treatment: STATIC_TYPES
+    page_streaming:
+      request:
+        page_size_field: maxResults
+        token_field: pageToken
+      response:
+        token_field: nextPageToken
+        resources_field: ResourcePolicyList
+    # TODO: Configure the retryable codes for this method.
+    retry_codes_name: idempotent
+    # TODO: Configure the retryable params for this method.
+    retry_params_name: default
+    field_name_patterns:
+      region: region
+    # TODO: Configure the default timeout for a non-retrying call.
+    timeout_millis: 60000
+  - name: compute.resourcePolicies.setIamPolicy
+    # TODO: Configure which groups of fields should be flattened into method
+    # params.
+    flattening:
+      groups:
+      - parameters:
+        - resource
+        - regionSetPolicyRequestResource
+    # TODO: Configure which fields are required.
+    required_fields:
+    - resource
+    - regionSetPolicyRequestResource
+    request_object_method: true
+    resource_name_treatment: STATIC_TYPES
+    # TODO: Configure the retryable codes for this method.
+    retry_codes_name: non_idempotent
+    # TODO: Configure the retryable params for this method.
+    retry_params_name: default
+    field_name_patterns:
+      resource: resourcePoliciesResource
+    # TODO: Configure the default timeout for a non-retrying call.
+    timeout_millis: 60000
+  - name: compute.resourcePolicies.testIamPermissions
+    # TODO: Configure which groups of fields should be flattened into method
+    # params.
+    flattening:
+      groups:
+      - parameters:
+        - resource
+        - testPermissionsRequestResource
+    # TODO: Configure which fields are required.
+    required_fields:
+    - resource
+    - testPermissionsRequestResource
+    request_object_method: true
+    resource_name_treatment: STATIC_TYPES
+    # TODO: Configure the retryable codes for this method.
+    retry_codes_name: non_idempotent
+    # TODO: Configure the retryable params for this method.
+    retry_params_name: default
+    field_name_patterns:
+      resource: resourcePoliciesResource
+    # TODO: Configure the default timeout for a non-retrying call.
+    timeout_millis: 60000
+  # The fully qualified name of the API interface.
+- name: google.compute.v1.Routers
+  # A list of resource collection configurations.
+  # Consists of a name_pattern and an entity_name.
+  # The name_pattern is a pattern to describe the names of the resources of this
+  # collection, using the platform's conventions for URI patterns. A generator
+  # may use this to generate methods to compose and decompose such names. The
+  # pattern should use named placeholders as in `shelves/{shelf}/books/{book}`;
+  # those will be taken as hints for the parameter names of the generated
+  # methods. If empty, no name methods are generated.
+  # The entity_name is the name to be used as a basis for generated methods and
+  # classes.
+  collections:
+  - name_pattern: projects/{project}
+    entity_name: project
+  - name_pattern: projects/{project}/regions/{region}
+    entity_name: region
+  - name_pattern: projects/{project}/regions/{region}/routers/{router}
+    entity_name: router
+  # Definition for retryable codes.
+  retry_codes_def:
+  - name: idempotent
+    retry_codes:
+    - SC_SERVICE_UNAVAILABLE
+    - SC_GATEWAY_TIMEOUT
+  - name: non_idempotent
+    retry_codes: []
+  # Definition for retry/backoff parameters.
+  retry_params_def:
+  - name: default
+    initial_retry_delay_millis: 100
+    retry_delay_multiplier: 1.3
+    max_retry_delay_millis: 60000
+    initial_rpc_timeout_millis: 20000
+    rpc_timeout_multiplier: 1
+    max_rpc_timeout_millis: 20000
+    total_timeout_millis: 600000
+  # A list of method configurations.
+  # Common properties:
+  #   name - The simple name of the method.
+  #   flattening - Specifies the configuration for parameter flattening.
+  #       Describes the parameter groups for which a generator should produce
+  #       method overloads which allow a client to directly pass request message
+  #       fields as method parameters. This information may or may not be used,
+  #       depending on the target language.
+  #       Consists of groups, which each represent a list of parameters to be
+  #       flattened. Each parameter listed must be a field of the request
+  #       message.
+  #   required_fields - Fields that are always required for a request to be
+  #       valid.
+  #   request_object_method - Turns on or off the generation of a method whose
+  #       sole parameter is a request object. Not all languages will generate
+  #       this method.
+  #   resource_name_treatment - An enum that specifies how to treat the
+  #       resource name formats defined in the field_name_patterns
+  #       and response_field_name_patterns fields.
+  #       UNSET: default value
+  #       NONE: the collection configs will not be used by the generated code.
+  #       VALIDATE: string fields will be validated by the client against the
+  #           specified resource name formats.
+  #       STATIC_TYPES: the client will use generated types for resource names.
   #   page_streaming - Specifies the configuration for paging.
   #       Describes information for generating a method which transforms a
   #       paging list RPC into a stream of resources.
@@ -9229,13 +11269,15 @@ interfaces:
     # TODO: Configure which fields are required.
     required_fields:
     - project
+    request_object_method: true
+    resource_name_treatment: STATIC_TYPES
     page_streaming:
       request:
         page_size_field: maxResults
         token_field: pageToken
       response:
         token_field: nextPageToken
-        resources_field: items
+        resources_field: RouterAggregatedList
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: idempotent
     # TODO: Configure the retryable params for this method.
@@ -9251,15 +11293,19 @@ interfaces:
       groups:
       - parameters:
         - router
+        - requestId
     # TODO: Configure which fields are required.
     required_fields:
     - router
+    - requestId
+    request_object_method: true
+    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      router: projectRegionRouter
+      router: router
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
   - name: compute.routers.get
@@ -9272,12 +11318,14 @@ interfaces:
     # TODO: Configure which fields are required.
     required_fields:
     - router
+    request_object_method: true
+    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      router: projectRegionRouter
+      router: router
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
   - name: compute.routers.getNatMappingInfo
@@ -9290,19 +11338,21 @@ interfaces:
     # TODO: Configure which fields are required.
     required_fields:
     - router
+    request_object_method: true
+    resource_name_treatment: STATIC_TYPES
     page_streaming:
       request:
         page_size_field: maxResults
         token_field: pageToken
       response:
         token_field: nextPageToken
-        resources_field: result
+        resources_field: VmEndpointNatMappingsList
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      router: projectRegionRouter
+      router: router
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
   - name: compute.routers.getRouterStatus
@@ -9315,12 +11365,14 @@ interfaces:
     # TODO: Configure which fields are required.
     required_fields:
     - router
+    request_object_method: true
+    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      router: projectRegionRouter
+      router: router
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
   - name: compute.routers.insert
@@ -9329,18 +11381,22 @@ interfaces:
     flattening:
       groups:
       - parameters:
+        - requestId
         - region
         - routerResource
     # TODO: Configure which fields are required.
     required_fields:
+    - requestId
     - region
     - routerResource
+    request_object_method: true
+    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: non_idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      region: projectRegion
+      region: region
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
   - name: compute.routers.list
@@ -9353,19 +11409,21 @@ interfaces:
     # TODO: Configure which fields are required.
     required_fields:
     - region
+    request_object_method: true
+    resource_name_treatment: STATIC_TYPES
     page_streaming:
       request:
         page_size_field: maxResults
         token_field: pageToken
       response:
         token_field: nextPageToken
-        resources_field: items
+        resources_field: RouterList
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      region: projectRegion
+      region: region
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
   - name: compute.routers.patch
@@ -9375,17 +11433,21 @@ interfaces:
       groups:
       - parameters:
         - router
+        - requestId
         - routerResource
     # TODO: Configure which fields are required.
     required_fields:
     - router
+    - requestId
     - routerResource
+    request_object_method: true
+    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: non_idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      router: projectRegionRouter
+      router: router
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
   - name: compute.routers.preview
@@ -9400,12 +11462,14 @@ interfaces:
     required_fields:
     - router
     - routerResource
+    request_object_method: true
+    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: non_idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      router: projectRegionRouter
+      router: router
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
   - name: compute.routers.update
@@ -9415,20 +11479,24 @@ interfaces:
       groups:
       - parameters:
         - router
+        - requestId
         - routerResource
     # TODO: Configure which fields are required.
     required_fields:
     - router
+    - requestId
     - routerResource
+    request_object_method: true
+    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      router: projectRegionRouter
+      router: router
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
-# The fully qualified name of the API interface.
+  # The fully qualified name of the API interface.
 - name: google.compute.v1.Routes
   # A list of resource collection configurations.
   # Consists of a name_pattern and an entity_name.
@@ -9441,16 +11509,16 @@ interfaces:
   # The entity_name is the name to be used as a basis for generated methods and
   # classes.
   collections:
-  - name_pattern: '{project}'
+  - name_pattern: projects/{project}
     entity_name: project
-  - name_pattern: '{project}/global/routes/{route}'
-    entity_name: projectGlobalRoute
+  - name_pattern: projects/{project}/routes/{route}
+    entity_name: route
   # Definition for retryable codes.
   retry_codes_def:
   - name: idempotent
     retry_codes:
-    - UNAVAILABLE
-    - DEADLINE_EXCEEDED
+    - SC_SERVICE_UNAVAILABLE
+    - SC_GATEWAY_TIMEOUT
   - name: non_idempotent
     retry_codes: []
   # Definition for retry/backoff parameters.
@@ -9476,6 +11544,17 @@ interfaces:
   #       message.
   #   required_fields - Fields that are always required for a request to be
   #       valid.
+  #   request_object_method - Turns on or off the generation of a method whose
+  #       sole parameter is a request object. Not all languages will generate
+  #       this method.
+  #   resource_name_treatment - An enum that specifies how to treat the
+  #       resource name formats defined in the field_name_patterns
+  #       and response_field_name_patterns fields.
+  #       UNSET: default value
+  #       NONE: the collection configs will not be used by the generated code.
+  #       VALIDATE: string fields will be validated by the client against the
+  #           specified resource name formats.
+  #       STATIC_TYPES: the client will use generated types for resource names.
   #   page_streaming - Specifies the configuration for paging.
   #       Describes information for generating a method which transforms a
   #       paging list RPC into a stream of resources.
@@ -9510,15 +11589,19 @@ interfaces:
       groups:
       - parameters:
         - route
+        - requestId
     # TODO: Configure which fields are required.
     required_fields:
     - route
+    - requestId
+    request_object_method: true
+    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      route: projectGlobalRoute
+      route: route
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
   - name: compute.routes.get
@@ -9531,12 +11614,14 @@ interfaces:
     # TODO: Configure which fields are required.
     required_fields:
     - route
+    request_object_method: true
+    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      route: projectGlobalRoute
+      route: route
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
   - name: compute.routes.insert
@@ -9545,12 +11630,16 @@ interfaces:
     flattening:
       groups:
       - parameters:
+        - requestId
         - project
         - routeResource
     # TODO: Configure which fields are required.
     required_fields:
+    - requestId
     - project
     - routeResource
+    request_object_method: true
+    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: non_idempotent
     # TODO: Configure the retryable params for this method.
@@ -9569,13 +11658,15 @@ interfaces:
     # TODO: Configure which fields are required.
     required_fields:
     - project
+    request_object_method: true
+    resource_name_treatment: STATIC_TYPES
     page_streaming:
       request:
         page_size_field: maxResults
         token_field: pageToken
       response:
         token_field: nextPageToken
-        resources_field: items
+        resources_field: RouteList
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: idempotent
     # TODO: Configure the retryable params for this method.
@@ -9584,7 +11675,7 @@ interfaces:
       project: project
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
-# The fully qualified name of the API interface.
+  # The fully qualified name of the API interface.
 - name: google.compute.v1.SecurityPolicies
   # A list of resource collection configurations.
   # Consists of a name_pattern and an entity_name.
@@ -9597,16 +11688,16 @@ interfaces:
   # The entity_name is the name to be used as a basis for generated methods and
   # classes.
   collections:
-  - name_pattern: '{project}'
+  - name_pattern: projects/{project}
     entity_name: project
-  - name_pattern: '{project}/global/securityPolicies/{securityPolicy}'
-    entity_name: projectGlobalSecurityPolicy
+  - name_pattern: projects/{project}/securityPolicies/{securityPolicy}
+    entity_name: securityPolicy
   # Definition for retryable codes.
   retry_codes_def:
   - name: idempotent
     retry_codes:
-    - UNAVAILABLE
-    - DEADLINE_EXCEEDED
+    - SC_SERVICE_UNAVAILABLE
+    - SC_GATEWAY_TIMEOUT
   - name: non_idempotent
     retry_codes: []
   # Definition for retry/backoff parameters.
@@ -9632,6 +11723,17 @@ interfaces:
   #       message.
   #   required_fields - Fields that are always required for a request to be
   #       valid.
+  #   request_object_method - Turns on or off the generation of a method whose
+  #       sole parameter is a request object. Not all languages will generate
+  #       this method.
+  #   resource_name_treatment - An enum that specifies how to treat the
+  #       resource name formats defined in the field_name_patterns
+  #       and response_field_name_patterns fields.
+  #       UNSET: default value
+  #       NONE: the collection configs will not be used by the generated code.
+  #       VALIDATE: string fields will be validated by the client against the
+  #           specified resource name formats.
+  #       STATIC_TYPES: the client will use generated types for resource names.
   #   page_streaming - Specifies the configuration for paging.
   #       Describes information for generating a method which transforms a
   #       paging list RPC into a stream of resources.
@@ -9671,12 +11773,14 @@ interfaces:
     required_fields:
     - securityPolicy
     - securityPolicyRuleResource
+    request_object_method: true
+    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: non_idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      securityPolicy: projectGlobalSecurityPolicy
+      securityPolicy: securityPolicy
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
   - name: compute.securityPolicies.delete
@@ -9685,16 +11789,20 @@ interfaces:
     flattening:
       groups:
       - parameters:
+        - requestId
         - securityPolicy
     # TODO: Configure which fields are required.
     required_fields:
+    - requestId
     - securityPolicy
+    request_object_method: true
+    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      securityPolicy: projectGlobalSecurityPolicy
+      securityPolicy: securityPolicy
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
   - name: compute.securityPolicies.get
@@ -9707,12 +11815,14 @@ interfaces:
     # TODO: Configure which fields are required.
     required_fields:
     - securityPolicy
+    request_object_method: true
+    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      securityPolicy: projectGlobalSecurityPolicy
+      securityPolicy: securityPolicy
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
   - name: compute.securityPolicies.getRule
@@ -9727,12 +11837,14 @@ interfaces:
     required_fields:
     - priority
     - securityPolicy
+    request_object_method: true
+    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      securityPolicy: projectGlobalSecurityPolicy
+      securityPolicy: securityPolicy
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
   - name: compute.securityPolicies.insert
@@ -9741,12 +11853,16 @@ interfaces:
     flattening:
       groups:
       - parameters:
+        - requestId
         - project
         - securityPolicyResource
     # TODO: Configure which fields are required.
     required_fields:
+    - requestId
     - project
     - securityPolicyResource
+    request_object_method: true
+    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: non_idempotent
     # TODO: Configure the retryable params for this method.
@@ -9765,13 +11881,15 @@ interfaces:
     # TODO: Configure which fields are required.
     required_fields:
     - project
+    request_object_method: true
+    resource_name_treatment: STATIC_TYPES
     page_streaming:
       request:
         page_size_field: maxResults
         token_field: pageToken
       response:
         token_field: nextPageToken
-        resources_field: items
+        resources_field: SecurityPolicyList
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: idempotent
     # TODO: Configure the retryable params for this method.
@@ -9786,18 +11904,22 @@ interfaces:
     flattening:
       groups:
       - parameters:
+        - requestId
         - securityPolicy
         - securityPolicyResource
     # TODO: Configure which fields are required.
     required_fields:
+    - requestId
     - securityPolicy
     - securityPolicyResource
+    request_object_method: true
+    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: non_idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      securityPolicy: projectGlobalSecurityPolicy
+      securityPolicy: securityPolicy
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
   - name: compute.securityPolicies.patchRule
@@ -9814,12 +11936,14 @@ interfaces:
     - priority
     - securityPolicy
     - securityPolicyRuleResource
+    request_object_method: true
+    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: non_idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      securityPolicy: projectGlobalSecurityPolicy
+      securityPolicy: securityPolicy
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
   - name: compute.securityPolicies.removeRule
@@ -9834,15 +11958,17 @@ interfaces:
     required_fields:
     - priority
     - securityPolicy
+    request_object_method: true
+    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: non_idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      securityPolicy: projectGlobalSecurityPolicy
+      securityPolicy: securityPolicy
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
-# The fully qualified name of the API interface.
+  # The fully qualified name of the API interface.
 - name: google.compute.v1.Snapshots
   # A list of resource collection configurations.
   # Consists of a name_pattern and an entity_name.
@@ -9855,18 +11981,18 @@ interfaces:
   # The entity_name is the name to be used as a basis for generated methods and
   # classes.
   collections:
-  - name_pattern: '{project}'
+  - name_pattern: projects/{project}
     entity_name: project
-  - name_pattern: '{project}/global/snapshots/{resource}'
-    entity_name: projectGlobalSnapshotResource
-  - name_pattern: '{project}/global/snapshots/{snapshot}'
-    entity_name: projectGlobalSnapshot
+  - name_pattern: projects/{project}/snapshots/{resource}
+    entity_name: snapshotsResource
+  - name_pattern: projects/{project}/snapshots/{snapshot}
+    entity_name: snapshot
   # Definition for retryable codes.
   retry_codes_def:
   - name: idempotent
     retry_codes:
-    - UNAVAILABLE
-    - DEADLINE_EXCEEDED
+    - SC_SERVICE_UNAVAILABLE
+    - SC_GATEWAY_TIMEOUT
   - name: non_idempotent
     retry_codes: []
   # Definition for retry/backoff parameters.
@@ -9892,6 +12018,17 @@ interfaces:
   #       message.
   #   required_fields - Fields that are always required for a request to be
   #       valid.
+  #   request_object_method - Turns on or off the generation of a method whose
+  #       sole parameter is a request object. Not all languages will generate
+  #       this method.
+  #   resource_name_treatment - An enum that specifies how to treat the
+  #       resource name formats defined in the field_name_patterns
+  #       and response_field_name_patterns fields.
+  #       UNSET: default value
+  #       NONE: the collection configs will not be used by the generated code.
+  #       VALIDATE: string fields will be validated by the client against the
+  #           specified resource name formats.
+  #       STATIC_TYPES: the client will use generated types for resource names.
   #   page_streaming - Specifies the configuration for paging.
   #       Describes information for generating a method which transforms a
   #       paging list RPC into a stream of resources.
@@ -9925,16 +12062,20 @@ interfaces:
     flattening:
       groups:
       - parameters:
+        - requestId
         - snapshot
     # TODO: Configure which fields are required.
     required_fields:
+    - requestId
     - snapshot
+    request_object_method: true
+    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      snapshot: projectGlobalSnapshot
+      snapshot: snapshot
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
   - name: compute.snapshots.get
@@ -9947,12 +12088,14 @@ interfaces:
     # TODO: Configure which fields are required.
     required_fields:
     - snapshot
+    request_object_method: true
+    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      snapshot: projectGlobalSnapshot
+      snapshot: snapshot
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
   - name: compute.snapshots.getIamPolicy
@@ -9965,12 +12108,14 @@ interfaces:
     # TODO: Configure which fields are required.
     required_fields:
     - resource
+    request_object_method: true
+    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      resource: projectGlobalSnapshotResource
+      resource: snapshotsResource
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
   - name: compute.snapshots.list
@@ -9983,13 +12128,15 @@ interfaces:
     # TODO: Configure which fields are required.
     required_fields:
     - project
+    request_object_method: true
+    resource_name_treatment: STATIC_TYPES
     page_streaming:
       request:
         page_size_field: maxResults
         token_field: pageToken
       response:
         token_field: nextPageToken
-        resources_field: items
+        resources_field: SnapshotList
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: idempotent
     # TODO: Configure the retryable params for this method.
@@ -10010,12 +12157,14 @@ interfaces:
     required_fields:
     - resource
     - globalSetPolicyRequestResource
+    request_object_method: true
+    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: non_idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      resource: projectGlobalSnapshotResource
+      resource: snapshotsResource
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
   - name: compute.snapshots.setLabels
@@ -10030,12 +12179,14 @@ interfaces:
     required_fields:
     - resource
     - globalSetLabelsRequestResource
+    request_object_method: true
+    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: non_idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      resource: projectGlobalSnapshotResource
+      resource: snapshotsResource
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
   - name: compute.snapshots.testIamPermissions
@@ -10050,15 +12201,17 @@ interfaces:
     required_fields:
     - resource
     - testPermissionsRequestResource
+    request_object_method: true
+    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: non_idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      resource: projectGlobalSnapshotResource
+      resource: snapshotsResource
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
-# The fully qualified name of the API interface.
+  # The fully qualified name of the API interface.
 - name: google.compute.v1.SslCertificates
   # A list of resource collection configurations.
   # Consists of a name_pattern and an entity_name.
@@ -10071,16 +12224,16 @@ interfaces:
   # The entity_name is the name to be used as a basis for generated methods and
   # classes.
   collections:
-  - name_pattern: '{project}'
+  - name_pattern: projects/{project}
     entity_name: project
-  - name_pattern: '{project}/global/sslCertificates/{sslCertificate}'
-    entity_name: projectGlobalSslCertificate
+  - name_pattern: projects/{project}/sslCertificates/{sslCertificate}
+    entity_name: sslCertificate
   # Definition for retryable codes.
   retry_codes_def:
   - name: idempotent
     retry_codes:
-    - UNAVAILABLE
-    - DEADLINE_EXCEEDED
+    - SC_SERVICE_UNAVAILABLE
+    - SC_GATEWAY_TIMEOUT
   - name: non_idempotent
     retry_codes: []
   # Definition for retry/backoff parameters.
@@ -10106,6 +12259,17 @@ interfaces:
   #       message.
   #   required_fields - Fields that are always required for a request to be
   #       valid.
+  #   request_object_method - Turns on or off the generation of a method whose
+  #       sole parameter is a request object. Not all languages will generate
+  #       this method.
+  #   resource_name_treatment - An enum that specifies how to treat the
+  #       resource name formats defined in the field_name_patterns
+  #       and response_field_name_patterns fields.
+  #       UNSET: default value
+  #       NONE: the collection configs will not be used by the generated code.
+  #       VALIDATE: string fields will be validated by the client against the
+  #           specified resource name formats.
+  #       STATIC_TYPES: the client will use generated types for resource names.
   #   page_streaming - Specifies the configuration for paging.
   #       Describes information for generating a method which transforms a
   #       paging list RPC into a stream of resources.
@@ -10140,15 +12304,19 @@ interfaces:
       groups:
       - parameters:
         - sslCertificate
+        - requestId
     # TODO: Configure which fields are required.
     required_fields:
     - sslCertificate
+    - requestId
+    request_object_method: true
+    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      sslCertificate: projectGlobalSslCertificate
+      sslCertificate: sslCertificate
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
   - name: compute.sslCertificates.get
@@ -10161,12 +12329,14 @@ interfaces:
     # TODO: Configure which fields are required.
     required_fields:
     - sslCertificate
+    request_object_method: true
+    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      sslCertificate: projectGlobalSslCertificate
+      sslCertificate: sslCertificate
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
   - name: compute.sslCertificates.insert
@@ -10175,12 +12345,16 @@ interfaces:
     flattening:
       groups:
       - parameters:
+        - requestId
         - project
         - sslCertificateResource
     # TODO: Configure which fields are required.
     required_fields:
+    - requestId
     - project
     - sslCertificateResource
+    request_object_method: true
+    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: non_idempotent
     # TODO: Configure the retryable params for this method.
@@ -10199,13 +12373,15 @@ interfaces:
     # TODO: Configure which fields are required.
     required_fields:
     - project
+    request_object_method: true
+    resource_name_treatment: STATIC_TYPES
     page_streaming:
       request:
         page_size_field: maxResults
         token_field: pageToken
       response:
         token_field: nextPageToken
-        resources_field: items
+        resources_field: SslCertificateList
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: idempotent
     # TODO: Configure the retryable params for this method.
@@ -10214,7 +12390,7 @@ interfaces:
       project: project
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
-# The fully qualified name of the API interface.
+  # The fully qualified name of the API interface.
 - name: google.compute.v1.SslPolicies
   # A list of resource collection configurations.
   # Consists of a name_pattern and an entity_name.
@@ -10227,16 +12403,16 @@ interfaces:
   # The entity_name is the name to be used as a basis for generated methods and
   # classes.
   collections:
-  - name_pattern: '{project}'
+  - name_pattern: projects/{project}
     entity_name: project
-  - name_pattern: '{project}/global/sslPolicies/{sslPolicy}'
-    entity_name: projectGlobalSslPolicy
+  - name_pattern: projects/{project}/sslPolicies/{sslPolicy}
+    entity_name: sslPolicy
   # Definition for retryable codes.
   retry_codes_def:
   - name: idempotent
     retry_codes:
-    - UNAVAILABLE
-    - DEADLINE_EXCEEDED
+    - SC_SERVICE_UNAVAILABLE
+    - SC_GATEWAY_TIMEOUT
   - name: non_idempotent
     retry_codes: []
   # Definition for retry/backoff parameters.
@@ -10262,6 +12438,17 @@ interfaces:
   #       message.
   #   required_fields - Fields that are always required for a request to be
   #       valid.
+  #   request_object_method - Turns on or off the generation of a method whose
+  #       sole parameter is a request object. Not all languages will generate
+  #       this method.
+  #   resource_name_treatment - An enum that specifies how to treat the
+  #       resource name formats defined in the field_name_patterns
+  #       and response_field_name_patterns fields.
+  #       UNSET: default value
+  #       NONE: the collection configs will not be used by the generated code.
+  #       VALIDATE: string fields will be validated by the client against the
+  #           specified resource name formats.
+  #       STATIC_TYPES: the client will use generated types for resource names.
   #   page_streaming - Specifies the configuration for paging.
   #       Describes information for generating a method which transforms a
   #       paging list RPC into a stream of resources.
@@ -10295,16 +12482,20 @@ interfaces:
     flattening:
       groups:
       - parameters:
+        - requestId
         - sslPolicy
     # TODO: Configure which fields are required.
     required_fields:
+    - requestId
     - sslPolicy
+    request_object_method: true
+    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      sslPolicy: projectGlobalSslPolicy
+      sslPolicy: sslPolicy
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
   - name: compute.sslPolicies.get
@@ -10317,12 +12508,14 @@ interfaces:
     # TODO: Configure which fields are required.
     required_fields:
     - sslPolicy
+    request_object_method: true
+    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      sslPolicy: projectGlobalSslPolicy
+      sslPolicy: sslPolicy
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
   - name: compute.sslPolicies.insert
@@ -10331,12 +12524,16 @@ interfaces:
     flattening:
       groups:
       - parameters:
+        - requestId
         - project
         - sslPolicyResource
     # TODO: Configure which fields are required.
     required_fields:
+    - requestId
     - project
     - sslPolicyResource
+    request_object_method: true
+    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: non_idempotent
     # TODO: Configure the retryable params for this method.
@@ -10355,13 +12552,15 @@ interfaces:
     # TODO: Configure which fields are required.
     required_fields:
     - project
+    request_object_method: true
+    resource_name_treatment: STATIC_TYPES
     page_streaming:
       request:
         page_size_field: maxResults
         token_field: pageToken
       response:
         token_field: nextPageToken
-        resources_field: items
+        resources_field: SslPoliciesList
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: idempotent
     # TODO: Configure the retryable params for this method.
@@ -10380,6 +12579,8 @@ interfaces:
     # TODO: Configure which fields are required.
     required_fields:
     - project
+    request_object_method: true
+    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: idempotent
     # TODO: Configure the retryable params for this method.
@@ -10394,21 +12595,25 @@ interfaces:
     flattening:
       groups:
       - parameters:
+        - requestId
         - sslPolicy
         - sslPolicyResource
     # TODO: Configure which fields are required.
     required_fields:
+    - requestId
     - sslPolicy
     - sslPolicyResource
+    request_object_method: true
+    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: non_idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      sslPolicy: projectGlobalSslPolicy
+      sslPolicy: sslPolicy
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
-# The fully qualified name of the API interface.
+  # The fully qualified name of the API interface.
 - name: google.compute.v1.Subnetworks
   # A list of resource collection configurations.
   # Consists of a name_pattern and an entity_name.
@@ -10421,20 +12626,20 @@ interfaces:
   # The entity_name is the name to be used as a basis for generated methods and
   # classes.
   collections:
-  - name_pattern: '{project}'
+  - name_pattern: projects/{project}
     entity_name: project
-  - name_pattern: '{project}/regions/{region}'
-    entity_name: projectRegion
-  - name_pattern: '{project}/regions/{region}/subnetworks/{resource}'
-    entity_name: projectRegionSubnetworkResource
-  - name_pattern: '{project}/regions/{region}/subnetworks/{subnetwork}'
-    entity_name: projectRegionSubnetwork
+  - name_pattern: projects/{project}/regions/{region}
+    entity_name: region
+  - name_pattern: projects/{project}/regions/{region}/subnetworks/{resource}
+    entity_name: subnetworksResource
+  - name_pattern: projects/{project}/regions/{region}/subnetworks/{subnetwork}
+    entity_name: subnetwork
   # Definition for retryable codes.
   retry_codes_def:
   - name: idempotent
     retry_codes:
-    - UNAVAILABLE
-    - DEADLINE_EXCEEDED
+    - SC_SERVICE_UNAVAILABLE
+    - SC_GATEWAY_TIMEOUT
   - name: non_idempotent
     retry_codes: []
   # Definition for retry/backoff parameters.
@@ -10460,6 +12665,17 @@ interfaces:
   #       message.
   #   required_fields - Fields that are always required for a request to be
   #       valid.
+  #   request_object_method - Turns on or off the generation of a method whose
+  #       sole parameter is a request object. Not all languages will generate
+  #       this method.
+  #   resource_name_treatment - An enum that specifies how to treat the
+  #       resource name formats defined in the field_name_patterns
+  #       and response_field_name_patterns fields.
+  #       UNSET: default value
+  #       NONE: the collection configs will not be used by the generated code.
+  #       VALIDATE: string fields will be validated by the client against the
+  #           specified resource name formats.
+  #       STATIC_TYPES: the client will use generated types for resource names.
   #   page_streaming - Specifies the configuration for paging.
   #       Describes information for generating a method which transforms a
   #       paging list RPC into a stream of resources.
@@ -10497,13 +12713,15 @@ interfaces:
     # TODO: Configure which fields are required.
     required_fields:
     - project
+    request_object_method: true
+    resource_name_treatment: STATIC_TYPES
     page_streaming:
       request:
         page_size_field: maxResults
         token_field: pageToken
       response:
         token_field: nextPageToken
-        resources_field: items
+        resources_field: SubnetworkAggregatedList
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: idempotent
     # TODO: Configure the retryable params for this method.
@@ -10518,16 +12736,20 @@ interfaces:
     flattening:
       groups:
       - parameters:
+        - requestId
         - subnetwork
     # TODO: Configure which fields are required.
     required_fields:
+    - requestId
     - subnetwork
+    request_object_method: true
+    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      subnetwork: projectRegionSubnetwork
+      subnetwork: subnetwork
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
   - name: compute.subnetworks.expandIpCidrRange
@@ -10536,18 +12758,22 @@ interfaces:
     flattening:
       groups:
       - parameters:
+        - requestId
         - subnetwork
         - subnetworksExpandIpCidrRangeRequestResource
     # TODO: Configure which fields are required.
     required_fields:
+    - requestId
     - subnetwork
     - subnetworksExpandIpCidrRangeRequestResource
+    request_object_method: true
+    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: non_idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      subnetwork: projectRegionSubnetwork
+      subnetwork: subnetwork
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
   - name: compute.subnetworks.get
@@ -10560,12 +12786,14 @@ interfaces:
     # TODO: Configure which fields are required.
     required_fields:
     - subnetwork
+    request_object_method: true
+    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      subnetwork: projectRegionSubnetwork
+      subnetwork: subnetwork
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
   - name: compute.subnetworks.getIamPolicy
@@ -10578,12 +12806,14 @@ interfaces:
     # TODO: Configure which fields are required.
     required_fields:
     - resource
+    request_object_method: true
+    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      resource: projectRegionSubnetworkResource
+      resource: subnetworksResource
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
   - name: compute.subnetworks.insert
@@ -10592,18 +12822,22 @@ interfaces:
     flattening:
       groups:
       - parameters:
+        - requestId
         - region
         - subnetworkResource
     # TODO: Configure which fields are required.
     required_fields:
+    - requestId
     - region
     - subnetworkResource
+    request_object_method: true
+    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: non_idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      region: projectRegion
+      region: region
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
   - name: compute.subnetworks.list
@@ -10616,19 +12850,21 @@ interfaces:
     # TODO: Configure which fields are required.
     required_fields:
     - region
+    request_object_method: true
+    resource_name_treatment: STATIC_TYPES
     page_streaming:
       request:
         page_size_field: maxResults
         token_field: pageToken
       response:
         token_field: nextPageToken
-        resources_field: items
+        resources_field: SubnetworkList
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      region: projectRegion
+      region: region
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
   - name: compute.subnetworks.listUsable
@@ -10641,13 +12877,15 @@ interfaces:
     # TODO: Configure which fields are required.
     required_fields:
     - project
+    request_object_method: true
+    resource_name_treatment: STATIC_TYPES
     page_streaming:
       request:
         page_size_field: maxResults
         token_field: pageToken
       response:
         token_field: nextPageToken
-        resources_field: items
+        resources_field: UsableSubnetworksAggregatedList
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: idempotent
     # TODO: Configure the retryable params for this method.
@@ -10662,18 +12900,22 @@ interfaces:
     flattening:
       groups:
       - parameters:
+        - requestId
         - subnetwork
         - subnetworkResource
     # TODO: Configure which fields are required.
     required_fields:
+    - requestId
     - subnetwork
     - subnetworkResource
+    request_object_method: true
+    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: non_idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      subnetwork: projectRegionSubnetwork
+      subnetwork: subnetwork
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
   - name: compute.subnetworks.setIamPolicy
@@ -10688,12 +12930,14 @@ interfaces:
     required_fields:
     - resource
     - regionSetPolicyRequestResource
+    request_object_method: true
+    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: non_idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      resource: projectRegionSubnetworkResource
+      resource: subnetworksResource
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
   - name: compute.subnetworks.setPrivateIpGoogleAccess
@@ -10702,18 +12946,22 @@ interfaces:
     flattening:
       groups:
       - parameters:
+        - requestId
         - subnetwork
         - subnetworksSetPrivateIpGoogleAccessRequestResource
     # TODO: Configure which fields are required.
     required_fields:
+    - requestId
     - subnetwork
     - subnetworksSetPrivateIpGoogleAccessRequestResource
+    request_object_method: true
+    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: non_idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      subnetwork: projectRegionSubnetwork
+      subnetwork: subnetwork
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
   - name: compute.subnetworks.testIamPermissions
@@ -10728,15 +12976,17 @@ interfaces:
     required_fields:
     - resource
     - testPermissionsRequestResource
+    request_object_method: true
+    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: non_idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      resource: projectRegionSubnetworkResource
+      resource: subnetworksResource
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
-# The fully qualified name of the API interface.
+  # The fully qualified name of the API interface.
 - name: google.compute.v1.TargetHttpProxies
   # A list of resource collection configurations.
   # Consists of a name_pattern and an entity_name.
@@ -10749,18 +12999,16 @@ interfaces:
   # The entity_name is the name to be used as a basis for generated methods and
   # classes.
   collections:
-  - name_pattern: '{project}'
+  - name_pattern: projects/{project}
     entity_name: project
-  - name_pattern: '{project}/global/targetHttpProxies/{targetHttpProxy}'
-    entity_name: projectGlobalTargetHttpProxy
-  - name_pattern: '{project}/targetHttpProxies/{targetHttpProxy}'
-    entity_name: projectTargetHttpProxy
+  - name_pattern: projects/{project}/targetHttpProxies/{targetHttpProxy}
+    entity_name: targetHttpProxy
   # Definition for retryable codes.
   retry_codes_def:
   - name: idempotent
     retry_codes:
-    - UNAVAILABLE
-    - DEADLINE_EXCEEDED
+    - SC_SERVICE_UNAVAILABLE
+    - SC_GATEWAY_TIMEOUT
   - name: non_idempotent
     retry_codes: []
   # Definition for retry/backoff parameters.
@@ -10786,6 +13034,17 @@ interfaces:
   #       message.
   #   required_fields - Fields that are always required for a request to be
   #       valid.
+  #   request_object_method - Turns on or off the generation of a method whose
+  #       sole parameter is a request object. Not all languages will generate
+  #       this method.
+  #   resource_name_treatment - An enum that specifies how to treat the
+  #       resource name formats defined in the field_name_patterns
+  #       and response_field_name_patterns fields.
+  #       UNSET: default value
+  #       NONE: the collection configs will not be used by the generated code.
+  #       VALIDATE: string fields will be validated by the client against the
+  #           specified resource name formats.
+  #       STATIC_TYPES: the client will use generated types for resource names.
   #   page_streaming - Specifies the configuration for paging.
   #       Describes information for generating a method which transforms a
   #       paging list RPC into a stream of resources.
@@ -10819,16 +13078,20 @@ interfaces:
     flattening:
       groups:
       - parameters:
+        - requestId
         - targetHttpProxy
     # TODO: Configure which fields are required.
     required_fields:
+    - requestId
     - targetHttpProxy
+    request_object_method: true
+    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      targetHttpProxy: projectGlobalTargetHttpProxy
+      targetHttpProxy: targetHttpProxy
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
   - name: compute.targetHttpProxies.get
@@ -10841,12 +13104,14 @@ interfaces:
     # TODO: Configure which fields are required.
     required_fields:
     - targetHttpProxy
+    request_object_method: true
+    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      targetHttpProxy: projectGlobalTargetHttpProxy
+      targetHttpProxy: targetHttpProxy
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
   - name: compute.targetHttpProxies.insert
@@ -10855,12 +13120,16 @@ interfaces:
     flattening:
       groups:
       - parameters:
+        - requestId
         - project
         - targetHttpProxyResource
     # TODO: Configure which fields are required.
     required_fields:
+    - requestId
     - project
     - targetHttpProxyResource
+    request_object_method: true
+    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: non_idempotent
     # TODO: Configure the retryable params for this method.
@@ -10879,13 +13148,15 @@ interfaces:
     # TODO: Configure which fields are required.
     required_fields:
     - project
+    request_object_method: true
+    resource_name_treatment: STATIC_TYPES
     page_streaming:
       request:
         page_size_field: maxResults
         token_field: pageToken
       response:
         token_field: nextPageToken
-        resources_field: items
+        resources_field: TargetHttpProxyList
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: idempotent
     # TODO: Configure the retryable params for this method.
@@ -10900,21 +13171,25 @@ interfaces:
     flattening:
       groups:
       - parameters:
+        - requestId
         - targetHttpProxy
         - urlMapReferenceResource
     # TODO: Configure which fields are required.
     required_fields:
+    - requestId
     - targetHttpProxy
     - urlMapReferenceResource
+    request_object_method: true
+    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: non_idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      targetHttpProxy: projectTargetHttpProxy
+      targetHttpProxy: targetHttpProxy
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
-# The fully qualified name of the API interface.
+  # The fully qualified name of the API interface.
 - name: google.compute.v1.TargetHttpsProxies
   # A list of resource collection configurations.
   # Consists of a name_pattern and an entity_name.
@@ -10927,18 +13202,16 @@ interfaces:
   # The entity_name is the name to be used as a basis for generated methods and
   # classes.
   collections:
-  - name_pattern: '{project}'
+  - name_pattern: projects/{project}
     entity_name: project
-  - name_pattern: '{project}/global/targetHttpsProxies/{targetHttpsProxy}'
-    entity_name: projectGlobalTargetHttpsProxy
-  - name_pattern: '{project}/targetHttpsProxies/{targetHttpsProxy}'
-    entity_name: projectTargetHttpsProxy
+  - name_pattern: projects/{project}/targetHttpsProxies/{targetHttpsProxy}
+    entity_name: targetHttpsProxy
   # Definition for retryable codes.
   retry_codes_def:
   - name: idempotent
     retry_codes:
-    - UNAVAILABLE
-    - DEADLINE_EXCEEDED
+    - SC_SERVICE_UNAVAILABLE
+    - SC_GATEWAY_TIMEOUT
   - name: non_idempotent
     retry_codes: []
   # Definition for retry/backoff parameters.
@@ -10964,6 +13237,17 @@ interfaces:
   #       message.
   #   required_fields - Fields that are always required for a request to be
   #       valid.
+  #   request_object_method - Turns on or off the generation of a method whose
+  #       sole parameter is a request object. Not all languages will generate
+  #       this method.
+  #   resource_name_treatment - An enum that specifies how to treat the
+  #       resource name formats defined in the field_name_patterns
+  #       and response_field_name_patterns fields.
+  #       UNSET: default value
+  #       NONE: the collection configs will not be used by the generated code.
+  #       VALIDATE: string fields will be validated by the client against the
+  #           specified resource name formats.
+  #       STATIC_TYPES: the client will use generated types for resource names.
   #   page_streaming - Specifies the configuration for paging.
   #       Describes information for generating a method which transforms a
   #       paging list RPC into a stream of resources.
@@ -10998,15 +13282,19 @@ interfaces:
       groups:
       - parameters:
         - targetHttpsProxy
+        - requestId
     # TODO: Configure which fields are required.
     required_fields:
     - targetHttpsProxy
+    - requestId
+    request_object_method: true
+    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      targetHttpsProxy: projectGlobalTargetHttpsProxy
+      targetHttpsProxy: targetHttpsProxy
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
   - name: compute.targetHttpsProxies.get
@@ -11019,12 +13307,14 @@ interfaces:
     # TODO: Configure which fields are required.
     required_fields:
     - targetHttpsProxy
+    request_object_method: true
+    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      targetHttpsProxy: projectGlobalTargetHttpsProxy
+      targetHttpsProxy: targetHttpsProxy
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
   - name: compute.targetHttpsProxies.insert
@@ -11033,12 +13323,16 @@ interfaces:
     flattening:
       groups:
       - parameters:
+        - requestId
         - project
         - targetHttpsProxyResource
     # TODO: Configure which fields are required.
     required_fields:
+    - requestId
     - project
     - targetHttpsProxyResource
+    request_object_method: true
+    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: non_idempotent
     # TODO: Configure the retryable params for this method.
@@ -11057,13 +13351,15 @@ interfaces:
     # TODO: Configure which fields are required.
     required_fields:
     - project
+    request_object_method: true
+    resource_name_treatment: STATIC_TYPES
     page_streaming:
       request:
         page_size_field: maxResults
         token_field: pageToken
       response:
         token_field: nextPageToken
-        resources_field: items
+        resources_field: TargetHttpsProxyList
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: idempotent
     # TODO: Configure the retryable params for this method.
@@ -11079,17 +13375,21 @@ interfaces:
       groups:
       - parameters:
         - targetHttpsProxy
+        - requestId
         - targetHttpsProxiesSetQuicOverrideRequestResource
     # TODO: Configure which fields are required.
     required_fields:
     - targetHttpsProxy
+    - requestId
     - targetHttpsProxiesSetQuicOverrideRequestResource
+    request_object_method: true
+    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: non_idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      targetHttpsProxy: projectGlobalTargetHttpsProxy
+      targetHttpsProxy: targetHttpsProxy
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
   - name: compute.targetHttpsProxies.setSslCertificates
@@ -11099,17 +13399,21 @@ interfaces:
       groups:
       - parameters:
         - targetHttpsProxy
+        - requestId
         - targetHttpsProxiesSetSslCertificatesRequestResource
     # TODO: Configure which fields are required.
     required_fields:
     - targetHttpsProxy
+    - requestId
     - targetHttpsProxiesSetSslCertificatesRequestResource
+    request_object_method: true
+    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: non_idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      targetHttpsProxy: projectTargetHttpsProxy
+      targetHttpsProxy: targetHttpsProxy
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
   - name: compute.targetHttpsProxies.setSslPolicy
@@ -11119,17 +13423,21 @@ interfaces:
       groups:
       - parameters:
         - targetHttpsProxy
+        - requestId
         - sslPolicyReferenceResource
     # TODO: Configure which fields are required.
     required_fields:
     - targetHttpsProxy
+    - requestId
     - sslPolicyReferenceResource
+    request_object_method: true
+    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: non_idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      targetHttpsProxy: projectGlobalTargetHttpsProxy
+      targetHttpsProxy: targetHttpsProxy
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
   - name: compute.targetHttpsProxies.setUrlMap
@@ -11139,20 +13447,24 @@ interfaces:
       groups:
       - parameters:
         - targetHttpsProxy
+        - requestId
         - urlMapReferenceResource
     # TODO: Configure which fields are required.
     required_fields:
     - targetHttpsProxy
+    - requestId
     - urlMapReferenceResource
+    request_object_method: true
+    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: non_idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      targetHttpsProxy: projectTargetHttpsProxy
+      targetHttpsProxy: targetHttpsProxy
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
-# The fully qualified name of the API interface.
+  # The fully qualified name of the API interface.
 - name: google.compute.v1.TargetInstances
   # A list of resource collection configurations.
   # Consists of a name_pattern and an entity_name.
@@ -11165,18 +13477,18 @@ interfaces:
   # The entity_name is the name to be used as a basis for generated methods and
   # classes.
   collections:
-  - name_pattern: '{project}'
+  - name_pattern: projects/{project}
     entity_name: project
-  - name_pattern: '{project}/zones/{zone}'
-    entity_name: projectZone
-  - name_pattern: '{project}/zones/{zone}/targetInstances/{targetInstance}'
-    entity_name: projectZoneTargetInstance
+  - name_pattern: projects/{project}/zones/{zone}
+    entity_name: zone
+  - name_pattern: projects/{project}/zones/{zone}/targetInstances/{targetInstance}
+    entity_name: targetInstance
   # Definition for retryable codes.
   retry_codes_def:
   - name: idempotent
     retry_codes:
-    - UNAVAILABLE
-    - DEADLINE_EXCEEDED
+    - SC_SERVICE_UNAVAILABLE
+    - SC_GATEWAY_TIMEOUT
   - name: non_idempotent
     retry_codes: []
   # Definition for retry/backoff parameters.
@@ -11202,6 +13514,17 @@ interfaces:
   #       message.
   #   required_fields - Fields that are always required for a request to be
   #       valid.
+  #   request_object_method - Turns on or off the generation of a method whose
+  #       sole parameter is a request object. Not all languages will generate
+  #       this method.
+  #   resource_name_treatment - An enum that specifies how to treat the
+  #       resource name formats defined in the field_name_patterns
+  #       and response_field_name_patterns fields.
+  #       UNSET: default value
+  #       NONE: the collection configs will not be used by the generated code.
+  #       VALIDATE: string fields will be validated by the client against the
+  #           specified resource name formats.
+  #       STATIC_TYPES: the client will use generated types for resource names.
   #   page_streaming - Specifies the configuration for paging.
   #       Describes information for generating a method which transforms a
   #       paging list RPC into a stream of resources.
@@ -11239,13 +13562,15 @@ interfaces:
     # TODO: Configure which fields are required.
     required_fields:
     - project
+    request_object_method: true
+    resource_name_treatment: STATIC_TYPES
     page_streaming:
       request:
         page_size_field: maxResults
         token_field: pageToken
       response:
         token_field: nextPageToken
-        resources_field: items
+        resources_field: TargetInstanceAggregatedList
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: idempotent
     # TODO: Configure the retryable params for this method.
@@ -11260,16 +13585,20 @@ interfaces:
     flattening:
       groups:
       - parameters:
+        - requestId
         - targetInstance
     # TODO: Configure which fields are required.
     required_fields:
+    - requestId
     - targetInstance
+    request_object_method: true
+    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      targetInstance: projectZoneTargetInstance
+      targetInstance: targetInstance
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
   - name: compute.targetInstances.get
@@ -11282,12 +13611,14 @@ interfaces:
     # TODO: Configure which fields are required.
     required_fields:
     - targetInstance
+    request_object_method: true
+    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      targetInstance: projectZoneTargetInstance
+      targetInstance: targetInstance
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
   - name: compute.targetInstances.insert
@@ -11297,17 +13628,21 @@ interfaces:
       groups:
       - parameters:
         - zone
+        - requestId
         - targetInstanceResource
     # TODO: Configure which fields are required.
     required_fields:
     - zone
+    - requestId
     - targetInstanceResource
+    request_object_method: true
+    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: non_idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      zone: projectZone
+      zone: zone
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
   - name: compute.targetInstances.list
@@ -11320,22 +13655,24 @@ interfaces:
     # TODO: Configure which fields are required.
     required_fields:
     - zone
+    request_object_method: true
+    resource_name_treatment: STATIC_TYPES
     page_streaming:
       request:
         page_size_field: maxResults
         token_field: pageToken
       response:
         token_field: nextPageToken
-        resources_field: items
+        resources_field: TargetInstanceList
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      zone: projectZone
+      zone: zone
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
-# The fully qualified name of the API interface.
+  # The fully qualified name of the API interface.
 - name: google.compute.v1.TargetPools
   # A list of resource collection configurations.
   # Consists of a name_pattern and an entity_name.
@@ -11348,18 +13685,18 @@ interfaces:
   # The entity_name is the name to be used as a basis for generated methods and
   # classes.
   collections:
-  - name_pattern: '{project}'
+  - name_pattern: projects/{project}
     entity_name: project
-  - name_pattern: '{project}/regions/{region}'
-    entity_name: projectRegion
-  - name_pattern: '{project}/regions/{region}/targetPools/{targetPool}'
-    entity_name: projectRegionTargetPool
+  - name_pattern: projects/{project}/regions/{region}
+    entity_name: region
+  - name_pattern: projects/{project}/regions/{region}/targetPools/{targetPool}
+    entity_name: targetPool
   # Definition for retryable codes.
   retry_codes_def:
   - name: idempotent
     retry_codes:
-    - UNAVAILABLE
-    - DEADLINE_EXCEEDED
+    - SC_SERVICE_UNAVAILABLE
+    - SC_GATEWAY_TIMEOUT
   - name: non_idempotent
     retry_codes: []
   # Definition for retry/backoff parameters.
@@ -11385,6 +13722,17 @@ interfaces:
   #       message.
   #   required_fields - Fields that are always required for a request to be
   #       valid.
+  #   request_object_method - Turns on or off the generation of a method whose
+  #       sole parameter is a request object. Not all languages will generate
+  #       this method.
+  #   resource_name_treatment - An enum that specifies how to treat the
+  #       resource name formats defined in the field_name_patterns
+  #       and response_field_name_patterns fields.
+  #       UNSET: default value
+  #       NONE: the collection configs will not be used by the generated code.
+  #       VALIDATE: string fields will be validated by the client against the
+  #           specified resource name formats.
+  #       STATIC_TYPES: the client will use generated types for resource names.
   #   page_streaming - Specifies the configuration for paging.
   #       Describes information for generating a method which transforms a
   #       paging list RPC into a stream of resources.
@@ -11419,17 +13767,21 @@ interfaces:
       groups:
       - parameters:
         - targetPool
+        - requestId
         - targetPoolsAddHealthCheckRequestResource
     # TODO: Configure which fields are required.
     required_fields:
     - targetPool
+    - requestId
     - targetPoolsAddHealthCheckRequestResource
+    request_object_method: true
+    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: non_idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      targetPool: projectRegionTargetPool
+      targetPool: targetPool
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
   - name: compute.targetPools.addInstance
@@ -11439,17 +13791,21 @@ interfaces:
       groups:
       - parameters:
         - targetPool
+        - requestId
         - targetPoolsAddInstanceRequestResource
     # TODO: Configure which fields are required.
     required_fields:
     - targetPool
+    - requestId
     - targetPoolsAddInstanceRequestResource
+    request_object_method: true
+    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: non_idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      targetPool: projectRegionTargetPool
+      targetPool: targetPool
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
   - name: compute.targetPools.aggregatedList
@@ -11462,13 +13818,15 @@ interfaces:
     # TODO: Configure which fields are required.
     required_fields:
     - project
+    request_object_method: true
+    resource_name_treatment: STATIC_TYPES
     page_streaming:
       request:
         page_size_field: maxResults
         token_field: pageToken
       response:
         token_field: nextPageToken
-        resources_field: items
+        resources_field: TargetPoolAggregatedList
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: idempotent
     # TODO: Configure the retryable params for this method.
@@ -11484,15 +13842,19 @@ interfaces:
       groups:
       - parameters:
         - targetPool
+        - requestId
     # TODO: Configure which fields are required.
     required_fields:
     - targetPool
+    - requestId
+    request_object_method: true
+    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      targetPool: projectRegionTargetPool
+      targetPool: targetPool
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
   - name: compute.targetPools.get
@@ -11505,12 +13867,14 @@ interfaces:
     # TODO: Configure which fields are required.
     required_fields:
     - targetPool
+    request_object_method: true
+    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      targetPool: projectRegionTargetPool
+      targetPool: targetPool
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
   - name: compute.targetPools.getHealth
@@ -11525,12 +13889,14 @@ interfaces:
     required_fields:
     - targetPool
     - instanceReferenceResource
+    request_object_method: true
+    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: non_idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      targetPool: projectRegionTargetPool
+      targetPool: targetPool
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
   - name: compute.targetPools.insert
@@ -11539,18 +13905,22 @@ interfaces:
     flattening:
       groups:
       - parameters:
+        - requestId
         - region
         - targetPoolResource
     # TODO: Configure which fields are required.
     required_fields:
+    - requestId
     - region
     - targetPoolResource
+    request_object_method: true
+    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: non_idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      region: projectRegion
+      region: region
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
   - name: compute.targetPools.list
@@ -11563,19 +13933,21 @@ interfaces:
     # TODO: Configure which fields are required.
     required_fields:
     - region
+    request_object_method: true
+    resource_name_treatment: STATIC_TYPES
     page_streaming:
       request:
         page_size_field: maxResults
         token_field: pageToken
       response:
         token_field: nextPageToken
-        resources_field: items
+        resources_field: TargetPoolList
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      region: projectRegion
+      region: region
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
   - name: compute.targetPools.removeHealthCheck
@@ -11585,17 +13957,21 @@ interfaces:
       groups:
       - parameters:
         - targetPool
+        - requestId
         - targetPoolsRemoveHealthCheckRequestResource
     # TODO: Configure which fields are required.
     required_fields:
     - targetPool
+    - requestId
     - targetPoolsRemoveHealthCheckRequestResource
+    request_object_method: true
+    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: non_idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      targetPool: projectRegionTargetPool
+      targetPool: targetPool
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
   - name: compute.targetPools.removeInstance
@@ -11605,17 +13981,21 @@ interfaces:
       groups:
       - parameters:
         - targetPool
+        - requestId
         - targetPoolsRemoveInstanceRequestResource
     # TODO: Configure which fields are required.
     required_fields:
     - targetPool
+    - requestId
     - targetPoolsRemoveInstanceRequestResource
+    request_object_method: true
+    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: non_idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      targetPool: projectRegionTargetPool
+      targetPool: targetPool
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
   - name: compute.targetPools.setBackup
@@ -11625,22 +14005,26 @@ interfaces:
       groups:
       - parameters:
         - targetPool
+        - requestId
         - failoverRatio
         - targetReferenceResource
     # TODO: Configure which fields are required.
     required_fields:
     - targetPool
+    - requestId
     - failoverRatio
     - targetReferenceResource
+    request_object_method: true
+    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: non_idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      targetPool: projectRegionTargetPool
+      targetPool: targetPool
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
-# The fully qualified name of the API interface.
+  # The fully qualified name of the API interface.
 - name: google.compute.v1.TargetSslProxies
   # A list of resource collection configurations.
   # Consists of a name_pattern and an entity_name.
@@ -11653,16 +14037,16 @@ interfaces:
   # The entity_name is the name to be used as a basis for generated methods and
   # classes.
   collections:
-  - name_pattern: '{project}'
+  - name_pattern: projects/{project}
     entity_name: project
-  - name_pattern: '{project}/global/targetSslProxies/{targetSslProxy}'
-    entity_name: projectGlobalTargetSslProxy
+  - name_pattern: projects/{project}/targetSslProxies/{targetSslProxy}
+    entity_name: targetSslProxy
   # Definition for retryable codes.
   retry_codes_def:
   - name: idempotent
     retry_codes:
-    - UNAVAILABLE
-    - DEADLINE_EXCEEDED
+    - SC_SERVICE_UNAVAILABLE
+    - SC_GATEWAY_TIMEOUT
   - name: non_idempotent
     retry_codes: []
   # Definition for retry/backoff parameters.
@@ -11688,6 +14072,17 @@ interfaces:
   #       message.
   #   required_fields - Fields that are always required for a request to be
   #       valid.
+  #   request_object_method - Turns on or off the generation of a method whose
+  #       sole parameter is a request object. Not all languages will generate
+  #       this method.
+  #   resource_name_treatment - An enum that specifies how to treat the
+  #       resource name formats defined in the field_name_patterns
+  #       and response_field_name_patterns fields.
+  #       UNSET: default value
+  #       NONE: the collection configs will not be used by the generated code.
+  #       VALIDATE: string fields will be validated by the client against the
+  #           specified resource name formats.
+  #       STATIC_TYPES: the client will use generated types for resource names.
   #   page_streaming - Specifies the configuration for paging.
   #       Describes information for generating a method which transforms a
   #       paging list RPC into a stream of resources.
@@ -11722,15 +14117,19 @@ interfaces:
       groups:
       - parameters:
         - targetSslProxy
+        - requestId
     # TODO: Configure which fields are required.
     required_fields:
     - targetSslProxy
+    - requestId
+    request_object_method: true
+    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      targetSslProxy: projectGlobalTargetSslProxy
+      targetSslProxy: targetSslProxy
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
   - name: compute.targetSslProxies.get
@@ -11743,12 +14142,14 @@ interfaces:
     # TODO: Configure which fields are required.
     required_fields:
     - targetSslProxy
+    request_object_method: true
+    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      targetSslProxy: projectGlobalTargetSslProxy
+      targetSslProxy: targetSslProxy
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
   - name: compute.targetSslProxies.insert
@@ -11757,12 +14158,16 @@ interfaces:
     flattening:
       groups:
       - parameters:
+        - requestId
         - project
         - targetSslProxyResource
     # TODO: Configure which fields are required.
     required_fields:
+    - requestId
     - project
     - targetSslProxyResource
+    request_object_method: true
+    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: non_idempotent
     # TODO: Configure the retryable params for this method.
@@ -11781,13 +14186,15 @@ interfaces:
     # TODO: Configure which fields are required.
     required_fields:
     - project
+    request_object_method: true
+    resource_name_treatment: STATIC_TYPES
     page_streaming:
       request:
         page_size_field: maxResults
         token_field: pageToken
       response:
         token_field: nextPageToken
-        resources_field: items
+        resources_field: TargetSslProxyList
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: idempotent
     # TODO: Configure the retryable params for this method.
@@ -11803,17 +14210,21 @@ interfaces:
       groups:
       - parameters:
         - targetSslProxy
+        - requestId
         - targetSslProxiesSetBackendServiceRequestResource
     # TODO: Configure which fields are required.
     required_fields:
     - targetSslProxy
+    - requestId
     - targetSslProxiesSetBackendServiceRequestResource
+    request_object_method: true
+    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: non_idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      targetSslProxy: projectGlobalTargetSslProxy
+      targetSslProxy: targetSslProxy
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
   - name: compute.targetSslProxies.setProxyHeader
@@ -11823,17 +14234,21 @@ interfaces:
       groups:
       - parameters:
         - targetSslProxy
+        - requestId
         - targetSslProxiesSetProxyHeaderRequestResource
     # TODO: Configure which fields are required.
     required_fields:
     - targetSslProxy
+    - requestId
     - targetSslProxiesSetProxyHeaderRequestResource
+    request_object_method: true
+    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: non_idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      targetSslProxy: projectGlobalTargetSslProxy
+      targetSslProxy: targetSslProxy
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
   - name: compute.targetSslProxies.setSslCertificates
@@ -11843,17 +14258,21 @@ interfaces:
       groups:
       - parameters:
         - targetSslProxy
+        - requestId
         - targetSslProxiesSetSslCertificatesRequestResource
     # TODO: Configure which fields are required.
     required_fields:
     - targetSslProxy
+    - requestId
     - targetSslProxiesSetSslCertificatesRequestResource
+    request_object_method: true
+    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: non_idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      targetSslProxy: projectGlobalTargetSslProxy
+      targetSslProxy: targetSslProxy
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
   - name: compute.targetSslProxies.setSslPolicy
@@ -11863,20 +14282,24 @@ interfaces:
       groups:
       - parameters:
         - targetSslProxy
+        - requestId
         - sslPolicyReferenceResource
     # TODO: Configure which fields are required.
     required_fields:
     - targetSslProxy
+    - requestId
     - sslPolicyReferenceResource
+    request_object_method: true
+    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: non_idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      targetSslProxy: projectGlobalTargetSslProxy
+      targetSslProxy: targetSslProxy
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
-# The fully qualified name of the API interface.
+  # The fully qualified name of the API interface.
 - name: google.compute.v1.TargetTcpProxies
   # A list of resource collection configurations.
   # Consists of a name_pattern and an entity_name.
@@ -11889,16 +14312,16 @@ interfaces:
   # The entity_name is the name to be used as a basis for generated methods and
   # classes.
   collections:
-  - name_pattern: '{project}'
+  - name_pattern: projects/{project}
     entity_name: project
-  - name_pattern: '{project}/global/targetTcpProxies/{targetTcpProxy}'
-    entity_name: projectGlobalTargetTcpProxy
+  - name_pattern: projects/{project}/targetTcpProxies/{targetTcpProxy}
+    entity_name: targetTcpProxy
   # Definition for retryable codes.
   retry_codes_def:
   - name: idempotent
     retry_codes:
-    - UNAVAILABLE
-    - DEADLINE_EXCEEDED
+    - SC_SERVICE_UNAVAILABLE
+    - SC_GATEWAY_TIMEOUT
   - name: non_idempotent
     retry_codes: []
   # Definition for retry/backoff parameters.
@@ -11924,6 +14347,17 @@ interfaces:
   #       message.
   #   required_fields - Fields that are always required for a request to be
   #       valid.
+  #   request_object_method - Turns on or off the generation of a method whose
+  #       sole parameter is a request object. Not all languages will generate
+  #       this method.
+  #   resource_name_treatment - An enum that specifies how to treat the
+  #       resource name formats defined in the field_name_patterns
+  #       and response_field_name_patterns fields.
+  #       UNSET: default value
+  #       NONE: the collection configs will not be used by the generated code.
+  #       VALIDATE: string fields will be validated by the client against the
+  #           specified resource name formats.
+  #       STATIC_TYPES: the client will use generated types for resource names.
   #   page_streaming - Specifies the configuration for paging.
   #       Describes information for generating a method which transforms a
   #       paging list RPC into a stream of resources.
@@ -11957,16 +14391,20 @@ interfaces:
     flattening:
       groups:
       - parameters:
+        - requestId
         - targetTcpProxy
     # TODO: Configure which fields are required.
     required_fields:
+    - requestId
     - targetTcpProxy
+    request_object_method: true
+    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      targetTcpProxy: projectGlobalTargetTcpProxy
+      targetTcpProxy: targetTcpProxy
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
   - name: compute.targetTcpProxies.get
@@ -11979,12 +14417,14 @@ interfaces:
     # TODO: Configure which fields are required.
     required_fields:
     - targetTcpProxy
+    request_object_method: true
+    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      targetTcpProxy: projectGlobalTargetTcpProxy
+      targetTcpProxy: targetTcpProxy
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
   - name: compute.targetTcpProxies.insert
@@ -11993,12 +14433,16 @@ interfaces:
     flattening:
       groups:
       - parameters:
+        - requestId
         - project
         - targetTcpProxyResource
     # TODO: Configure which fields are required.
     required_fields:
+    - requestId
     - project
     - targetTcpProxyResource
+    request_object_method: true
+    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: non_idempotent
     # TODO: Configure the retryable params for this method.
@@ -12017,13 +14461,15 @@ interfaces:
     # TODO: Configure which fields are required.
     required_fields:
     - project
+    request_object_method: true
+    resource_name_treatment: STATIC_TYPES
     page_streaming:
       request:
         page_size_field: maxResults
         token_field: pageToken
       response:
         token_field: nextPageToken
-        resources_field: items
+        resources_field: TargetTcpProxyList
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: idempotent
     # TODO: Configure the retryable params for this method.
@@ -12038,18 +14484,22 @@ interfaces:
     flattening:
       groups:
       - parameters:
+        - requestId
         - targetTcpProxy
         - targetTcpProxiesSetBackendServiceRequestResource
     # TODO: Configure which fields are required.
     required_fields:
+    - requestId
     - targetTcpProxy
     - targetTcpProxiesSetBackendServiceRequestResource
+    request_object_method: true
+    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: non_idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      targetTcpProxy: projectGlobalTargetTcpProxy
+      targetTcpProxy: targetTcpProxy
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
   - name: compute.targetTcpProxies.setProxyHeader
@@ -12058,21 +14508,25 @@ interfaces:
     flattening:
       groups:
       - parameters:
+        - requestId
         - targetTcpProxy
         - targetTcpProxiesSetProxyHeaderRequestResource
     # TODO: Configure which fields are required.
     required_fields:
+    - requestId
     - targetTcpProxy
     - targetTcpProxiesSetProxyHeaderRequestResource
+    request_object_method: true
+    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: non_idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      targetTcpProxy: projectGlobalTargetTcpProxy
+      targetTcpProxy: targetTcpProxy
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
-# The fully qualified name of the API interface.
+  # The fully qualified name of the API interface.
 - name: google.compute.v1.TargetVpnGateways
   # A list of resource collection configurations.
   # Consists of a name_pattern and an entity_name.
@@ -12085,18 +14539,18 @@ interfaces:
   # The entity_name is the name to be used as a basis for generated methods and
   # classes.
   collections:
-  - name_pattern: '{project}'
+  - name_pattern: projects/{project}
     entity_name: project
-  - name_pattern: '{project}/regions/{region}'
-    entity_name: projectRegion
-  - name_pattern: '{project}/regions/{region}/targetVpnGateways/{targetVpnGateway}'
-    entity_name: projectRegionTargetVpnGateway
+  - name_pattern: projects/{project}/regions/{region}
+    entity_name: region
+  - name_pattern: projects/{project}/regions/{region}/targetVpnGateways/{targetVpnGateway}
+    entity_name: targetVpnGateway
   # Definition for retryable codes.
   retry_codes_def:
   - name: idempotent
     retry_codes:
-    - UNAVAILABLE
-    - DEADLINE_EXCEEDED
+    - SC_SERVICE_UNAVAILABLE
+    - SC_GATEWAY_TIMEOUT
   - name: non_idempotent
     retry_codes: []
   # Definition for retry/backoff parameters.
@@ -12122,6 +14576,17 @@ interfaces:
   #       message.
   #   required_fields - Fields that are always required for a request to be
   #       valid.
+  #   request_object_method - Turns on or off the generation of a method whose
+  #       sole parameter is a request object. Not all languages will generate
+  #       this method.
+  #   resource_name_treatment - An enum that specifies how to treat the
+  #       resource name formats defined in the field_name_patterns
+  #       and response_field_name_patterns fields.
+  #       UNSET: default value
+  #       NONE: the collection configs will not be used by the generated code.
+  #       VALIDATE: string fields will be validated by the client against the
+  #           specified resource name formats.
+  #       STATIC_TYPES: the client will use generated types for resource names.
   #   page_streaming - Specifies the configuration for paging.
   #       Describes information for generating a method which transforms a
   #       paging list RPC into a stream of resources.
@@ -12159,13 +14624,15 @@ interfaces:
     # TODO: Configure which fields are required.
     required_fields:
     - project
+    request_object_method: true
+    resource_name_treatment: STATIC_TYPES
     page_streaming:
       request:
         page_size_field: maxResults
         token_field: pageToken
       response:
         token_field: nextPageToken
-        resources_field: items
+        resources_field: TargetVpnGatewayAggregatedList
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: idempotent
     # TODO: Configure the retryable params for this method.
@@ -12180,16 +14647,20 @@ interfaces:
     flattening:
       groups:
       - parameters:
+        - requestId
         - targetVpnGateway
     # TODO: Configure which fields are required.
     required_fields:
+    - requestId
     - targetVpnGateway
+    request_object_method: true
+    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      targetVpnGateway: projectRegionTargetVpnGateway
+      targetVpnGateway: targetVpnGateway
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
   - name: compute.targetVpnGateways.get
@@ -12202,12 +14673,14 @@ interfaces:
     # TODO: Configure which fields are required.
     required_fields:
     - targetVpnGateway
+    request_object_method: true
+    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      targetVpnGateway: projectRegionTargetVpnGateway
+      targetVpnGateway: targetVpnGateway
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
   - name: compute.targetVpnGateways.insert
@@ -12216,18 +14689,22 @@ interfaces:
     flattening:
       groups:
       - parameters:
+        - requestId
         - region
         - targetVpnGatewayResource
     # TODO: Configure which fields are required.
     required_fields:
+    - requestId
     - region
     - targetVpnGatewayResource
+    request_object_method: true
+    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: non_idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      region: projectRegion
+      region: region
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
   - name: compute.targetVpnGateways.list
@@ -12240,22 +14717,24 @@ interfaces:
     # TODO: Configure which fields are required.
     required_fields:
     - region
+    request_object_method: true
+    resource_name_treatment: STATIC_TYPES
     page_streaming:
       request:
         page_size_field: maxResults
         token_field: pageToken
       response:
         token_field: nextPageToken
-        resources_field: items
+        resources_field: TargetVpnGatewayList
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      region: projectRegion
+      region: region
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
-# The fully qualified name of the API interface.
+  # The fully qualified name of the API interface.
 - name: google.compute.v1.UrlMaps
   # A list of resource collection configurations.
   # Consists of a name_pattern and an entity_name.
@@ -12268,16 +14747,16 @@ interfaces:
   # The entity_name is the name to be used as a basis for generated methods and
   # classes.
   collections:
-  - name_pattern: '{project}'
+  - name_pattern: projects/{project}
     entity_name: project
-  - name_pattern: '{project}/global/urlMaps/{urlMap}'
-    entity_name: projectGlobalUrlMap
+  - name_pattern: projects/{project}/urlMaps/{urlMap}
+    entity_name: urlMap
   # Definition for retryable codes.
   retry_codes_def:
   - name: idempotent
     retry_codes:
-    - UNAVAILABLE
-    - DEADLINE_EXCEEDED
+    - SC_SERVICE_UNAVAILABLE
+    - SC_GATEWAY_TIMEOUT
   - name: non_idempotent
     retry_codes: []
   # Definition for retry/backoff parameters.
@@ -12303,6 +14782,17 @@ interfaces:
   #       message.
   #   required_fields - Fields that are always required for a request to be
   #       valid.
+  #   request_object_method - Turns on or off the generation of a method whose
+  #       sole parameter is a request object. Not all languages will generate
+  #       this method.
+  #   resource_name_treatment - An enum that specifies how to treat the
+  #       resource name formats defined in the field_name_patterns
+  #       and response_field_name_patterns fields.
+  #       UNSET: default value
+  #       NONE: the collection configs will not be used by the generated code.
+  #       VALIDATE: string fields will be validated by the client against the
+  #           specified resource name formats.
+  #       STATIC_TYPES: the client will use generated types for resource names.
   #   page_streaming - Specifies the configuration for paging.
   #       Describes information for generating a method which transforms a
   #       paging list RPC into a stream of resources.
@@ -12337,15 +14827,19 @@ interfaces:
       groups:
       - parameters:
         - urlMap
+        - requestId
     # TODO: Configure which fields are required.
     required_fields:
     - urlMap
+    - requestId
+    request_object_method: true
+    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      urlMap: projectGlobalUrlMap
+      urlMap: urlMap
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
   - name: compute.urlMaps.get
@@ -12358,12 +14852,14 @@ interfaces:
     # TODO: Configure which fields are required.
     required_fields:
     - urlMap
+    request_object_method: true
+    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      urlMap: projectGlobalUrlMap
+      urlMap: urlMap
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
   - name: compute.urlMaps.insert
@@ -12372,12 +14868,16 @@ interfaces:
     flattening:
       groups:
       - parameters:
+        - requestId
         - project
         - urlMapResource
     # TODO: Configure which fields are required.
     required_fields:
+    - requestId
     - project
     - urlMapResource
+    request_object_method: true
+    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: non_idempotent
     # TODO: Configure the retryable params for this method.
@@ -12393,17 +14893,21 @@ interfaces:
       groups:
       - parameters:
         - urlMap
+        - requestId
         - cacheInvalidationRuleResource
     # TODO: Configure which fields are required.
     required_fields:
     - urlMap
+    - requestId
     - cacheInvalidationRuleResource
+    request_object_method: true
+    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: non_idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      urlMap: projectGlobalUrlMap
+      urlMap: urlMap
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
   - name: compute.urlMaps.list
@@ -12416,13 +14920,15 @@ interfaces:
     # TODO: Configure which fields are required.
     required_fields:
     - project
+    request_object_method: true
+    resource_name_treatment: STATIC_TYPES
     page_streaming:
       request:
         page_size_field: maxResults
         token_field: pageToken
       response:
         token_field: nextPageToken
-        resources_field: items
+        resources_field: UrlMapList
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: idempotent
     # TODO: Configure the retryable params for this method.
@@ -12438,17 +14944,21 @@ interfaces:
       groups:
       - parameters:
         - urlMap
+        - requestId
         - urlMapResource
     # TODO: Configure which fields are required.
     required_fields:
     - urlMap
+    - requestId
     - urlMapResource
+    request_object_method: true
+    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: non_idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      urlMap: projectGlobalUrlMap
+      urlMap: urlMap
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
   - name: compute.urlMaps.update
@@ -12458,17 +14968,21 @@ interfaces:
       groups:
       - parameters:
         - urlMap
+        - requestId
         - urlMapResource
     # TODO: Configure which fields are required.
     required_fields:
     - urlMap
+    - requestId
     - urlMapResource
+    request_object_method: true
+    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      urlMap: projectGlobalUrlMap
+      urlMap: urlMap
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
   - name: compute.urlMaps.validate
@@ -12483,15 +14997,17 @@ interfaces:
     required_fields:
     - urlMap
     - urlMapsValidateRequestResource
+    request_object_method: true
+    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: non_idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      urlMap: projectGlobalUrlMap
+      urlMap: urlMap
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
-# The fully qualified name of the API interface.
+  # The fully qualified name of the API interface.
 - name: google.compute.v1.VpnTunnels
   # A list of resource collection configurations.
   # Consists of a name_pattern and an entity_name.
@@ -12504,18 +15020,18 @@ interfaces:
   # The entity_name is the name to be used as a basis for generated methods and
   # classes.
   collections:
-  - name_pattern: '{project}'
+  - name_pattern: projects/{project}
     entity_name: project
-  - name_pattern: '{project}/regions/{region}'
-    entity_name: projectRegion
-  - name_pattern: '{project}/regions/{region}/vpnTunnels/{vpnTunnel}'
-    entity_name: projectRegionVpnTunnel
+  - name_pattern: projects/{project}/regions/{region}
+    entity_name: region
+  - name_pattern: projects/{project}/regions/{region}/vpnTunnels/{vpnTunnel}
+    entity_name: vpnTunnel
   # Definition for retryable codes.
   retry_codes_def:
   - name: idempotent
     retry_codes:
-    - UNAVAILABLE
-    - DEADLINE_EXCEEDED
+    - SC_SERVICE_UNAVAILABLE
+    - SC_GATEWAY_TIMEOUT
   - name: non_idempotent
     retry_codes: []
   # Definition for retry/backoff parameters.
@@ -12541,6 +15057,17 @@ interfaces:
   #       message.
   #   required_fields - Fields that are always required for a request to be
   #       valid.
+  #   request_object_method - Turns on or off the generation of a method whose
+  #       sole parameter is a request object. Not all languages will generate
+  #       this method.
+  #   resource_name_treatment - An enum that specifies how to treat the
+  #       resource name formats defined in the field_name_patterns
+  #       and response_field_name_patterns fields.
+  #       UNSET: default value
+  #       NONE: the collection configs will not be used by the generated code.
+  #       VALIDATE: string fields will be validated by the client against the
+  #           specified resource name formats.
+  #       STATIC_TYPES: the client will use generated types for resource names.
   #   page_streaming - Specifies the configuration for paging.
   #       Describes information for generating a method which transforms a
   #       paging list RPC into a stream of resources.
@@ -12578,13 +15105,15 @@ interfaces:
     # TODO: Configure which fields are required.
     required_fields:
     - project
+    request_object_method: true
+    resource_name_treatment: STATIC_TYPES
     page_streaming:
       request:
         page_size_field: maxResults
         token_field: pageToken
       response:
         token_field: nextPageToken
-        resources_field: items
+        resources_field: VpnTunnelAggregatedList
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: idempotent
     # TODO: Configure the retryable params for this method.
@@ -12599,16 +15128,20 @@ interfaces:
     flattening:
       groups:
       - parameters:
+        - requestId
         - vpnTunnel
     # TODO: Configure which fields are required.
     required_fields:
+    - requestId
     - vpnTunnel
+    request_object_method: true
+    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      vpnTunnel: projectRegionVpnTunnel
+      vpnTunnel: vpnTunnel
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
   - name: compute.vpnTunnels.get
@@ -12621,12 +15154,14 @@ interfaces:
     # TODO: Configure which fields are required.
     required_fields:
     - vpnTunnel
+    request_object_method: true
+    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      vpnTunnel: projectRegionVpnTunnel
+      vpnTunnel: vpnTunnel
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
   - name: compute.vpnTunnels.insert
@@ -12635,18 +15170,22 @@ interfaces:
     flattening:
       groups:
       - parameters:
+        - requestId
         - region
         - vpnTunnelResource
     # TODO: Configure which fields are required.
     required_fields:
+    - requestId
     - region
     - vpnTunnelResource
+    request_object_method: true
+    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: non_idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      region: projectRegion
+      region: region
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
   - name: compute.vpnTunnels.list
@@ -12659,22 +15198,24 @@ interfaces:
     # TODO: Configure which fields are required.
     required_fields:
     - region
+    request_object_method: true
+    resource_name_treatment: STATIC_TYPES
     page_streaming:
       request:
         page_size_field: maxResults
         token_field: pageToken
       response:
         token_field: nextPageToken
-        resources_field: items
+        resources_field: VpnTunnelList
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      region: projectRegion
+      region: region
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
-# The fully qualified name of the API interface.
+  # The fully qualified name of the API interface.
 - name: google.compute.v1.ZoneOperations
   # A list of resource collection configurations.
   # Consists of a name_pattern and an entity_name.
@@ -12687,16 +15228,16 @@ interfaces:
   # The entity_name is the name to be used as a basis for generated methods and
   # classes.
   collections:
-  - name_pattern: '{project}/zones/{zone}'
-    entity_name: projectZone
-  - name_pattern: '{project}/zones/{zone}/operations/{operation}'
-    entity_name: projectZoneOperation
+  - name_pattern: projects/{project}/zones/{zone}
+    entity_name: zone
+  - name_pattern: projects/{project}/zones/{zone}/operations/{operation}
+    entity_name: zoneOperationsOperation
   # Definition for retryable codes.
   retry_codes_def:
   - name: idempotent
     retry_codes:
-    - UNAVAILABLE
-    - DEADLINE_EXCEEDED
+    - SC_SERVICE_UNAVAILABLE
+    - SC_GATEWAY_TIMEOUT
   - name: non_idempotent
     retry_codes: []
   # Definition for retry/backoff parameters.
@@ -12722,6 +15263,17 @@ interfaces:
   #       message.
   #   required_fields - Fields that are always required for a request to be
   #       valid.
+  #   request_object_method - Turns on or off the generation of a method whose
+  #       sole parameter is a request object. Not all languages will generate
+  #       this method.
+  #   resource_name_treatment - An enum that specifies how to treat the
+  #       resource name formats defined in the field_name_patterns
+  #       and response_field_name_patterns fields.
+  #       UNSET: default value
+  #       NONE: the collection configs will not be used by the generated code.
+  #       VALIDATE: string fields will be validated by the client against the
+  #           specified resource name formats.
+  #       STATIC_TYPES: the client will use generated types for resource names.
   #   page_streaming - Specifies the configuration for paging.
   #       Describes information for generating a method which transforms a
   #       paging list RPC into a stream of resources.
@@ -12759,12 +15311,14 @@ interfaces:
     # TODO: Configure which fields are required.
     required_fields:
     - operation
+    request_object_method: true
+    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      operation: projectZoneOperation
+      operation: zoneOperationsOperation
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
   - name: compute.zoneOperations.get
@@ -12777,12 +15331,14 @@ interfaces:
     # TODO: Configure which fields are required.
     required_fields:
     - operation
+    request_object_method: true
+    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      operation: projectZoneOperation
+      operation: zoneOperationsOperation
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
   - name: compute.zoneOperations.list
@@ -12795,22 +15351,24 @@ interfaces:
     # TODO: Configure which fields are required.
     required_fields:
     - zone
+    request_object_method: true
+    resource_name_treatment: STATIC_TYPES
     page_streaming:
       request:
         page_size_field: maxResults
         token_field: pageToken
       response:
         token_field: nextPageToken
-        resources_field: items
+        resources_field: OperationList
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      zone: projectZone
+      zone: zone
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
-# The fully qualified name of the API interface.
+  # The fully qualified name of the API interface.
 - name: google.compute.v1.Zones
   # A list of resource collection configurations.
   # Consists of a name_pattern and an entity_name.
@@ -12823,16 +15381,16 @@ interfaces:
   # The entity_name is the name to be used as a basis for generated methods and
   # classes.
   collections:
-  - name_pattern: '{project}'
+  - name_pattern: projects/{project}
     entity_name: project
-  - name_pattern: '{project}/zones/{zone}'
-    entity_name: projectZone
+  - name_pattern: projects/{project}/zones/{zone}
+    entity_name: zone
   # Definition for retryable codes.
   retry_codes_def:
   - name: idempotent
     retry_codes:
-    - UNAVAILABLE
-    - DEADLINE_EXCEEDED
+    - SC_SERVICE_UNAVAILABLE
+    - SC_GATEWAY_TIMEOUT
   - name: non_idempotent
     retry_codes: []
   # Definition for retry/backoff parameters.
@@ -12858,6 +15416,17 @@ interfaces:
   #       message.
   #   required_fields - Fields that are always required for a request to be
   #       valid.
+  #   request_object_method - Turns on or off the generation of a method whose
+  #       sole parameter is a request object. Not all languages will generate
+  #       this method.
+  #   resource_name_treatment - An enum that specifies how to treat the
+  #       resource name formats defined in the field_name_patterns
+  #       and response_field_name_patterns fields.
+  #       UNSET: default value
+  #       NONE: the collection configs will not be used by the generated code.
+  #       VALIDATE: string fields will be validated by the client against the
+  #           specified resource name formats.
+  #       STATIC_TYPES: the client will use generated types for resource names.
   #   page_streaming - Specifies the configuration for paging.
   #       Describes information for generating a method which transforms a
   #       paging list RPC into a stream of resources.
@@ -12895,12 +15464,14 @@ interfaces:
     # TODO: Configure which fields are required.
     required_fields:
     - zone
+    request_object_method: true
+    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      zone: projectZone
+      zone: zone
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
   - name: compute.zones.list
@@ -12913,13 +15484,15 @@ interfaces:
     # TODO: Configure which fields are required.
     required_fields:
     - project
+    request_object_method: true
+    resource_name_treatment: STATIC_TYPES
     page_streaming:
       request:
         page_size_field: maxResults
         token_field: pageToken
       response:
         token_field: nextPageToken
-        resources_field: items
+        resources_field: ZoneList
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: idempotent
     # TODO: Configure the retryable params for this method.
@@ -12934,58 +15507,58 @@ resource_name_generation:
     project: project
 - message_name: GetAcceleratorTypeHttpRequest
   field_entity_map:
-    acceleratorType: projectZoneAcceleratorType
+    acceleratorType: acceleratorType
 - message_name: ListAcceleratorTypesHttpRequest
   field_entity_map:
-    zone: projectZone
+    zone: zone
 - message_name: AggregatedListAddressesHttpRequest
   field_entity_map:
     project: project
 - message_name: DeleteAddressHttpRequest
   field_entity_map:
-    address: projectRegionAddress
+    address: address
 - message_name: GetAddressHttpRequest
   field_entity_map:
-    address: projectRegionAddress
+    address: address
 - message_name: InsertAddressHttpRequest
   field_entity_map:
-    region: projectRegion
+    region: region
 - message_name: ListAddressesHttpRequest
   field_entity_map:
-    region: projectRegion
+    region: region
 - message_name: AggregatedListAutoscalersHttpRequest
   field_entity_map:
     project: project
 - message_name: DeleteAutoscalerHttpRequest
   field_entity_map:
-    autoscaler: projectZoneAutoscaler
+    autoscaler: autoscaler
 - message_name: GetAutoscalerHttpRequest
   field_entity_map:
-    autoscaler: projectZoneAutoscaler
+    autoscaler: autoscaler
 - message_name: InsertAutoscalerHttpRequest
   field_entity_map:
-    zone: projectZone
+    zone: zone
 - message_name: ListAutoscalersHttpRequest
   field_entity_map:
-    zone: projectZone
+    zone: zone
 - message_name: PatchAutoscalerHttpRequest
   field_entity_map:
-    zone: projectZone
+    zone: zone
 - message_name: UpdateAutoscalerHttpRequest
   field_entity_map:
-    zone: projectZone
+    zone: zone
 - message_name: AddSignedUrlKeyBackendBucketHttpRequest
   field_entity_map:
-    backendBucket: projectGlobalBackendBucket
+    backendBucket: backendBucket
 - message_name: DeleteBackendBucketHttpRequest
   field_entity_map:
-    backendBucket: projectGlobalBackendBucket
+    backendBucket: backendBucket
 - message_name: DeleteSignedUrlKeyBackendBucketHttpRequest
   field_entity_map:
-    backendBucket: projectGlobalBackendBucket
+    backendBucket: backendBucket
 - message_name: GetBackendBucketHttpRequest
   field_entity_map:
-    backendBucket: projectGlobalBackendBucket
+    backendBucket: backendBucket
 - message_name: InsertBackendBucketHttpRequest
   field_entity_map:
     project: project
@@ -12994,28 +15567,28 @@ resource_name_generation:
     project: project
 - message_name: PatchBackendBucketHttpRequest
   field_entity_map:
-    backendBucket: projectGlobalBackendBucket
+    backendBucket: backendBucket
 - message_name: UpdateBackendBucketHttpRequest
   field_entity_map:
-    backendBucket: projectGlobalBackendBucket
+    backendBucket: backendBucket
 - message_name: AddSignedUrlKeyBackendServiceHttpRequest
   field_entity_map:
-    backendService: projectGlobalBackendService
+    backendService: backendService
 - message_name: AggregatedListBackendServicesHttpRequest
   field_entity_map:
     project: project
 - message_name: DeleteBackendServiceHttpRequest
   field_entity_map:
-    backendService: projectGlobalBackendService
+    backendService: backendService
 - message_name: DeleteSignedUrlKeyBackendServiceHttpRequest
   field_entity_map:
-    backendService: projectGlobalBackendService
+    backendService: backendService
 - message_name: GetBackendServiceHttpRequest
   field_entity_map:
-    backendService: projectGlobalBackendService
+    backendService: backendService
 - message_name: GetHealthBackendServiceHttpRequest
   field_entity_map:
-    backendService: projectGlobalBackendService
+    backendService: backendService
 - message_name: InsertBackendServiceHttpRequest
   field_entity_map:
     project: project
@@ -13024,61 +15597,67 @@ resource_name_generation:
     project: project
 - message_name: PatchBackendServiceHttpRequest
   field_entity_map:
-    backendService: projectGlobalBackendService
+    backendService: backendService
 - message_name: SetSecurityPolicyBackendServiceHttpRequest
   field_entity_map:
-    backendService: projectGlobalBackendService
+    backendService: backendService
 - message_name: UpdateBackendServiceHttpRequest
   field_entity_map:
-    backendService: projectGlobalBackendService
+    backendService: backendService
 - message_name: AggregatedListDiskTypesHttpRequest
   field_entity_map:
     project: project
 - message_name: GetDiskTypeHttpRequest
   field_entity_map:
-    diskType: projectZoneDiskType
+    diskType: diskType
 - message_name: ListDiskTypesHttpRequest
   field_entity_map:
-    zone: projectZone
+    zone: zone
+- message_name: AddResourcePoliciesDiskHttpRequest
+  field_entity_map:
+    disk: disk
 - message_name: AggregatedListDisksHttpRequest
   field_entity_map:
     project: project
 - message_name: CreateSnapshotDiskHttpRequest
   field_entity_map:
-    disk: projectZoneDisk
+    disk: disk
 - message_name: DeleteDiskHttpRequest
   field_entity_map:
-    disk: projectZoneDisk
+    disk: disk
 - message_name: GetDiskHttpRequest
   field_entity_map:
-    disk: projectZoneDisk
+    disk: disk
 - message_name: GetIamPolicyDiskHttpRequest
   field_entity_map:
-    resource: projectZoneDiskResource
+    resource: disksResource
 - message_name: InsertDiskHttpRequest
   field_entity_map:
-    zone: projectZone
+    zone: zone
 - message_name: ListDisksHttpRequest
   field_entity_map:
-    zone: projectZone
+    zone: zone
+- message_name: RemoveResourcePoliciesDiskHttpRequest
+  field_entity_map:
+    disk: disk
 - message_name: ResizeDiskHttpRequest
   field_entity_map:
-    disk: projectZoneDisk
+    disk: disk
 - message_name: SetIamPolicyDiskHttpRequest
   field_entity_map:
-    resource: projectZoneDiskResource
+    resource: disksResource
 - message_name: SetLabelsDiskHttpRequest
   field_entity_map:
-    resource: projectZoneDiskResource
+    resource: disksResource
 - message_name: TestIamPermissionsDiskHttpRequest
   field_entity_map:
-    resource: projectZoneDiskResource
+    resource: disksResource
 - message_name: DeleteFirewallHttpRequest
   field_entity_map:
-    firewall: projectGlobalFirewall
+    firewall: firewall
 - message_name: GetFirewallHttpRequest
   field_entity_map:
-    firewall: projectGlobalFirewall
+    firewall: firewall
 - message_name: InsertFirewallHttpRequest
   field_entity_map:
     project: project
@@ -13087,34 +15666,34 @@ resource_name_generation:
     project: project
 - message_name: PatchFirewallHttpRequest
   field_entity_map:
-    firewall: projectGlobalFirewall
+    firewall: firewall
 - message_name: UpdateFirewallHttpRequest
   field_entity_map:
-    firewall: projectGlobalFirewall
+    firewall: firewall
 - message_name: AggregatedListForwardingRulesHttpRequest
   field_entity_map:
     project: project
 - message_name: DeleteForwardingRuleHttpRequest
   field_entity_map:
-    forwardingRule: projectRegionForwardingRule
+    forwardingRule: forwardingRule
 - message_name: GetForwardingRuleHttpRequest
   field_entity_map:
-    forwardingRule: projectRegionForwardingRule
+    forwardingRule: forwardingRule
 - message_name: InsertForwardingRuleHttpRequest
   field_entity_map:
-    region: projectRegion
+    region: region
 - message_name: ListForwardingRulesHttpRequest
   field_entity_map:
-    region: projectRegion
+    region: region
 - message_name: SetTargetForwardingRuleHttpRequest
   field_entity_map:
-    forwardingRule: projectRegionForwardingRule
+    forwardingRule: forwardingRule
 - message_name: DeleteGlobalAddressHttpRequest
   field_entity_map:
-    address: projectGlobalAddress
+    address: globalAddressesAddress
 - message_name: GetGlobalAddressHttpRequest
   field_entity_map:
-    address: projectGlobalAddress
+    address: globalAddressesAddress
 - message_name: InsertGlobalAddressHttpRequest
   field_entity_map:
     project: project
@@ -13123,10 +15702,10 @@ resource_name_generation:
     project: project
 - message_name: DeleteGlobalForwardingRuleHttpRequest
   field_entity_map:
-    forwardingRule: projectGlobalForwardingRule
+    forwardingRule: globalForwardingRulesForwardingRule
 - message_name: GetGlobalForwardingRuleHttpRequest
   field_entity_map:
-    forwardingRule: projectGlobalForwardingRule
+    forwardingRule: globalForwardingRulesForwardingRule
 - message_name: InsertGlobalForwardingRuleHttpRequest
   field_entity_map:
     project: project
@@ -13135,25 +15714,25 @@ resource_name_generation:
     project: project
 - message_name: SetTargetGlobalForwardingRuleHttpRequest
   field_entity_map:
-    forwardingRule: projectGlobalForwardingRule
+    forwardingRule: globalForwardingRulesForwardingRule
 - message_name: AggregatedListGlobalOperationsHttpRequest
   field_entity_map:
     project: project
 - message_name: DeleteGlobalOperationHttpRequest
   field_entity_map:
-    operation: projectGlobalOperation
+    operation: globalOperationsOperation
 - message_name: GetGlobalOperationHttpRequest
   field_entity_map:
-    operation: projectGlobalOperation
+    operation: globalOperationsOperation
 - message_name: ListGlobalOperationsHttpRequest
   field_entity_map:
     project: project
 - message_name: DeleteHealthCheckHttpRequest
   field_entity_map:
-    healthCheck: projectGlobalHealthCheck
+    healthCheck: healthCheck
 - message_name: GetHealthCheckHttpRequest
   field_entity_map:
-    healthCheck: projectGlobalHealthCheck
+    healthCheck: healthCheck
 - message_name: InsertHealthCheckHttpRequest
   field_entity_map:
     project: project
@@ -13162,16 +15741,16 @@ resource_name_generation:
     project: project
 - message_name: PatchHealthCheckHttpRequest
   field_entity_map:
-    healthCheck: projectGlobalHealthCheck
+    healthCheck: healthCheck
 - message_name: UpdateHealthCheckHttpRequest
   field_entity_map:
-    healthCheck: projectGlobalHealthCheck
+    healthCheck: healthCheck
 - message_name: DeleteHttpHealthCheckHttpRequest
   field_entity_map:
-    httpHealthCheck: projectGlobalHttpHealthCheck
+    httpHealthCheck: httpHealthCheck
 - message_name: GetHttpHealthCheckHttpRequest
   field_entity_map:
-    httpHealthCheck: projectGlobalHttpHealthCheck
+    httpHealthCheck: httpHealthCheck
 - message_name: InsertHttpHealthCheckHttpRequest
   field_entity_map:
     project: project
@@ -13180,16 +15759,16 @@ resource_name_generation:
     project: project
 - message_name: PatchHttpHealthCheckHttpRequest
   field_entity_map:
-    httpHealthCheck: projectGlobalHttpHealthCheck
+    httpHealthCheck: httpHealthCheck
 - message_name: UpdateHttpHealthCheckHttpRequest
   field_entity_map:
-    httpHealthCheck: projectGlobalHttpHealthCheck
+    httpHealthCheck: httpHealthCheck
 - message_name: DeleteHttpsHealthCheckHttpRequest
   field_entity_map:
-    httpsHealthCheck: projectGlobalHttpsHealthCheck
+    httpsHealthCheck: httpsHealthCheck
 - message_name: GetHttpsHealthCheckHttpRequest
   field_entity_map:
-    httpsHealthCheck: projectGlobalHttpsHealthCheck
+    httpsHealthCheck: httpsHealthCheck
 - message_name: InsertHttpsHealthCheckHttpRequest
   field_entity_map:
     project: project
@@ -13198,25 +15777,25 @@ resource_name_generation:
     project: project
 - message_name: PatchHttpsHealthCheckHttpRequest
   field_entity_map:
-    httpsHealthCheck: projectGlobalHttpsHealthCheck
+    httpsHealthCheck: httpsHealthCheck
 - message_name: UpdateHttpsHealthCheckHttpRequest
   field_entity_map:
-    httpsHealthCheck: projectGlobalHttpsHealthCheck
+    httpsHealthCheck: httpsHealthCheck
 - message_name: DeleteImageHttpRequest
   field_entity_map:
-    image: projectGlobalImage
+    image: image
 - message_name: DeprecateImageHttpRequest
   field_entity_map:
-    image: projectGlobalImage
+    image: image
 - message_name: GetImageHttpRequest
   field_entity_map:
-    image: projectGlobalImage
+    image: image
 - message_name: GetFromFamilyImageHttpRequest
   field_entity_map:
-    family: projectGlobalImageFamily
+    family: family
 - message_name: GetIamPolicyImageHttpRequest
   field_entity_map:
-    resource: projectGlobalImageResource
+    resource: imagesResource
 - message_name: InsertImageHttpRequest
   field_entity_map:
     project: project
@@ -13225,88 +15804,88 @@ resource_name_generation:
     project: project
 - message_name: SetIamPolicyImageHttpRequest
   field_entity_map:
-    resource: projectGlobalImageResource
+    resource: imagesResource
 - message_name: SetLabelsImageHttpRequest
   field_entity_map:
-    resource: projectGlobalImageResource
+    resource: imagesResource
 - message_name: TestIamPermissionsImageHttpRequest
   field_entity_map:
-    resource: projectGlobalImageResource
+    resource: imagesResource
 - message_name: AbandonInstancesInstanceGroupManagerHttpRequest
   field_entity_map:
-    instanceGroupManager: projectZoneInstanceGroupManager
+    instanceGroupManager: instanceGroupManager
 - message_name: AggregatedListInstanceGroupManagersHttpRequest
   field_entity_map:
     project: project
 - message_name: DeleteInstanceGroupManagerHttpRequest
   field_entity_map:
-    instanceGroupManager: projectZoneInstanceGroupManager
+    instanceGroupManager: instanceGroupManager
 - message_name: DeleteInstancesInstanceGroupManagerHttpRequest
   field_entity_map:
-    instanceGroupManager: projectZoneInstanceGroupManager
+    instanceGroupManager: instanceGroupManager
 - message_name: GetInstanceGroupManagerHttpRequest
   field_entity_map:
-    instanceGroupManager: projectZoneInstanceGroupManager
+    instanceGroupManager: instanceGroupManager
 - message_name: InsertInstanceGroupManagerHttpRequest
   field_entity_map:
-    zone: projectZone
+    zone: zone
 - message_name: ListInstanceGroupManagersHttpRequest
   field_entity_map:
-    zone: projectZone
+    zone: zone
 - message_name: ListManagedInstancesInstanceGroupManagersHttpRequest
   field_entity_map:
-    instanceGroupManager: projectZoneInstanceGroupManager
+    instanceGroupManager: instanceGroupManager
 - message_name: PatchInstanceGroupManagerHttpRequest
   field_entity_map:
-    instanceGroupManager: projectZoneInstanceGroupManager
+    instanceGroupManager: instanceGroupManager
 - message_name: RecreateInstancesInstanceGroupManagerHttpRequest
   field_entity_map:
-    instanceGroupManager: projectZoneInstanceGroupManager
+    instanceGroupManager: instanceGroupManager
 - message_name: ResizeInstanceGroupManagerHttpRequest
   field_entity_map:
-    instanceGroupManager: projectZoneInstanceGroupManager
+    instanceGroupManager: instanceGroupManager
 - message_name: SetInstanceTemplateInstanceGroupManagerHttpRequest
   field_entity_map:
-    instanceGroupManager: projectZoneInstanceGroupManager
+    instanceGroupManager: instanceGroupManager
 - message_name: SetTargetPoolsInstanceGroupManagerHttpRequest
   field_entity_map:
-    instanceGroupManager: projectZoneInstanceGroupManager
+    instanceGroupManager: instanceGroupManager
 - message_name: AddInstancesInstanceGroupHttpRequest
   field_entity_map:
-    instanceGroup: projectZoneInstanceGroup
+    instanceGroup: instanceGroup
 - message_name: AggregatedListInstanceGroupsHttpRequest
   field_entity_map:
     project: project
 - message_name: DeleteInstanceGroupHttpRequest
   field_entity_map:
-    instanceGroup: projectZoneInstanceGroup
+    instanceGroup: instanceGroup
 - message_name: GetInstanceGroupHttpRequest
   field_entity_map:
-    instanceGroup: projectZoneInstanceGroup
+    instanceGroup: instanceGroup
 - message_name: InsertInstanceGroupHttpRequest
   field_entity_map:
-    zone: projectZone
+    zone: zone
 - message_name: ListInstanceGroupsHttpRequest
   field_entity_map:
-    zone: projectZone
+    zone: zone
 - message_name: ListInstancesInstanceGroupsHttpRequest
   field_entity_map:
-    instanceGroup: projectZoneInstanceGroup
+    instanceGroup: instanceGroup
 - message_name: RemoveInstancesInstanceGroupHttpRequest
   field_entity_map:
-    instanceGroup: projectZoneInstanceGroup
+    instanceGroup: instanceGroup
 - message_name: SetNamedPortsInstanceGroupHttpRequest
   field_entity_map:
-    instanceGroup: projectZoneInstanceGroup
+    instanceGroup: instanceGroup
 - message_name: DeleteInstanceTemplateHttpRequest
   field_entity_map:
-    instanceTemplate: projectGlobalInstanceTemplate
+    instanceTemplate: instanceTemplate
 - message_name: GetInstanceTemplateHttpRequest
   field_entity_map:
-    instanceTemplate: projectGlobalInstanceTemplate
+    instanceTemplate: instanceTemplate
 - message_name: GetIamPolicyInstanceTemplateHttpRequest
   field_entity_map:
-    resource: projectGlobalInstanceTemplateResource
+    resource: instanceTemplatesResource
 - message_name: InsertInstanceTemplateHttpRequest
   field_entity_map:
     project: project
@@ -13315,145 +15894,148 @@ resource_name_generation:
     project: project
 - message_name: SetIamPolicyInstanceTemplateHttpRequest
   field_entity_map:
-    resource: projectGlobalInstanceTemplateResource
+    resource: instanceTemplatesResource
 - message_name: TestIamPermissionsInstanceTemplateHttpRequest
   field_entity_map:
-    resource: projectGlobalInstanceTemplateResource
+    resource: instanceTemplatesResource
 - message_name: AddAccessConfigInstanceHttpRequest
   field_entity_map:
-    instance: projectZoneInstance
+    instance: instance
 - message_name: AggregatedListInstancesHttpRequest
   field_entity_map:
     project: project
 - message_name: AttachDiskInstanceHttpRequest
   field_entity_map:
-    instance: projectZoneInstance
+    instance: instance
 - message_name: DeleteInstanceHttpRequest
   field_entity_map:
-    instance: projectZoneInstance
+    instance: instance
 - message_name: DeleteAccessConfigInstanceHttpRequest
   field_entity_map:
-    instance: projectZoneInstance
+    instance: instance
 - message_name: DetachDiskInstanceHttpRequest
   field_entity_map:
-    instance: projectZoneInstance
+    instance: instance
 - message_name: GetInstanceHttpRequest
   field_entity_map:
-    instance: projectZoneInstance
+    instance: instance
+- message_name: GetGuestAttributesInstanceHttpRequest
+  field_entity_map:
+    instance: instance
 - message_name: GetIamPolicyInstanceHttpRequest
   field_entity_map:
-    resource: projectZoneInstanceResource
+    resource: instancesResource
 - message_name: GetSerialPortOutputInstanceHttpRequest
   field_entity_map:
-    instance: projectZoneInstance
+    instance: instance
 - message_name: GetShieldedInstanceIdentityInstanceHttpRequest
   field_entity_map:
-    instance: projectZoneInstance
+    instance: instance
 - message_name: InsertInstanceHttpRequest
   field_entity_map:
-    zone: projectZone
+    zone: zone
 - message_name: ListInstancesHttpRequest
   field_entity_map:
-    zone: projectZone
+    zone: zone
 - message_name: ListReferrersInstancesHttpRequest
   field_entity_map:
-    instance: projectZoneInstance
+    instance: instance
 - message_name: ResetInstanceHttpRequest
   field_entity_map:
-    instance: projectZoneInstance
+    instance: instance
 - message_name: SetDeletionProtectionInstanceHttpRequest
   field_entity_map:
-    resource: projectZoneInstanceResource
+    resource: instancesResource
 - message_name: SetDiskAutoDeleteInstanceHttpRequest
   field_entity_map:
-    instance: projectZoneInstance
+    instance: instance
 - message_name: SetIamPolicyInstanceHttpRequest
   field_entity_map:
-    resource: projectZoneInstanceResource
+    resource: instancesResource
 - message_name: SetLabelsInstanceHttpRequest
   field_entity_map:
-    instance: projectZoneInstance
+    instance: instance
 - message_name: SetMachineResourcesInstanceHttpRequest
   field_entity_map:
-    instance: projectZoneInstance
+    instance: instance
 - message_name: SetMachineTypeInstanceHttpRequest
   field_entity_map:
-    instance: projectZoneInstance
+    instance: instance
 - message_name: SetMetadataInstanceHttpRequest
   field_entity_map:
-    instance: projectZoneInstance
+    instance: instance
 - message_name: SetMinCpuPlatformInstanceHttpRequest
   field_entity_map:
-    instance: projectZoneInstance
+    instance: instance
 - message_name: SetSchedulingInstanceHttpRequest
   field_entity_map:
-    instance: projectZoneInstance
+    instance: instance
 - message_name: SetServiceAccountInstanceHttpRequest
   field_entity_map:
-    instance: projectZoneInstance
+    instance: instance
 - message_name: SetShieldedInstanceIntegrityPolicyInstanceHttpRequest
   field_entity_map:
-    instance: projectZoneInstance
+    instance: instance
 - message_name: SetTagsInstanceHttpRequest
   field_entity_map:
-    instance: projectZoneInstance
+    instance: instance
 - message_name: SimulateMaintenanceEventInstanceHttpRequest
   field_entity_map:
-    instance: projectZoneInstance
+    instance: instance
 - message_name: StartInstanceHttpRequest
   field_entity_map:
-    instance: projectZoneInstance
+    instance: instance
 - message_name: StartWithEncryptionKeyInstanceHttpRequest
   field_entity_map:
-    instance: projectZoneInstance
+    instance: instance
 - message_name: StopInstanceHttpRequest
   field_entity_map:
-    instance: projectZoneInstance
+    instance: instance
 - message_name: TestIamPermissionsInstanceHttpRequest
   field_entity_map:
-    resource: projectZoneInstanceResource
+    resource: instancesResource
 - message_name: UpdateAccessConfigInstanceHttpRequest
   field_entity_map:
-    instance: projectZoneInstance
+    instance: instance
 - message_name: UpdateNetworkInterfaceInstanceHttpRequest
   field_entity_map:
-    instance: projectZoneInstance
+    instance: instance
 - message_name: UpdateShieldedInstanceConfigInstanceHttpRequest
   field_entity_map:
-    instance: projectZoneInstance
+    instance: instance
 - message_name: AggregatedListInterconnectAttachmentsHttpRequest
   field_entity_map:
     project: project
 - message_name: DeleteInterconnectAttachmentHttpRequest
   field_entity_map:
-    interconnectAttachment: projectRegionInterconnectAttachment
+    interconnectAttachment: interconnectAttachment
 - message_name: GetInterconnectAttachmentHttpRequest
   field_entity_map:
-    interconnectAttachment: projectRegionInterconnectAttachment
+    interconnectAttachment: interconnectAttachment
 - message_name: InsertInterconnectAttachmentHttpRequest
   field_entity_map:
-    region: projectRegion
+    region: region
 - message_name: ListInterconnectAttachmentsHttpRequest
   field_entity_map:
-    region: projectRegion
+    region: region
 - message_name: PatchInterconnectAttachmentHttpRequest
   field_entity_map:
-    interconnectAttachment: projectRegionInterconnectAttachment
+    interconnectAttachment: interconnectAttachment
 - message_name: GetInterconnectLocationHttpRequest
   field_entity_map:
-    interconnectLocation: projectGlobalInterconnectLocation
+    interconnectLocation: interconnectLocation
 - message_name: ListInterconnectLocationsHttpRequest
   field_entity_map:
     project: project
 - message_name: DeleteInterconnectHttpRequest
   field_entity_map:
-    interconnect: projectGlobalInterconnect
+    interconnect: interconnect
 - message_name: GetInterconnectHttpRequest
   field_entity_map:
-    interconnect: projectGlobalInterconnect
+    interconnect: interconnect
 - message_name: GetDiagnosticsInterconnectHttpRequest
   field_entity_map:
-    interconnect: projectGlobalInterconnect
+    interconnect: interconnect
 - message_name: InsertInterconnectHttpRequest
   field_entity_map:
     project: project
@@ -13462,79 +16044,79 @@ resource_name_generation:
     project: project
 - message_name: PatchInterconnectHttpRequest
   field_entity_map:
-    interconnect: projectGlobalInterconnect
+    interconnect: interconnect
 - message_name: GetLicenseCodeHttpRequest
   field_entity_map:
-    licenseCode: projectGlobalLicenseCode
+    licenseCode: licenseCode
 - message_name: TestIamPermissionsLicenseCodeHttpRequest
   field_entity_map:
-    resource: projectGlobalLicenseCodeResource
-- message_name: DeleteLicenseHttpRequest
+    resource: licenseCodesResource
+- message_name: DeleteLicensHttpRequest
   field_entity_map:
-    license: projectGlobalLicense
-- message_name: GetLicenseHttpRequest
+    license: license
+- message_name: GetLicensHttpRequest
   field_entity_map:
-    license: projectGlobalLicense
-- message_name: GetIamPolicyLicenseHttpRequest
+    license: license
+- message_name: GetIamPolicyLicensHttpRequest
   field_entity_map:
-    resource: projectGlobalLicenseResource
-- message_name: InsertLicenseHttpRequest
+    resource: licensesResource
+- message_name: InsertLicensHttpRequest
   field_entity_map:
     project: project
 - message_name: ListLicensesHttpRequest
   field_entity_map:
     project: project
-- message_name: SetIamPolicyLicenseHttpRequest
+- message_name: SetIamPolicyLicensHttpRequest
   field_entity_map:
-    resource: projectGlobalLicenseResource
-- message_name: TestIamPermissionsLicenseHttpRequest
+    resource: licensesResource
+- message_name: TestIamPermissionsLicensHttpRequest
   field_entity_map:
-    resource: projectGlobalLicenseResource
+    resource: licensesResource
 - message_name: AggregatedListMachineTypesHttpRequest
   field_entity_map:
     project: project
 - message_name: GetMachineTypeHttpRequest
   field_entity_map:
-    machineType: projectZoneMachineType
+    machineType: machineType
 - message_name: ListMachineTypesHttpRequest
   field_entity_map:
-    zone: projectZone
+    zone: zone
 - message_name: AggregatedListNetworkEndpointGroupsHttpRequest
   field_entity_map:
     project: project
 - message_name: AttachNetworkEndpointsNetworkEndpointGroupHttpRequest
   field_entity_map:
-    networkEndpointGroup: projectZoneNetworkEndpointGroup
+    networkEndpointGroup: networkEndpointGroup
 - message_name: DeleteNetworkEndpointGroupHttpRequest
   field_entity_map:
-    networkEndpointGroup: projectZoneNetworkEndpointGroup
+    networkEndpointGroup: networkEndpointGroup
 - message_name: DetachNetworkEndpointsNetworkEndpointGroupHttpRequest
   field_entity_map:
-    networkEndpointGroup: projectZoneNetworkEndpointGroup
+    networkEndpointGroup: networkEndpointGroup
 - message_name: GetNetworkEndpointGroupHttpRequest
   field_entity_map:
-    networkEndpointGroup: projectZoneNetworkEndpointGroup
+    networkEndpointGroup: networkEndpointGroup
 - message_name: InsertNetworkEndpointGroupHttpRequest
   field_entity_map:
-    zone: projectZone
+    zone: zone
 - message_name: ListNetworkEndpointGroupsHttpRequest
   field_entity_map:
-    zone: projectZone
+    zone: zone
 - message_name: ListNetworkEndpointsNetworkEndpointGroupsHttpRequest
   field_entity_map:
-    networkEndpointGroup: projectZoneNetworkEndpointGroup
+    networkEndpointGroup: networkEndpointGroup
 - message_name: TestIamPermissionsNetworkEndpointGroupHttpRequest
   field_entity_map:
-    resource: projectZoneNetworkEndpointGroupResource
+    resource: networkEndpointGroupsResource
 - message_name: AddPeeringNetworkHttpRequest
   field_entity_map:
-    network: projectGlobalNetwork
+    network: network
 - message_name: DeleteNetworkHttpRequest
   field_entity_map:
-    network: projectGlobalNetwork
+    network: network
 - message_name: GetNetworkHttpRequest
   field_entity_map:
-    network: projectGlobalNetwork
+    network: network
 - message_name: InsertNetworkHttpRequest
   field_entity_map:
     project: project
@@ -13543,82 +16125,82 @@ resource_name_generation:
     project: project
 - message_name: PatchNetworkHttpRequest
   field_entity_map:
-    network: projectGlobalNetwork
+    network: network
 - message_name: RemovePeeringNetworkHttpRequest
   field_entity_map:
-    network: projectGlobalNetwork
+    network: network
 - message_name: SwitchToCustomModeNetworkHttpRequest
   field_entity_map:
-    network: projectGlobalNetwork
+    network: network
 - message_name: AddNodesNodeGroupHttpRequest
   field_entity_map:
-    nodeGroup: projectZoneNodeGroup
+    nodeGroup: nodeGroup
 - message_name: AggregatedListNodeGroupsHttpRequest
   field_entity_map:
     project: project
 - message_name: DeleteNodeGroupHttpRequest
   field_entity_map:
-    nodeGroup: projectZoneNodeGroup
+    nodeGroup: nodeGroup
 - message_name: DeleteNodesNodeGroupHttpRequest
   field_entity_map:
-    nodeGroup: projectZoneNodeGroup
+    nodeGroup: nodeGroup
 - message_name: GetNodeGroupHttpRequest
   field_entity_map:
-    nodeGroup: projectZoneNodeGroup
+    nodeGroup: nodeGroup
 - message_name: GetIamPolicyNodeGroupHttpRequest
   field_entity_map:
-    resource: projectZoneNodeGroupResource
+    resource: nodeGroupsResource
 - message_name: InsertNodeGroupHttpRequest
   field_entity_map:
-    zone: projectZone
+    zone: zone
 - message_name: ListNodeGroupsHttpRequest
   field_entity_map:
-    zone: projectZone
+    zone: zone
 - message_name: ListNodesNodeGroupsHttpRequest
   field_entity_map:
-    nodeGroup: projectZoneNodeGroup
+    nodeGroup: nodeGroup
 - message_name: SetIamPolicyNodeGroupHttpRequest
   field_entity_map:
-    resource: projectZoneNodeGroupResource
+    resource: nodeGroupsResource
 - message_name: SetNodeTemplateNodeGroupHttpRequest
   field_entity_map:
-    nodeGroup: projectZoneNodeGroup
+    nodeGroup: nodeGroup
 - message_name: TestIamPermissionsNodeGroupHttpRequest
   field_entity_map:
-    resource: projectZoneNodeGroupResource
+    resource: nodeGroupsResource
 - message_name: AggregatedListNodeTemplatesHttpRequest
   field_entity_map:
     project: project
 - message_name: DeleteNodeTemplateHttpRequest
   field_entity_map:
-    nodeTemplate: projectRegionNodeTemplate
+    nodeTemplate: nodeTemplate
 - message_name: GetNodeTemplateHttpRequest
   field_entity_map:
-    nodeTemplate: projectRegionNodeTemplate
+    nodeTemplate: nodeTemplate
 - message_name: GetIamPolicyNodeTemplateHttpRequest
   field_entity_map:
-    resource: projectRegionNodeTemplateResource
+    resource: nodeTemplatesResource
 - message_name: InsertNodeTemplateHttpRequest
   field_entity_map:
-    region: projectRegion
+    region: region
 - message_name: ListNodeTemplatesHttpRequest
   field_entity_map:
-    region: projectRegion
+    region: region
 - message_name: SetIamPolicyNodeTemplateHttpRequest
   field_entity_map:
-    resource: projectRegionNodeTemplateResource
+    resource: nodeTemplatesResource
 - message_name: TestIamPermissionsNodeTemplateHttpRequest
   field_entity_map:
-    resource: projectRegionNodeTemplateResource
+    resource: nodeTemplatesResource
 - message_name: AggregatedListNodeTypesHttpRequest
   field_entity_map:
     project: project
 - message_name: GetNodeTypeHttpRequest
   field_entity_map:
-    nodeType: projectZoneNodeType
+    nodeType: nodeType
 - message_name: ListNodeTypesHttpRequest
   field_entity_map:
-    zone: projectZone
+    zone: zone
 - message_name: DisableXpnHostProjectHttpRequest
   field_entity_map:
     project: project
@@ -13660,184 +16242,241 @@ resource_name_generation:
     project: project
 - message_name: DeleteRegionAutoscalerHttpRequest
   field_entity_map:
-    autoscaler: projectRegionAutoscaler
+    autoscaler: regionAutoscalersAutoscaler
 - message_name: GetRegionAutoscalerHttpRequest
   field_entity_map:
-    autoscaler: projectRegionAutoscaler
+    autoscaler: regionAutoscalersAutoscaler
 - message_name: InsertRegionAutoscalerHttpRequest
   field_entity_map:
-    region: projectRegion
+    region: region
 - message_name: ListRegionAutoscalersHttpRequest
   field_entity_map:
-    region: projectRegion
+    region: region
 - message_name: PatchRegionAutoscalerHttpRequest
   field_entity_map:
-    region: projectRegion
+    region: region
 - message_name: UpdateRegionAutoscalerHttpRequest
   field_entity_map:
-    region: projectRegion
+    region: region
 - message_name: DeleteRegionBackendServiceHttpRequest
   field_entity_map:
-    backendService: projectRegionBackendService
+    backendService: regionBackendServicesBackendService
 - message_name: GetRegionBackendServiceHttpRequest
   field_entity_map:
-    backendService: projectRegionBackendService
+    backendService: regionBackendServicesBackendService
 - message_name: GetHealthRegionBackendServiceHttpRequest
   field_entity_map:
-    backendService: projectRegionBackendService
+    backendService: regionBackendServicesBackendService
 - message_name: InsertRegionBackendServiceHttpRequest
   field_entity_map:
-    region: projectRegion
+    region: region
 - message_name: ListRegionBackendServicesHttpRequest
   field_entity_map:
-    region: projectRegion
+    region: region
 - message_name: PatchRegionBackendServiceHttpRequest
   field_entity_map:
-    backendService: projectRegionBackendService
+    backendService: regionBackendServicesBackendService
 - message_name: UpdateRegionBackendServiceHttpRequest
   field_entity_map:
-    backendService: projectRegionBackendService
+    backendService: regionBackendServicesBackendService
 - message_name: AggregatedListRegionCommitmentsHttpRequest
   field_entity_map:
     project: project
 - message_name: GetRegionCommitmentHttpRequest
   field_entity_map:
-    commitment: projectRegionCommitment
+    commitment: commitment
 - message_name: InsertRegionCommitmentHttpRequest
   field_entity_map:
-    region: projectRegion
+    region: region
 - message_name: ListRegionCommitmentsHttpRequest
   field_entity_map:
-    region: projectRegion
+    region: region
 - message_name: GetRegionDiskTypeHttpRequest
   field_entity_map:
-    diskType: projectRegionDiskType
+    diskType: regionDiskTypesDiskType
 - message_name: ListRegionDiskTypesHttpRequest
   field_entity_map:
-    region: projectRegion
+    region: region
+- message_name: AddResourcePoliciesRegionDiskHttpRequest
+  field_entity_map:
+    disk: regionDisksDisk
 - message_name: CreateSnapshotRegionDiskHttpRequest
   field_entity_map:
-    disk: projectRegionDisk
+    disk: regionDisksDisk
 - message_name: DeleteRegionDiskHttpRequest
   field_entity_map:
-    disk: projectRegionDisk
+    disk: regionDisksDisk
 - message_name: GetRegionDiskHttpRequest
   field_entity_map:
-    disk: projectRegionDisk
+    disk: regionDisksDisk
 - message_name: InsertRegionDiskHttpRequest
   field_entity_map:
-    region: projectRegion
+    region: region
 - message_name: ListRegionDisksHttpRequest
   field_entity_map:
-    region: projectRegion
+    region: region
+- message_name: RemoveResourcePoliciesRegionDiskHttpRequest
+  field_entity_map:
+    disk: regionDisksDisk
 - message_name: ResizeRegionDiskHttpRequest
   field_entity_map:
-    disk: projectRegionDisk
+    disk: regionDisksDisk
 - message_name: SetLabelsRegionDiskHttpRequest
   field_entity_map:
-    resource: projectRegionDiskResource
+    resource: regionDisksResource
 - message_name: TestIamPermissionsRegionDiskHttpRequest
   field_entity_map:
-    resource: projectRegionDiskResource
+    resource: regionDisksResource
 - message_name: AbandonInstancesRegionInstanceGroupManagerHttpRequest
   field_entity_map:
-    instanceGroupManager: projectRegionInstanceGroupManager
+    instanceGroupManager: regionInstanceGroupManagersInstanceGroupManager
 - message_name: DeleteRegionInstanceGroupManagerHttpRequest
   field_entity_map:
-    instanceGroupManager: projectRegionInstanceGroupManager
+    instanceGroupManager: regionInstanceGroupManagersInstanceGroupManager
 - message_name: DeleteInstancesRegionInstanceGroupManagerHttpRequest
   field_entity_map:
-    instanceGroupManager: projectRegionInstanceGroupManager
+    instanceGroupManager: regionInstanceGroupManagersInstanceGroupManager
 - message_name: GetRegionInstanceGroupManagerHttpRequest
   field_entity_map:
-    instanceGroupManager: projectRegionInstanceGroupManager
+    instanceGroupManager: regionInstanceGroupManagersInstanceGroupManager
 - message_name: InsertRegionInstanceGroupManagerHttpRequest
   field_entity_map:
-    region: projectRegion
+    region: region
 - message_name: ListRegionInstanceGroupManagersHttpRequest
   field_entity_map:
-    region: projectRegion
+    region: region
 - message_name: ListManagedInstancesRegionInstanceGroupManagersHttpRequest
   field_entity_map:
-    instanceGroupManager: projectRegionInstanceGroupManager
+    instanceGroupManager: regionInstanceGroupManagersInstanceGroupManager
 - message_name: PatchRegionInstanceGroupManagerHttpRequest
   field_entity_map:
-    instanceGroupManager: projectRegionInstanceGroupManager
+    instanceGroupManager: regionInstanceGroupManagersInstanceGroupManager
 - message_name: RecreateInstancesRegionInstanceGroupManagerHttpRequest
   field_entity_map:
-    instanceGroupManager: projectRegionInstanceGroupManager
+    instanceGroupManager: regionInstanceGroupManagersInstanceGroupManager
 - message_name: ResizeRegionInstanceGroupManagerHttpRequest
   field_entity_map:
-    instanceGroupManager: projectRegionInstanceGroupManager
+    instanceGroupManager: regionInstanceGroupManagersInstanceGroupManager
 - message_name: SetInstanceTemplateRegionInstanceGroupManagerHttpRequest
   field_entity_map:
-    instanceGroupManager: projectRegionInstanceGroupManager
+    instanceGroupManager: regionInstanceGroupManagersInstanceGroupManager
 - message_name: SetTargetPoolsRegionInstanceGroupManagerHttpRequest
   field_entity_map:
-    instanceGroupManager: projectRegionInstanceGroupManager
+    instanceGroupManager: regionInstanceGroupManagersInstanceGroupManager
 - message_name: GetRegionInstanceGroupHttpRequest
   field_entity_map:
-    instanceGroup: projectRegionInstanceGroup
+    instanceGroup: regionInstanceGroupsInstanceGroup
 - message_name: ListRegionInstanceGroupsHttpRequest
   field_entity_map:
-    region: projectRegion
+    region: region
 - message_name: ListInstancesRegionInstanceGroupsHttpRequest
   field_entity_map:
-    instanceGroup: projectRegionInstanceGroup
+    instanceGroup: regionInstanceGroupsInstanceGroup
 - message_name: SetNamedPortsRegionInstanceGroupHttpRequest
   field_entity_map:
-    instanceGroup: projectRegionInstanceGroup
+    instanceGroup: regionInstanceGroupsInstanceGroup
 - message_name: DeleteRegionOperationHttpRequest
   field_entity_map:
-    operation: projectRegionOperation
+    operation: regionOperationsOperation
 - message_name: GetRegionOperationHttpRequest
   field_entity_map:
-    operation: projectRegionOperation
+    operation: regionOperationsOperation
 - message_name: ListRegionOperationsHttpRequest
   field_entity_map:
-    region: projectRegion
+    region: region
 - message_name: GetRegionHttpRequest
   field_entity_map:
-    region: projectRegion
+    region: region
 - message_name: ListRegionsHttpRequest
   field_entity_map:
     project: project
+- message_name: AggregatedListReservationsHttpRequest
+  field_entity_map:
+    project: project
+- message_name: DeleteReservationHttpRequest
+  field_entity_map:
+    reservation: reservation
+- message_name: GetReservationHttpRequest
+  field_entity_map:
+    reservation: reservation
+- message_name: GetIamPolicyReservationHttpRequest
+  field_entity_map:
+    resource: reservationsResource
+- message_name: InsertReservationHttpRequest
+  field_entity_map:
+    zone: zone
+- message_name: ListReservationsHttpRequest
+  field_entity_map:
+    zone: zone
+- message_name: ResizeReservationHttpRequest
+  field_entity_map:
+    reservation: reservation
+- message_name: SetIamPolicyReservationHttpRequest
+  field_entity_map:
+    resource: reservationsResource
+- message_name: TestIamPermissionsReservationHttpRequest
+  field_entity_map:
+    resource: reservationsResource
+- message_name: AggregatedListResourcePoliciesHttpRequest
+  field_entity_map:
+    project: project
+- message_name: DeleteResourcePolicyHttpRequest
+  field_entity_map:
+    resourcePolicy: resourcePolicy
+- message_name: GetResourcePolicyHttpRequest
+  field_entity_map:
+    resourcePolicy: resourcePolicy
+- message_name: GetIamPolicyResourcePolicyHttpRequest
+  field_entity_map:
+    resource: resourcePoliciesResource
+- message_name: InsertResourcePolicyHttpRequest
+  field_entity_map:
+    region: region
+- message_name: ListResourcePoliciesHttpRequest
+  field_entity_map:
+    region: region
+- message_name: SetIamPolicyResourcePolicyHttpRequest
+  field_entity_map:
+    resource: resourcePoliciesResource
+- message_name: TestIamPermissionsResourcePolicyHttpRequest
+  field_entity_map:
+    resource: resourcePoliciesResource
 - message_name: AggregatedListRoutersHttpRequest
   field_entity_map:
     project: project
 - message_name: DeleteRouterHttpRequest
   field_entity_map:
-    router: projectRegionRouter
+    router: router
 - message_name: GetRouterHttpRequest
   field_entity_map:
-    router: projectRegionRouter
+    router: router
 - message_name: GetNatMappingInfoRoutersHttpRequest
   field_entity_map:
-    router: projectRegionRouter
+    router: router
 - message_name: GetRouterStatusRouterHttpRequest
   field_entity_map:
-    router: projectRegionRouter
+    router: router
 - message_name: InsertRouterHttpRequest
   field_entity_map:
-    region: projectRegion
+    region: region
 - message_name: ListRoutersHttpRequest
   field_entity_map:
-    region: projectRegion
+    region: region
 - message_name: PatchRouterHttpRequest
   field_entity_map:
-    router: projectRegionRouter
+    router: router
 - message_name: PreviewRouterHttpRequest
   field_entity_map:
-    router: projectRegionRouter
+    router: router
 - message_name: UpdateRouterHttpRequest
   field_entity_map:
-    router: projectRegionRouter
+    router: router
 - message_name: DeleteRouteHttpRequest
   field_entity_map:
-    route: projectGlobalRoute
+    route: route
 - message_name: GetRouteHttpRequest
   field_entity_map:
-    route: projectGlobalRoute
+    route: route
 - message_name: InsertRouteHttpRequest
   field_entity_map:
     project: project
@@ -13846,16 +16485,16 @@ resource_name_generation:
     project: project
 - message_name: AddRuleSecurityPolicyHttpRequest
   field_entity_map:
-    securityPolicy: projectGlobalSecurityPolicy
+    securityPolicy: securityPolicy
 - message_name: DeleteSecurityPolicyHttpRequest
   field_entity_map:
-    securityPolicy: projectGlobalSecurityPolicy
+    securityPolicy: securityPolicy
 - message_name: GetSecurityPolicyHttpRequest
   field_entity_map:
-    securityPolicy: projectGlobalSecurityPolicy
+    securityPolicy: securityPolicy
 - message_name: GetRuleSecurityPolicyHttpRequest
   field_entity_map:
-    securityPolicy: projectGlobalSecurityPolicy
+    securityPolicy: securityPolicy
 - message_name: InsertSecurityPolicyHttpRequest
   field_entity_map:
     project: project
@@ -13864,40 +16503,40 @@ resource_name_generation:
     project: project
 - message_name: PatchSecurityPolicyHttpRequest
   field_entity_map:
-    securityPolicy: projectGlobalSecurityPolicy
+    securityPolicy: securityPolicy
 - message_name: PatchRuleSecurityPolicyHttpRequest
   field_entity_map:
-    securityPolicy: projectGlobalSecurityPolicy
+    securityPolicy: securityPolicy
 - message_name: RemoveRuleSecurityPolicyHttpRequest
   field_entity_map:
-    securityPolicy: projectGlobalSecurityPolicy
+    securityPolicy: securityPolicy
 - message_name: DeleteSnapshotHttpRequest
   field_entity_map:
-    snapshot: projectGlobalSnapshot
+    snapshot: snapshot
 - message_name: GetSnapshotHttpRequest
   field_entity_map:
-    snapshot: projectGlobalSnapshot
+    snapshot: snapshot
 - message_name: GetIamPolicySnapshotHttpRequest
   field_entity_map:
-    resource: projectGlobalSnapshotResource
+    resource: snapshotsResource
 - message_name: ListSnapshotsHttpRequest
   field_entity_map:
     project: project
 - message_name: SetIamPolicySnapshotHttpRequest
   field_entity_map:
-    resource: projectGlobalSnapshotResource
+    resource: snapshotsResource
 - message_name: SetLabelsSnapshotHttpRequest
   field_entity_map:
-    resource: projectGlobalSnapshotResource
+    resource: snapshotsResource
 - message_name: TestIamPermissionsSnapshotHttpRequest
   field_entity_map:
-    resource: projectGlobalSnapshotResource
+    resource: snapshotsResource
 - message_name: DeleteSslCertificateHttpRequest
   field_entity_map:
-    sslCertificate: projectGlobalSslCertificate
+    sslCertificate: sslCertificate
 - message_name: GetSslCertificateHttpRequest
   field_entity_map:
-    sslCertificate: projectGlobalSslCertificate
+    sslCertificate: sslCertificate
 - message_name: InsertSslCertificateHttpRequest
   field_entity_map:
     project: project
@@ -13906,10 +16545,10 @@ resource_name_generation:
     project: project
 - message_name: DeleteSslPolicyHttpRequest
   field_entity_map:
-    sslPolicy: projectGlobalSslPolicy
+    sslPolicy: sslPolicy
 - message_name: GetSslPolicyHttpRequest
   field_entity_map:
-    sslPolicy: projectGlobalSslPolicy
+    sslPolicy: sslPolicy
 - message_name: InsertSslPolicyHttpRequest
   field_entity_map:
     project: project
@@ -13921,49 +16560,49 @@ resource_name_generation:
     project: project
 - message_name: PatchSslPolicyHttpRequest
   field_entity_map:
-    sslPolicy: projectGlobalSslPolicy
+    sslPolicy: sslPolicy
 - message_name: AggregatedListSubnetworksHttpRequest
   field_entity_map:
     project: project
 - message_name: DeleteSubnetworkHttpRequest
   field_entity_map:
-    subnetwork: projectRegionSubnetwork
+    subnetwork: subnetwork
 - message_name: ExpandIpCidrRangeSubnetworkHttpRequest
   field_entity_map:
-    subnetwork: projectRegionSubnetwork
+    subnetwork: subnetwork
 - message_name: GetSubnetworkHttpRequest
   field_entity_map:
-    subnetwork: projectRegionSubnetwork
+    subnetwork: subnetwork
 - message_name: GetIamPolicySubnetworkHttpRequest
   field_entity_map:
-    resource: projectRegionSubnetworkResource
+    resource: subnetworksResource
 - message_name: InsertSubnetworkHttpRequest
   field_entity_map:
-    region: projectRegion
+    region: region
 - message_name: ListSubnetworksHttpRequest
   field_entity_map:
-    region: projectRegion
+    region: region
 - message_name: ListUsableSubnetworksHttpRequest
   field_entity_map:
     project: project
 - message_name: PatchSubnetworkHttpRequest
   field_entity_map:
-    subnetwork: projectRegionSubnetwork
+    subnetwork: subnetwork
 - message_name: SetIamPolicySubnetworkHttpRequest
   field_entity_map:
-    resource: projectRegionSubnetworkResource
+    resource: subnetworksResource
 - message_name: SetPrivateIpGoogleAccessSubnetworkHttpRequest
   field_entity_map:
-    subnetwork: projectRegionSubnetwork
+    subnetwork: subnetwork
 - message_name: TestIamPermissionsSubnetworkHttpRequest
   field_entity_map:
-    resource: projectRegionSubnetworkResource
+    resource: subnetworksResource
 - message_name: DeleteTargetHttpProxyHttpRequest
   field_entity_map:
-    targetHttpProxy: projectGlobalTargetHttpProxy
+    targetHttpProxy: targetHttpProxy
 - message_name: GetTargetHttpProxyHttpRequest
   field_entity_map:
-    targetHttpProxy: projectGlobalTargetHttpProxy
+    targetHttpProxy: targetHttpProxy
 - message_name: InsertTargetHttpProxyHttpRequest
   field_entity_map:
     project: project
@@ -13972,13 +16611,13 @@ resource_name_generation:
     project: project
 - message_name: SetUrlMapTargetHttpProxyHttpRequest
   field_entity_map:
-    targetHttpProxy: projectTargetHttpProxy
+    targetHttpProxy: targetHttpProxy
 - message_name: DeleteTargetHttpsProxyHttpRequest
   field_entity_map:
-    targetHttpsProxy: projectGlobalTargetHttpsProxy
+    targetHttpsProxy: targetHttpsProxy
 - message_name: GetTargetHttpsProxyHttpRequest
   field_entity_map:
-    targetHttpsProxy: projectGlobalTargetHttpsProxy
+    targetHttpsProxy: targetHttpsProxy
 - message_name: InsertTargetHttpsProxyHttpRequest
   field_entity_map:
     project: project
@@ -13987,70 +16626,70 @@ resource_name_generation:
     project: project
 - message_name: SetQuicOverrideTargetHttpsProxyHttpRequest
   field_entity_map:
-    targetHttpsProxy: projectGlobalTargetHttpsProxy
+    targetHttpsProxy: targetHttpsProxy
 - message_name: SetSslCertificatesTargetHttpsProxyHttpRequest
   field_entity_map:
-    targetHttpsProxy: projectTargetHttpsProxy
+    targetHttpsProxy: targetHttpsProxy
 - message_name: SetSslPolicyTargetHttpsProxyHttpRequest
   field_entity_map:
-    targetHttpsProxy: projectGlobalTargetHttpsProxy
+    targetHttpsProxy: targetHttpsProxy
 - message_name: SetUrlMapTargetHttpsProxyHttpRequest
   field_entity_map:
-    targetHttpsProxy: projectTargetHttpsProxy
+    targetHttpsProxy: targetHttpsProxy
 - message_name: AggregatedListTargetInstancesHttpRequest
   field_entity_map:
     project: project
 - message_name: DeleteTargetInstanceHttpRequest
   field_entity_map:
-    targetInstance: projectZoneTargetInstance
+    targetInstance: targetInstance
 - message_name: GetTargetInstanceHttpRequest
   field_entity_map:
-    targetInstance: projectZoneTargetInstance
+    targetInstance: targetInstance
 - message_name: InsertTargetInstanceHttpRequest
   field_entity_map:
-    zone: projectZone
+    zone: zone
 - message_name: ListTargetInstancesHttpRequest
   field_entity_map:
-    zone: projectZone
+    zone: zone
 - message_name: AddHealthCheckTargetPoolHttpRequest
   field_entity_map:
-    targetPool: projectRegionTargetPool
+    targetPool: targetPool
 - message_name: AddInstanceTargetPoolHttpRequest
   field_entity_map:
-    targetPool: projectRegionTargetPool
+    targetPool: targetPool
 - message_name: AggregatedListTargetPoolsHttpRequest
   field_entity_map:
     project: project
 - message_name: DeleteTargetPoolHttpRequest
   field_entity_map:
-    targetPool: projectRegionTargetPool
+    targetPool: targetPool
 - message_name: GetTargetPoolHttpRequest
   field_entity_map:
-    targetPool: projectRegionTargetPool
+    targetPool: targetPool
 - message_name: GetHealthTargetPoolHttpRequest
   field_entity_map:
-    targetPool: projectRegionTargetPool
+    targetPool: targetPool
 - message_name: InsertTargetPoolHttpRequest
   field_entity_map:
-    region: projectRegion
+    region: region
 - message_name: ListTargetPoolsHttpRequest
   field_entity_map:
-    region: projectRegion
+    region: region
 - message_name: RemoveHealthCheckTargetPoolHttpRequest
   field_entity_map:
-    targetPool: projectRegionTargetPool
+    targetPool: targetPool
 - message_name: RemoveInstanceTargetPoolHttpRequest
   field_entity_map:
-    targetPool: projectRegionTargetPool
+    targetPool: targetPool
 - message_name: SetBackupTargetPoolHttpRequest
   field_entity_map:
-    targetPool: projectRegionTargetPool
+    targetPool: targetPool
 - message_name: DeleteTargetSslProxyHttpRequest
   field_entity_map:
-    targetSslProxy: projectGlobalTargetSslProxy
+    targetSslProxy: targetSslProxy
 - message_name: GetTargetSslProxyHttpRequest
   field_entity_map:
-    targetSslProxy: projectGlobalTargetSslProxy
+    targetSslProxy: targetSslProxy
 - message_name: InsertTargetSslProxyHttpRequest
   field_entity_map:
     project: project
@@ -14059,22 +16698,22 @@ resource_name_generation:
     project: project
 - message_name: SetBackendServiceTargetSslProxyHttpRequest
   field_entity_map:
-    targetSslProxy: projectGlobalTargetSslProxy
+    targetSslProxy: targetSslProxy
 - message_name: SetProxyHeaderTargetSslProxyHttpRequest
   field_entity_map:
-    targetSslProxy: projectGlobalTargetSslProxy
+    targetSslProxy: targetSslProxy
 - message_name: SetSslCertificatesTargetSslProxyHttpRequest
   field_entity_map:
-    targetSslProxy: projectGlobalTargetSslProxy
+    targetSslProxy: targetSslProxy
 - message_name: SetSslPolicyTargetSslProxyHttpRequest
   field_entity_map:
-    targetSslProxy: projectGlobalTargetSslProxy
+    targetSslProxy: targetSslProxy
 - message_name: DeleteTargetTcpProxyHttpRequest
   field_entity_map:
-    targetTcpProxy: projectGlobalTargetTcpProxy
+    targetTcpProxy: targetTcpProxy
 - message_name: GetTargetTcpProxyHttpRequest
   field_entity_map:
-    targetTcpProxy: projectGlobalTargetTcpProxy
+    targetTcpProxy: targetTcpProxy
 - message_name: InsertTargetTcpProxyHttpRequest
   field_entity_map:
     project: project
@@ -14083,76 +16722,76 @@ resource_name_generation:
     project: project
 - message_name: SetBackendServiceTargetTcpProxyHttpRequest
   field_entity_map:
-    targetTcpProxy: projectGlobalTargetTcpProxy
+    targetTcpProxy: targetTcpProxy
 - message_name: SetProxyHeaderTargetTcpProxyHttpRequest
   field_entity_map:
-    targetTcpProxy: projectGlobalTargetTcpProxy
+    targetTcpProxy: targetTcpProxy
 - message_name: AggregatedListTargetVpnGatewaysHttpRequest
   field_entity_map:
     project: project
 - message_name: DeleteTargetVpnGatewayHttpRequest
   field_entity_map:
-    targetVpnGateway: projectRegionTargetVpnGateway
+    targetVpnGateway: targetVpnGateway
 - message_name: GetTargetVpnGatewayHttpRequest
   field_entity_map:
-    targetVpnGateway: projectRegionTargetVpnGateway
+    targetVpnGateway: targetVpnGateway
 - message_name: InsertTargetVpnGatewayHttpRequest
   field_entity_map:
-    region: projectRegion
+    region: region
 - message_name: ListTargetVpnGatewaysHttpRequest
   field_entity_map:
-    region: projectRegion
+    region: region
 - message_name: DeleteUrlMapHttpRequest
   field_entity_map:
-    urlMap: projectGlobalUrlMap
+    urlMap: urlMap
 - message_name: GetUrlMapHttpRequest
   field_entity_map:
-    urlMap: projectGlobalUrlMap
+    urlMap: urlMap
 - message_name: InsertUrlMapHttpRequest
   field_entity_map:
     project: project
 - message_name: InvalidateCacheUrlMapHttpRequest
   field_entity_map:
-    urlMap: projectGlobalUrlMap
+    urlMap: urlMap
 - message_name: ListUrlMapsHttpRequest
   field_entity_map:
     project: project
 - message_name: PatchUrlMapHttpRequest
   field_entity_map:
-    urlMap: projectGlobalUrlMap
+    urlMap: urlMap
 - message_name: UpdateUrlMapHttpRequest
   field_entity_map:
-    urlMap: projectGlobalUrlMap
+    urlMap: urlMap
 - message_name: ValidateUrlMapHttpRequest
   field_entity_map:
-    urlMap: projectGlobalUrlMap
+    urlMap: urlMap
 - message_name: AggregatedListVpnTunnelsHttpRequest
   field_entity_map:
     project: project
 - message_name: DeleteVpnTunnelHttpRequest
   field_entity_map:
-    vpnTunnel: projectRegionVpnTunnel
+    vpnTunnel: vpnTunnel
 - message_name: GetVpnTunnelHttpRequest
   field_entity_map:
-    vpnTunnel: projectRegionVpnTunnel
+    vpnTunnel: vpnTunnel
 - message_name: InsertVpnTunnelHttpRequest
   field_entity_map:
-    region: projectRegion
+    region: region
 - message_name: ListVpnTunnelsHttpRequest
   field_entity_map:
-    region: projectRegion
+    region: region
 - message_name: DeleteZoneOperationHttpRequest
   field_entity_map:
-    operation: projectZoneOperation
+    operation: zoneOperationsOperation
 - message_name: GetZoneOperationHttpRequest
   field_entity_map:
-    operation: projectZoneOperation
+    operation: zoneOperationsOperation
 - message_name: ListZoneOperationsHttpRequest
   field_entity_map:
-    zone: projectZone
+    zone: zone
 - message_name: GetZoneHttpRequest
   field_entity_map:
-    zone: projectZone
+    zone: zone
 - message_name: ListZonesHttpRequest
   field_entity_map:
     project: project

--- a/toolkit/build.gradle
+++ b/toolkit/build.gradle
@@ -462,6 +462,19 @@ task runGrpcMetadataGen(type: JavaExec) {
   }
 }
 
+// Task to run DiscoveryConfigGeneratorTool
+// =================================================================
+task runDiscoConfigGen(type: JavaExec) {
+//
+// Command line args can be passed to the tool as a comma-separated list:
+//   ./gradlew runDiscoConfigGen '-Pclargs=--discovery_doc=../discoveries/compute.v1.json,-output=../gapic/google/compute/v1/compute_gapic.yaml'
+  classpath = sourceSets.main.runtimeClasspath
+  main = 'com.google.api.codegen.configgen.DiscoConfigGeneratorTool'
+  if (project.hasProperty('clargs')) {
+    args = clargs.split(',').toList()
+  }
+}
+
 // Task to run DiscoveryFragmentGeneratorTool
 // =================================================================
 task runDiscoGen(type: JavaExec) {

--- a/toolkit/src/main/java/com/google/api/codegen/configgen/DiscoConfigGeneratorTool.java
+++ b/toolkit/src/main/java/com/google/api/codegen/configgen/DiscoConfigGeneratorTool.java
@@ -39,7 +39,7 @@ public class DiscoConfigGeneratorTool {
     options.addOption(
         Option.builder("o")
             .longOpt("output")
-            .desc("The directory in which to output the generated config.")
+            .desc("The output file name for the generated config.")
             .hasArg()
             .argName("OUTPUT-FILE")
             .required(true)


### PR DESCRIPTION
As a reference for future refreshes, this update was done as follows:
1. from the `toolkit/` directory, run:
  ```
./gradlew runDiscoConfigGen '-Pclargs=--discovery_doc=../discoveries/compute.v1.json,-output=../gapic/google/compute/v1/compute_gapic.yaml'
```
2. manually edit the top packaging section of the yaml so it matches previous versions

This PR also includes the new gradle rule `runDiscoConfigGen` used
above, and clarifies the relevant command-line flag.

This should lead to https://github.com/googleapis/google-cloud-java/issues/5471 being resolved.