### PR TITLE
Regenerate Compute gapic config

### DIFF
--- a/gapic/google/compute/v1/compute_gapic.yaml
+++ b/gapic/google/compute/v1/compute_gapic.yaml
@@ -10,20 +10,20 @@ language_settings:
   java:
     package_name: com.google.cloud.compute.v1
   python:
-    package_name: com.google.compute_v1.gapic
+    package_name: google.cloud.compute_v1.gapic
   go:
-    package_name: google.golang.org/com/google/compute/v1
+    package_name: cloud.google.com/go/compute/apiv1
   csharp:
-    package_name: Com.Google.Compute.V1
+    package_name: Google.Compute.V1
   ruby:
-    package_name: Com::Google::Compute::V1
+    package_name: Google::Cloud::Compute::V1
   php:
-    package_name: Com\Google\Compute\V1
+    package_name: Google\Cloud\Compute\V1
   nodejs:
     package_name: compute.v1
 # A list of API interface configurations.
 interfaces:
-  # The fully qualified name of the API interface.
+# The fully qualified name of the API interface.
 - name: google.compute.v1.AcceleratorTypes
   # A list of resource collection configurations.
   # Consists of a name_pattern and an entity_name.
@@ -36,18 +36,18 @@ interfaces:
   # The entity_name is the name to be used as a basis for generated methods and
   # classes.
   collections:
-  - name_pattern: projects/{project}
+  - name_pattern: '{project}'
     entity_name: project
-  - name_pattern: projects/{project}/zones/{zone}
-    entity_name: zone
-  - name_pattern: projects/{project}/zones/{zone}/acceleratorTypes/{acceleratorType}
-    entity_name: acceleratorType
+  - name_pattern: '{project}/zones/{zone}'
+    entity_name: projectZone
+  - name_pattern: '{project}/zones/{zone}/acceleratorTypes/{acceleratorType}'
+    entity_name: projectZoneAcceleratorType
   # Definition for retryable codes.
   retry_codes_def:
   - name: idempotent
     retry_codes:
-    - SC_SERVICE_UNAVAILABLE
-    - SC_GATEWAY_TIMEOUT
+    - UNAVAILABLE
+    - DEADLINE_EXCEEDED
   - name: non_idempotent
     retry_codes: []
   # Definition for retry/backoff parameters.
@@ -73,17 +73,6 @@ interfaces:
   #       message.
   #   required_fields - Fields that are always required for a request to be
   #       valid.
-  #   request_object_method - Turns on or off the generation of a method whose
-  #       sole parameter is a request object. Not all languages will generate
-  #       this method.
-  #   resource_name_treatment - An enum that specifies how to treat the
-  #       resource name formats defined in the field_name_patterns
-  #       and response_field_name_patterns fields.
-  #       UNSET: default value
-  #       NONE: the collection configs will not be used by the generated code.
-  #       VALIDATE: string fields will be validated by the client against the
-  #           specified resource name formats.
-  #       STATIC_TYPES: the client will use generated types for resource names.
   #   page_streaming - Specifies the configuration for paging.
   #       Describes information for generating a method which transforms a
   #       paging list RPC into a stream of resources.
@@ -121,15 +110,13 @@ interfaces:
     # TODO: Configure which fields are required.
     required_fields:
     - project
-    request_object_method: true
-    resource_name_treatment: STATIC_TYPES
     page_streaming:
       request:
         page_size_field: maxResults
         token_field: pageToken
       response:
         token_field: nextPageToken
-        resources_field: AcceleratorTypeAggregatedList
+        resources_field: items
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: idempotent
     # TODO: Configure the retryable params for this method.
@@ -148,14 +135,12 @@ interfaces:
     # TODO: Configure which fields are required.
     required_fields:
     - acceleratorType
-    request_object_method: true
-    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      acceleratorType: acceleratorType
+      acceleratorType: projectZoneAcceleratorType
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
   - name: compute.acceleratorTypes.list
@@ -168,24 +153,22 @@ interfaces:
     # TODO: Configure which fields are required.
     required_fields:
     - zone
-    request_object_method: true
-    resource_name_treatment: STATIC_TYPES
     page_streaming:
       request:
         page_size_field: maxResults
         token_field: pageToken
       response:
         token_field: nextPageToken
-        resources_field: AcceleratorTypeList
+        resources_field: items
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      zone: zone
+      zone: projectZone
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
-  # The fully qualified name of the API interface.
+# The fully qualified name of the API interface.
 - name: google.compute.v1.Addresses
   # A list of resource collection configurations.
   # Consists of a name_pattern and an entity_name.
@@ -198,18 +181,18 @@ interfaces:
   # The entity_name is the name to be used as a basis for generated methods and
   # classes.
   collections:
-  - name_pattern: projects/{project}
+  - name_pattern: '{project}'
     entity_name: project
-  - name_pattern: projects/{project}/regions/{region}
-    entity_name: region
-  - name_pattern: projects/{project}/regions/{region}/addresses/{address}
-    entity_name: address
+  - name_pattern: '{project}/regions/{region}'
+    entity_name: projectRegion
+  - name_pattern: '{project}/regions/{region}/addresses/{address}'
+    entity_name: projectRegionAddress
   # Definition for retryable codes.
   retry_codes_def:
   - name: idempotent
     retry_codes:
-    - SC_SERVICE_UNAVAILABLE
-    - SC_GATEWAY_TIMEOUT
+    - UNAVAILABLE
+    - DEADLINE_EXCEEDED
   - name: non_idempotent
     retry_codes: []
   # Definition for retry/backoff parameters.
@@ -235,17 +218,6 @@ interfaces:
   #       message.
   #   required_fields - Fields that are always required for a request to be
   #       valid.
-  #   request_object_method - Turns on or off the generation of a method whose
-  #       sole parameter is a request object. Not all languages will generate
-  #       this method.
-  #   resource_name_treatment - An enum that specifies how to treat the
-  #       resource name formats defined in the field_name_patterns
-  #       and response_field_name_patterns fields.
-  #       UNSET: default value
-  #       NONE: the collection configs will not be used by the generated code.
-  #       VALIDATE: string fields will be validated by the client against the
-  #           specified resource name formats.
-  #       STATIC_TYPES: the client will use generated types for resource names.
   #   page_streaming - Specifies the configuration for paging.
   #       Describes information for generating a method which transforms a
   #       paging list RPC into a stream of resources.
@@ -283,15 +255,13 @@ interfaces:
     # TODO: Configure which fields are required.
     required_fields:
     - project
-    request_object_method: true
-    resource_name_treatment: STATIC_TYPES
     page_streaming:
       request:
         page_size_field: maxResults
         token_field: pageToken
       response:
         token_field: nextPageToken
-        resources_field: AddressAggregatedList
+        resources_field: items
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: idempotent
     # TODO: Configure the retryable params for this method.
@@ -307,19 +277,15 @@ interfaces:
       groups:
       - parameters:
         - address
-        - requestId
     # TODO: Configure which fields are required.
     required_fields:
     - address
-    - requestId
-    request_object_method: true
-    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      address: address
+      address: projectRegionAddress
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
   - name: compute.addresses.get
@@ -332,14 +298,12 @@ interfaces:
     # TODO: Configure which fields are required.
     required_fields:
     - address
-    request_object_method: true
-    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      address: address
+      address: projectRegionAddress
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
   - name: compute.addresses.insert
@@ -348,22 +312,18 @@ interfaces:
     flattening:
       groups:
       - parameters:
-        - requestId
         - region
         - addressResource
     # TODO: Configure which fields are required.
     required_fields:
-    - requestId
     - region
     - addressResource
-    request_object_method: true
-    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: non_idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      region: region
+      region: projectRegion
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
   - name: compute.addresses.list
@@ -376,24 +336,22 @@ interfaces:
     # TODO: Configure which fields are required.
     required_fields:
     - region
-    request_object_method: true
-    resource_name_treatment: STATIC_TYPES
     page_streaming:
       request:
         page_size_field: maxResults
         token_field: pageToken
       response:
         token_field: nextPageToken
-        resources_field: AddressList
+        resources_field: items
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      region: region
+      region: projectRegion
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
-  # The fully qualified name of the API interface.
+# The fully qualified name of the API interface.
 - name: google.compute.v1.Autoscalers
   # A list of resource collection configurations.
   # Consists of a name_pattern and an entity_name.
@@ -406,18 +364,18 @@ interfaces:
   # The entity_name is the name to be used as a basis for generated methods and
   # classes.
   collections:
-  - name_pattern: projects/{project}
+  - name_pattern: '{project}'
     entity_name: project
-  - name_pattern: projects/{project}/zones/{zone}
-    entity_name: zone
-  - name_pattern: projects/{project}/zones/{zone}/autoscalers/{autoscaler}
-    entity_name: autoscaler
+  - name_pattern: '{project}/zones/{zone}'
+    entity_name: projectZone
+  - name_pattern: '{project}/zones/{zone}/autoscalers/{autoscaler}'
+    entity_name: projectZoneAutoscaler
   # Definition for retryable codes.
   retry_codes_def:
   - name: idempotent
     retry_codes:
-    - SC_SERVICE_UNAVAILABLE
-    - SC_GATEWAY_TIMEOUT
+    - UNAVAILABLE
+    - DEADLINE_EXCEEDED
   - name: non_idempotent
     retry_codes: []
   # Definition for retry/backoff parameters.
@@ -443,17 +401,6 @@ interfaces:
   #       message.
   #   required_fields - Fields that are always required for a request to be
   #       valid.
-  #   request_object_method - Turns on or off the generation of a method whose
-  #       sole parameter is a request object. Not all languages will generate
-  #       this method.
-  #   resource_name_treatment - An enum that specifies how to treat the
-  #       resource name formats defined in the field_name_patterns
-  #       and response_field_name_patterns fields.
-  #       UNSET: default value
-  #       NONE: the collection configs will not be used by the generated code.
-  #       VALIDATE: string fields will be validated by the client against the
-  #           specified resource name formats.
-  #       STATIC_TYPES: the client will use generated types for resource names.
   #   page_streaming - Specifies the configuration for paging.
   #       Describes information for generating a method which transforms a
   #       paging list RPC into a stream of resources.
@@ -491,15 +438,13 @@ interfaces:
     # TODO: Configure which fields are required.
     required_fields:
     - project
-    request_object_method: true
-    resource_name_treatment: STATIC_TYPES
     page_streaming:
       request:
         page_size_field: maxResults
         token_field: pageToken
       response:
         token_field: nextPageToken
-        resources_field: AutoscalerAggregatedList
+        resources_field: items
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: idempotent
     # TODO: Configure the retryable params for this method.
@@ -515,19 +460,15 @@ interfaces:
       groups:
       - parameters:
         - autoscaler
-        - requestId
     # TODO: Configure which fields are required.
     required_fields:
     - autoscaler
-    - requestId
-    request_object_method: true
-    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      autoscaler: autoscaler
+      autoscaler: projectZoneAutoscaler
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
   - name: compute.autoscalers.get
@@ -540,14 +481,12 @@ interfaces:
     # TODO: Configure which fields are required.
     required_fields:
     - autoscaler
-    request_object_method: true
-    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      autoscaler: autoscaler
+      autoscaler: projectZoneAutoscaler
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
   - name: compute.autoscalers.insert
@@ -557,21 +496,17 @@ interfaces:
       groups:
       - parameters:
         - zone
-        - requestId
         - autoscalerResource
     # TODO: Configure which fields are required.
     required_fields:
     - zone
-    - requestId
     - autoscalerResource
-    request_object_method: true
-    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: non_idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      zone: zone
+      zone: projectZone
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
   - name: compute.autoscalers.list
@@ -584,21 +519,19 @@ interfaces:
     # TODO: Configure which fields are required.
     required_fields:
     - zone
-    request_object_method: true
-    resource_name_treatment: STATIC_TYPES
     page_streaming:
       request:
         page_size_field: maxResults
         token_field: pageToken
       response:
         token_field: nextPageToken
-        resources_field: AutoscalerList
+        resources_field: items
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      zone: zone
+      zone: projectZone
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
   - name: compute.autoscalers.patch
@@ -609,22 +542,18 @@ interfaces:
       - parameters:
         - autoscaler
         - zone
-        - requestId
         - autoscalerResource
     # TODO: Configure which fields are required.
     required_fields:
     - autoscaler
     - zone
-    - requestId
     - autoscalerResource
-    request_object_method: true
-    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: non_idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      zone: zone
+      zone: projectZone
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
   - name: compute.autoscalers.update
@@ -635,25 +564,21 @@ interfaces:
       - parameters:
         - autoscaler
         - zone
-        - requestId
         - autoscalerResource
     # TODO: Configure which fields are required.
     required_fields:
     - autoscaler
     - zone
-    - requestId
     - autoscalerResource
-    request_object_method: true
-    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      zone: zone
+      zone: projectZone
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
-  # The fully qualified name of the API interface.
+# The fully qualified name of the API interface.
 - name: google.compute.v1.BackendBuckets
   # A list of resource collection configurations.
   # Consists of a name_pattern and an entity_name.
@@ -666,16 +591,16 @@ interfaces:
   # The entity_name is the name to be used as a basis for generated methods and
   # classes.
   collections:
-  - name_pattern: projects/{project}
+  - name_pattern: '{project}'
     entity_name: project
-  - name_pattern: projects/{project}/backendBuckets/{backendBucket}
-    entity_name: backendBucket
+  - name_pattern: '{project}/global/backendBuckets/{backendBucket}'
+    entity_name: projectGlobalBackendBucket
   # Definition for retryable codes.
   retry_codes_def:
   - name: idempotent
     retry_codes:
-    - SC_SERVICE_UNAVAILABLE
-    - SC_GATEWAY_TIMEOUT
+    - UNAVAILABLE
+    - DEADLINE_EXCEEDED
   - name: non_idempotent
     retry_codes: []
   # Definition for retry/backoff parameters.
@@ -701,17 +626,6 @@ interfaces:
   #       message.
   #   required_fields - Fields that are always required for a request to be
   #       valid.
-  #   request_object_method - Turns on or off the generation of a method whose
-  #       sole parameter is a request object. Not all languages will generate
-  #       this method.
-  #   resource_name_treatment - An enum that specifies how to treat the
-  #       resource name formats defined in the field_name_patterns
-  #       and response_field_name_patterns fields.
-  #       UNSET: default value
-  #       NONE: the collection configs will not be used by the generated code.
-  #       VALIDATE: string fields will be validated by the client against the
-  #           specified resource name formats.
-  #       STATIC_TYPES: the client will use generated types for resource names.
   #   page_streaming - Specifies the configuration for paging.
   #       Describes information for generating a method which transforms a
   #       paging list RPC into a stream of resources.
@@ -746,21 +660,17 @@ interfaces:
       groups:
       - parameters:
         - backendBucket
-        - requestId
         - signedUrlKeyResource
     # TODO: Configure which fields are required.
     required_fields:
     - backendBucket
-    - requestId
     - signedUrlKeyResource
-    request_object_method: true
-    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: non_idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      backendBucket: backendBucket
+      backendBucket: projectGlobalBackendBucket
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
   - name: compute.backendBuckets.delete
@@ -770,19 +680,15 @@ interfaces:
       groups:
       - parameters:
         - backendBucket
-        - requestId
     # TODO: Configure which fields are required.
     required_fields:
     - backendBucket
-    - requestId
-    request_object_method: true
-    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      backendBucket: backendBucket
+      backendBucket: projectGlobalBackendBucket
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
   - name: compute.backendBuckets.deleteSignedUrlKey
@@ -792,21 +698,17 @@ interfaces:
       groups:
       - parameters:
         - backendBucket
-        - requestId
         - keyName
     # TODO: Configure which fields are required.
     required_fields:
     - backendBucket
-    - requestId
     - keyName
-    request_object_method: true
-    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: non_idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      backendBucket: backendBucket
+      backendBucket: projectGlobalBackendBucket
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
   - name: compute.backendBuckets.get
@@ -819,14 +721,12 @@ interfaces:
     # TODO: Configure which fields are required.
     required_fields:
     - backendBucket
-    request_object_method: true
-    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      backendBucket: backendBucket
+      backendBucket: projectGlobalBackendBucket
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
   - name: compute.backendBuckets.insert
@@ -835,16 +735,12 @@ interfaces:
     flattening:
       groups:
       - parameters:
-        - requestId
         - project
         - backendBucketResource
     # TODO: Configure which fields are required.
     required_fields:
-    - requestId
     - project
     - backendBucketResource
-    request_object_method: true
-    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: non_idempotent
     # TODO: Configure the retryable params for this method.
@@ -863,15 +759,13 @@ interfaces:
     # TODO: Configure which fields are required.
     required_fields:
     - project
-    request_object_method: true
-    resource_name_treatment: STATIC_TYPES
     page_streaming:
       request:
         page_size_field: maxResults
         token_field: pageToken
       response:
         token_field: nextPageToken
-        resources_field: BackendBucketList
+        resources_field: items
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: idempotent
     # TODO: Configure the retryable params for this method.
@@ -887,21 +781,17 @@ interfaces:
       groups:
       - parameters:
         - backendBucket
-        - requestId
         - backendBucketResource
     # TODO: Configure which fields are required.
     required_fields:
     - backendBucket
-    - requestId
     - backendBucketResource
-    request_object_method: true
-    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: non_idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      backendBucket: backendBucket
+      backendBucket: projectGlobalBackendBucket
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
   - name: compute.backendBuckets.update
@@ -911,24 +801,20 @@ interfaces:
       groups:
       - parameters:
         - backendBucket
-        - requestId
         - backendBucketResource
     # TODO: Configure which fields are required.
     required_fields:
     - backendBucket
-    - requestId
     - backendBucketResource
-    request_object_method: true
-    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      backendBucket: backendBucket
+      backendBucket: projectGlobalBackendBucket
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
-  # The fully qualified name of the API interface.
+# The fully qualified name of the API interface.
 - name: google.compute.v1.BackendServices
   # A list of resource collection configurations.
   # Consists of a name_pattern and an entity_name.
@@ -941,16 +827,16 @@ interfaces:
   # The entity_name is the name to be used as a basis for generated methods and
   # classes.
   collections:
-  - name_pattern: projects/{project}
+  - name_pattern: '{project}'
     entity_name: project
-  - name_pattern: projects/{project}/backendServices/{backendService}
-    entity_name: backendService
+  - name_pattern: '{project}/global/backendServices/{backendService}'
+    entity_name: projectGlobalBackendService
   # Definition for retryable codes.
   retry_codes_def:
   - name: idempotent
     retry_codes:
-    - SC_SERVICE_UNAVAILABLE
-    - SC_GATEWAY_TIMEOUT
+    - UNAVAILABLE
+    - DEADLINE_EXCEEDED
   - name: non_idempotent
     retry_codes: []
   # Definition for retry/backoff parameters.
@@ -976,17 +862,6 @@ interfaces:
   #       message.
   #   required_fields - Fields that are always required for a request to be
   #       valid.
-  #   request_object_method - Turns on or off the generation of a method whose
-  #       sole parameter is a request object. Not all languages will generate
-  #       this method.
-  #   resource_name_treatment - An enum that specifies how to treat the
-  #       resource name formats defined in the field_name_patterns
-  #       and response_field_name_patterns fields.
-  #       UNSET: default value
-  #       NONE: the collection configs will not be used by the generated code.
-  #       VALIDATE: string fields will be validated by the client against the
-  #           specified resource name formats.
-  #       STATIC_TYPES: the client will use generated types for resource names.
   #   page_streaming - Specifies the configuration for paging.
   #       Describes information for generating a method which transforms a
   #       paging list RPC into a stream of resources.
@@ -1020,22 +895,18 @@ interfaces:
     flattening:
       groups:
       - parameters:
-        - requestId
         - backendService
         - signedUrlKeyResource
     # TODO: Configure which fields are required.
     required_fields:
-    - requestId
     - backendService
     - signedUrlKeyResource
-    request_object_method: true
-    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: non_idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      backendService: backendService
+      backendService: projectGlobalBackendService
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
   - name: compute.backendServices.aggregatedList
@@ -1048,15 +919,13 @@ interfaces:
     # TODO: Configure which fields are required.
     required_fields:
     - project
-    request_object_method: true
-    resource_name_treatment: STATIC_TYPES
     page_streaming:
       request:
         page_size_field: maxResults
         token_field: pageToken
       response:
         token_field: nextPageToken
-        resources_field: BackendServiceAggregatedList
+        resources_field: items
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: idempotent
     # TODO: Configure the retryable params for this method.
@@ -1071,20 +940,16 @@ interfaces:
     flattening:
       groups:
       - parameters:
-        - requestId
         - backendService
     # TODO: Configure which fields are required.
     required_fields:
-    - requestId
     - backendService
-    request_object_method: true
-    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      backendService: backendService
+      backendService: projectGlobalBackendService
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
   - name: compute.backendServices.deleteSignedUrlKey
@@ -1093,22 +958,18 @@ interfaces:
     flattening:
       groups:
       - parameters:
-        - requestId
         - backendService
         - keyName
     # TODO: Configure which fields are required.
     required_fields:
-    - requestId
     - backendService
     - keyName
-    request_object_method: true
-    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: non_idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      backendService: backendService
+      backendService: projectGlobalBackendService
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
   - name: compute.backendServices.get
@@ -1121,14 +982,12 @@ interfaces:
     # TODO: Configure which fields are required.
     required_fields:
     - backendService
-    request_object_method: true
-    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      backendService: backendService
+      backendService: projectGlobalBackendService
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
   - name: compute.backendServices.getHealth
@@ -1143,14 +1002,12 @@ interfaces:
     required_fields:
     - backendService
     - resourceGroupReferenceResource
-    request_object_method: true
-    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: non_idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      backendService: backendService
+      backendService: projectGlobalBackendService
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
   - name: compute.backendServices.insert
@@ -1159,16 +1016,12 @@ interfaces:
     flattening:
       groups:
       - parameters:
-        - requestId
         - project
         - backendServiceResource
     # TODO: Configure which fields are required.
     required_fields:
-    - requestId
     - project
     - backendServiceResource
-    request_object_method: true
-    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: non_idempotent
     # TODO: Configure the retryable params for this method.
@@ -1187,15 +1040,13 @@ interfaces:
     # TODO: Configure which fields are required.
     required_fields:
     - project
-    request_object_method: true
-    resource_name_treatment: STATIC_TYPES
     page_streaming:
       request:
         page_size_field: maxResults
         token_field: pageToken
       response:
         token_field: nextPageToken
-        resources_field: BackendServiceList
+        resources_field: items
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: idempotent
     # TODO: Configure the retryable params for this method.
@@ -1210,22 +1061,18 @@ interfaces:
     flattening:
       groups:
       - parameters:
-        - requestId
         - backendService
         - backendServiceResource
     # TODO: Configure which fields are required.
     required_fields:
-    - requestId
     - backendService
     - backendServiceResource
-    request_object_method: true
-    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: non_idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      backendService: backendService
+      backendService: projectGlobalBackendService
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
   - name: compute.backendServices.setSecurityPolicy
@@ -1234,22 +1081,18 @@ interfaces:
     flattening:
       groups:
       - parameters:
-        - requestId
         - backendService
         - securityPolicyReferenceResource
     # TODO: Configure which fields are required.
     required_fields:
-    - requestId
     - backendService
     - securityPolicyReferenceResource
-    request_object_method: true
-    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: non_idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      backendService: backendService
+      backendService: projectGlobalBackendService
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
   - name: compute.backendServices.update
@@ -1258,25 +1101,21 @@ interfaces:
     flattening:
       groups:
       - parameters:
-        - requestId
         - backendService
         - backendServiceResource
     # TODO: Configure which fields are required.
     required_fields:
-    - requestId
     - backendService
     - backendServiceResource
-    request_object_method: true
-    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      backendService: backendService
+      backendService: projectGlobalBackendService
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
-  # The fully qualified name of the API interface.
+# The fully qualified name of the API interface.
 - name: google.compute.v1.DiskTypes
   # A list of resource collection configurations.
   # Consists of a name_pattern and an entity_name.
@@ -1289,18 +1128,18 @@ interfaces:
   # The entity_name is the name to be used as a basis for generated methods and
   # classes.
   collections:
-  - name_pattern: projects/{project}
+  - name_pattern: '{project}'
     entity_name: project
-  - name_pattern: projects/{project}/zones/{zone}
-    entity_name: zone
-  - name_pattern: projects/{project}/zones/{zone}/diskTypes/{diskType}
-    entity_name: diskType
+  - name_pattern: '{project}/zones/{zone}'
+    entity_name: projectZone
+  - name_pattern: '{project}/zones/{zone}/diskTypes/{diskType}'
+    entity_name: projectZoneDiskType
   # Definition for retryable codes.
   retry_codes_def:
   - name: idempotent
     retry_codes:
-    - SC_SERVICE_UNAVAILABLE
-    - SC_GATEWAY_TIMEOUT
+    - UNAVAILABLE
+    - DEADLINE_EXCEEDED
   - name: non_idempotent
     retry_codes: []
   # Definition for retry/backoff parameters.
@@ -1326,17 +1165,6 @@ interfaces:
   #       message.
   #   required_fields - Fields that are always required for a request to be
   #       valid.
-  #   request_object_method - Turns on or off the generation of a method whose
-  #       sole parameter is a request object. Not all languages will generate
-  #       this method.
-  #   resource_name_treatment - An enum that specifies how to treat the
-  #       resource name formats defined in the field_name_patterns
-  #       and response_field_name_patterns fields.
-  #       UNSET: default value
-  #       NONE: the collection configs will not be used by the generated code.
-  #       VALIDATE: string fields will be validated by the client against the
-  #           specified resource name formats.
-  #       STATIC_TYPES: the client will use generated types for resource names.
   #   page_streaming - Specifies the configuration for paging.
   #       Describes information for generating a method which transforms a
   #       paging list RPC into a stream of resources.
@@ -1374,15 +1202,13 @@ interfaces:
     # TODO: Configure which fields are required.
     required_fields:
     - project
-    request_object_method: true
-    resource_name_treatment: STATIC_TYPES
     page_streaming:
       request:
         page_size_field: maxResults
         token_field: pageToken
       response:
         token_field: nextPageToken
-        resources_field: DiskTypeAggregatedList
+        resources_field: items
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: idempotent
     # TODO: Configure the retryable params for this method.
@@ -1401,14 +1227,12 @@ interfaces:
     # TODO: Configure which fields are required.
     required_fields:
     - diskType
-    request_object_method: true
-    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      diskType: diskType
+      diskType: projectZoneDiskType
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
   - name: compute.diskTypes.list
@@ -1421,24 +1245,22 @@ interfaces:
     # TODO: Configure which fields are required.
     required_fields:
     - zone
-    request_object_method: true
-    resource_name_treatment: STATIC_TYPES
     page_streaming:
       request:
         page_size_field: maxResults
         token_field: pageToken
       response:
         token_field: nextPageToken
-        resources_field: DiskTypeList
+        resources_field: items
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      zone: zone
+      zone: projectZone
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
-  # The fully qualified name of the API interface.
+# The fully qualified name of the API interface.
 - name: google.compute.v1.Disks
   # A list of resource collection configurations.
   # Consists of a name_pattern and an entity_name.
@@ -1451,20 +1273,20 @@ interfaces:
   # The entity_name is the name to be used as a basis for generated methods and
   # classes.
   collections:
-  - name_pattern: projects/{project}
+  - name_pattern: '{project}'
     entity_name: project
-  - name_pattern: projects/{project}/zones/{zone}
-    entity_name: zone
-  - name_pattern: projects/{project}/zones/{zone}/disks/{disk}
-    entity_name: disk
-  - name_pattern: projects/{project}/zones/{zone}/disks/{resource}
-    entity_name: disksResource
+  - name_pattern: '{project}/zones/{zone}'
+    entity_name: projectZone
+  - name_pattern: '{project}/zones/{zone}/disks/{disk}'
+    entity_name: projectZoneDisk
+  - name_pattern: '{project}/zones/{zone}/disks/{resource}'
+    entity_name: projectZoneDiskResource
   # Definition for retryable codes.
   retry_codes_def:
   - name: idempotent
     retry_codes:
-    - SC_SERVICE_UNAVAILABLE
-    - SC_GATEWAY_TIMEOUT
+    - UNAVAILABLE
+    - DEADLINE_EXCEEDED
   - name: non_idempotent
     retry_codes: []
   # Definition for retry/backoff parameters.
@@ -1490,17 +1312,6 @@ interfaces:
   #       message.
   #   required_fields - Fields that are always required for a request to be
   #       valid.
-  #   request_object_method - Turns on or off the generation of a method whose
-  #       sole parameter is a request object. Not all languages will generate
-  #       this method.
-  #   resource_name_treatment - An enum that specifies how to treat the
-  #       resource name formats defined in the field_name_patterns
-  #       and response_field_name_patterns fields.
-  #       UNSET: default value
-  #       NONE: the collection configs will not be used by the generated code.
-  #       VALIDATE: string fields will be validated by the client against the
-  #           specified resource name formats.
-  #       STATIC_TYPES: the client will use generated types for resource names.
   #   page_streaming - Specifies the configuration for paging.
   #       Describes information for generating a method which transforms a
   #       paging list RPC into a stream of resources.
@@ -1535,21 +1346,17 @@ interfaces:
       groups:
       - parameters:
         - disk
-        - requestId
         - disksAddResourcePoliciesRequestResource
     # TODO: Configure which fields are required.
     required_fields:
     - disk
-    - requestId
     - disksAddResourcePoliciesRequestResource
-    request_object_method: true
-    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: non_idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      disk: disk
+      disk: projectZoneDisk
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
   - name: compute.disks.aggregatedList
@@ -1562,15 +1369,13 @@ interfaces:
     # TODO: Configure which fields are required.
     required_fields:
     - project
-    request_object_method: true
-    resource_name_treatment: STATIC_TYPES
     page_streaming:
       request:
         page_size_field: maxResults
         token_field: pageToken
       response:
         token_field: nextPageToken
-        resources_field: DiskAggregatedList
+        resources_field: items
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: idempotent
     # TODO: Configure the retryable params for this method.
@@ -1586,23 +1391,19 @@ interfaces:
       groups:
       - parameters:
         - disk
-        - requestId
         - guestFlush
         - snapshotResource
     # TODO: Configure which fields are required.
     required_fields:
     - disk
-    - requestId
     - guestFlush
     - snapshotResource
-    request_object_method: true
-    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: non_idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      disk: disk
+      disk: projectZoneDisk
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
   - name: compute.disks.delete
@@ -1612,19 +1413,15 @@ interfaces:
       groups:
       - parameters:
         - disk
-        - requestId
     # TODO: Configure which fields are required.
     required_fields:
     - disk
-    - requestId
-    request_object_method: true
-    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      disk: disk
+      disk: projectZoneDisk
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
   - name: compute.disks.get
@@ -1637,14 +1434,12 @@ interfaces:
     # TODO: Configure which fields are required.
     required_fields:
     - disk
-    request_object_method: true
-    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      disk: disk
+      disk: projectZoneDisk
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
   - name: compute.disks.getIamPolicy
@@ -1657,14 +1452,12 @@ interfaces:
     # TODO: Configure which fields are required.
     required_fields:
     - resource
-    request_object_method: true
-    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      resource: disksResource
+      resource: projectZoneDiskResource
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
   - name: compute.disks.insert
@@ -1674,23 +1467,17 @@ interfaces:
       groups:
       - parameters:
         - zone
-        - requestId
-        - sourceImage
         - diskResource
     # TODO: Configure which fields are required.
     required_fields:
     - zone
-    - requestId
-    - sourceImage
     - diskResource
-    request_object_method: true
-    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: non_idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      zone: zone
+      zone: projectZone
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
   - name: compute.disks.list
@@ -1703,21 +1490,19 @@ interfaces:
     # TODO: Configure which fields are required.
     required_fields:
     - zone
-    request_object_method: true
-    resource_name_treatment: STATIC_TYPES
     page_streaming:
       request:
         page_size_field: maxResults
         token_field: pageToken
       response:
         token_field: nextPageToken
-        resources_field: DiskList
+        resources_field: items
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      zone: zone
+      zone: projectZone
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
   - name: compute.disks.removeResourcePolicies
@@ -1727,21 +1512,17 @@ interfaces:
       groups:
       - parameters:
         - disk
-        - requestId
         - disksRemoveResourcePoliciesRequestResource
     # TODO: Configure which fields are required.
     required_fields:
     - disk
-    - requestId
     - disksRemoveResourcePoliciesRequestResource
-    request_object_method: true
-    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: non_idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      disk: disk
+      disk: projectZoneDisk
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
   - name: compute.disks.resize
@@ -1751,21 +1532,17 @@ interfaces:
       groups:
       - parameters:
         - disk
-        - requestId
         - disksResizeRequestResource
     # TODO: Configure which fields are required.
     required_fields:
     - disk
-    - requestId
     - disksResizeRequestResource
-    request_object_method: true
-    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: non_idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      disk: disk
+      disk: projectZoneDisk
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
   - name: compute.disks.setIamPolicy
@@ -1780,14 +1557,12 @@ interfaces:
     required_fields:
     - resource
     - zoneSetPolicyRequestResource
-    request_object_method: true
-    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: non_idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      resource: disksResource
+      resource: projectZoneDiskResource
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
   - name: compute.disks.setLabels
@@ -1797,21 +1572,17 @@ interfaces:
       groups:
       - parameters:
         - resource
-        - requestId
         - zoneSetLabelsRequestResource
     # TODO: Configure which fields are required.
     required_fields:
     - resource
-    - requestId
     - zoneSetLabelsRequestResource
-    request_object_method: true
-    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: non_idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      resource: disksResource
+      resource: projectZoneDiskResource
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
   - name: compute.disks.testIamPermissions
@@ -1826,17 +1597,15 @@ interfaces:
     required_fields:
     - resource
     - testPermissionsRequestResource
-    request_object_method: true
-    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: non_idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      resource: disksResource
+      resource: projectZoneDiskResource
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
-  # The fully qualified name of the API interface.
+# The fully qualified name of the API interface.
 - name: google.compute.v1.Firewalls
   # A list of resource collection configurations.
   # Consists of a name_pattern and an entity_name.
@@ -1849,16 +1618,16 @@ interfaces:
   # The entity_name is the name to be used as a basis for generated methods and
   # classes.
   collections:
-  - name_pattern: projects/{project}
+  - name_pattern: '{project}'
     entity_name: project
-  - name_pattern: projects/{project}/firewalls/{firewall}
-    entity_name: firewall
+  - name_pattern: '{project}/global/firewalls/{firewall}'
+    entity_name: projectGlobalFirewall
   # Definition for retryable codes.
   retry_codes_def:
   - name: idempotent
     retry_codes:
-    - SC_SERVICE_UNAVAILABLE
-    - SC_GATEWAY_TIMEOUT
+    - UNAVAILABLE
+    - DEADLINE_EXCEEDED
   - name: non_idempotent
     retry_codes: []
   # Definition for retry/backoff parameters.
@@ -1884,17 +1653,6 @@ interfaces:
   #       message.
   #   required_fields - Fields that are always required for a request to be
   #       valid.
-  #   request_object_method - Turns on or off the generation of a method whose
-  #       sole parameter is a request object. Not all languages will generate
-  #       this method.
-  #   resource_name_treatment - An enum that specifies how to treat the
-  #       resource name formats defined in the field_name_patterns
-  #       and response_field_name_patterns fields.
-  #       UNSET: default value
-  #       NONE: the collection configs will not be used by the generated code.
-  #       VALIDATE: string fields will be validated by the client against the
-  #           specified resource name formats.
-  #       STATIC_TYPES: the client will use generated types for resource names.
   #   page_streaming - Specifies the configuration for paging.
   #       Describes information for generating a method which transforms a
   #       paging list RPC into a stream of resources.
@@ -1929,19 +1687,15 @@ interfaces:
       groups:
       - parameters:
         - firewall
-        - requestId
     # TODO: Configure which fields are required.
     required_fields:
     - firewall
-    - requestId
-    request_object_method: true
-    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      firewall: firewall
+      firewall: projectGlobalFirewall
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
   - name: compute.firewalls.get
@@ -1954,14 +1708,12 @@ interfaces:
     # TODO: Configure which fields are required.
     required_fields:
     - firewall
-    request_object_method: true
-    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      firewall: firewall
+      firewall: projectGlobalFirewall
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
   - name: compute.firewalls.insert
@@ -1970,16 +1722,12 @@ interfaces:
     flattening:
       groups:
       - parameters:
-        - requestId
         - project
         - firewallResource
     # TODO: Configure which fields are required.
     required_fields:
-    - requestId
     - project
     - firewallResource
-    request_object_method: true
-    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: non_idempotent
     # TODO: Configure the retryable params for this method.
@@ -1998,15 +1746,13 @@ interfaces:
     # TODO: Configure which fields are required.
     required_fields:
     - project
-    request_object_method: true
-    resource_name_treatment: STATIC_TYPES
     page_streaming:
       request:
         page_size_field: maxResults
         token_field: pageToken
       response:
         token_field: nextPageToken
-        resources_field: FirewallList
+        resources_field: items
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: idempotent
     # TODO: Configure the retryable params for this method.
@@ -2022,21 +1768,17 @@ interfaces:
       groups:
       - parameters:
         - firewall
-        - requestId
         - firewallResource
     # TODO: Configure which fields are required.
     required_fields:
     - firewall
-    - requestId
     - firewallResource
-    request_object_method: true
-    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: non_idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      firewall: firewall
+      firewall: projectGlobalFirewall
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
   - name: compute.firewalls.update
@@ -2046,24 +1788,20 @@ interfaces:
       groups:
       - parameters:
         - firewall
-        - requestId
         - firewallResource
     # TODO: Configure which fields are required.
     required_fields:
     - firewall
-    - requestId
     - firewallResource
-    request_object_method: true
-    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      firewall: firewall
+      firewall: projectGlobalFirewall
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
-  # The fully qualified name of the API interface.
+# The fully qualified name of the API interface.
 - name: google.compute.v1.ForwardingRules
   # A list of resource collection configurations.
   # Consists of a name_pattern and an entity_name.
@@ -2076,18 +1814,18 @@ interfaces:
   # The entity_name is the name to be used as a basis for generated methods and
   # classes.
   collections:
-  - name_pattern: projects/{project}
+  - name_pattern: '{project}'
     entity_name: project
-  - name_pattern: projects/{project}/regions/{region}
-    entity_name: region
-  - name_pattern: projects/{project}/regions/{region}/forwardingRules/{forwardingRule}
-    entity_name: forwardingRule
+  - name_pattern: '{project}/regions/{region}'
+    entity_name: projectRegion
+  - name_pattern: '{project}/regions/{region}/forwardingRules/{forwardingRule}'
+    entity_name: projectRegionForwardingRule
   # Definition for retryable codes.
   retry_codes_def:
   - name: idempotent
     retry_codes:
-    - SC_SERVICE_UNAVAILABLE
-    - SC_GATEWAY_TIMEOUT
+    - UNAVAILABLE
+    - DEADLINE_EXCEEDED
   - name: non_idempotent
     retry_codes: []
   # Definition for retry/backoff parameters.
@@ -2113,17 +1851,6 @@ interfaces:
   #       message.
   #   required_fields - Fields that are always required for a request to be
   #       valid.
-  #   request_object_method - Turns on or off the generation of a method whose
-  #       sole parameter is a request object. Not all languages will generate
-  #       this method.
-  #   resource_name_treatment - An enum that specifies how to treat the
-  #       resource name formats defined in the field_name_patterns
-  #       and response_field_name_patterns fields.
-  #       UNSET: default value
-  #       NONE: the collection configs will not be used by the generated code.
-  #       VALIDATE: string fields will be validated by the client against the
-  #           specified resource name formats.
-  #       STATIC_TYPES: the client will use generated types for resource names.
   #   page_streaming - Specifies the configuration for paging.
   #       Describes information for generating a method which transforms a
   #       paging list RPC into a stream of resources.
@@ -2161,15 +1888,13 @@ interfaces:
     # TODO: Configure which fields are required.
     required_fields:
     - project
-    request_object_method: true
-    resource_name_treatment: STATIC_TYPES
     page_streaming:
       request:
         page_size_field: maxResults
         token_field: pageToken
       response:
         token_field: nextPageToken
-        resources_field: ForwardingRuleAggregatedList
+        resources_field: items
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: idempotent
     # TODO: Configure the retryable params for this method.
@@ -2184,20 +1909,16 @@ interfaces:
     flattening:
       groups:
       - parameters:
-        - requestId
         - forwardingRule
     # TODO: Configure which fields are required.
     required_fields:
-    - requestId
     - forwardingRule
-    request_object_method: true
-    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      forwardingRule: forwardingRule
+      forwardingRule: projectRegionForwardingRule
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
   - name: compute.forwardingRules.get
@@ -2210,14 +1931,12 @@ interfaces:
     # TODO: Configure which fields are required.
     required_fields:
     - forwardingRule
-    request_object_method: true
-    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      forwardingRule: forwardingRule
+      forwardingRule: projectRegionForwardingRule
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
   - name: compute.forwardingRules.insert
@@ -2226,22 +1945,18 @@ interfaces:
     flattening:
       groups:
       - parameters:
-        - requestId
         - region
         - forwardingRuleResource
     # TODO: Configure which fields are required.
     required_fields:
-    - requestId
     - region
     - forwardingRuleResource
-    request_object_method: true
-    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: non_idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      region: region
+      region: projectRegion
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
   - name: compute.forwardingRules.list
@@ -2254,21 +1969,19 @@ interfaces:
     # TODO: Configure which fields are required.
     required_fields:
     - region
-    request_object_method: true
-    resource_name_treatment: STATIC_TYPES
     page_streaming:
       request:
         page_size_field: maxResults
         token_field: pageToken
       response:
         token_field: nextPageToken
-        resources_field: ForwardingRuleList
+        resources_field: items
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      region: region
+      region: projectRegion
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
   - name: compute.forwardingRules.setTarget
@@ -2277,25 +1990,21 @@ interfaces:
     flattening:
       groups:
       - parameters:
-        - requestId
         - forwardingRule
         - targetReferenceResource
     # TODO: Configure which fields are required.
     required_fields:
-    - requestId
     - forwardingRule
     - targetReferenceResource
-    request_object_method: true
-    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: non_idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      forwardingRule: forwardingRule
+      forwardingRule: projectRegionForwardingRule
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
-  # The fully qualified name of the API interface.
+# The fully qualified name of the API interface.
 - name: google.compute.v1.GlobalAddresses
   # A list of resource collection configurations.
   # Consists of a name_pattern and an entity_name.
@@ -2308,16 +2017,16 @@ interfaces:
   # The entity_name is the name to be used as a basis for generated methods and
   # classes.
   collections:
-  - name_pattern: projects/{project}
+  - name_pattern: '{project}'
     entity_name: project
-  - name_pattern: projects/{project}/addresses/{address}
-    entity_name: globalAddressesAddress
+  - name_pattern: '{project}/global/addresses/{address}'
+    entity_name: projectGlobalAddress
   # Definition for retryable codes.
   retry_codes_def:
   - name: idempotent
     retry_codes:
-    - SC_SERVICE_UNAVAILABLE
-    - SC_GATEWAY_TIMEOUT
+    - UNAVAILABLE
+    - DEADLINE_EXCEEDED
   - name: non_idempotent
     retry_codes: []
   # Definition for retry/backoff parameters.
@@ -2343,17 +2052,6 @@ interfaces:
   #       message.
   #   required_fields - Fields that are always required for a request to be
   #       valid.
-  #   request_object_method - Turns on or off the generation of a method whose
-  #       sole parameter is a request object. Not all languages will generate
-  #       this method.
-  #   resource_name_treatment - An enum that specifies how to treat the
-  #       resource name formats defined in the field_name_patterns
-  #       and response_field_name_patterns fields.
-  #       UNSET: default value
-  #       NONE: the collection configs will not be used by the generated code.
-  #       VALIDATE: string fields will be validated by the client against the
-  #           specified resource name formats.
-  #       STATIC_TYPES: the client will use generated types for resource names.
   #   page_streaming - Specifies the configuration for paging.
   #       Describes information for generating a method which transforms a
   #       paging list RPC into a stream of resources.
@@ -2388,19 +2086,15 @@ interfaces:
       groups:
       - parameters:
         - address
-        - requestId
     # TODO: Configure which fields are required.
     required_fields:
     - address
-    - requestId
-    request_object_method: true
-    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      address: globalAddressesAddress
+      address: projectGlobalAddress
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
   - name: compute.globalAddresses.get
@@ -2413,14 +2107,12 @@ interfaces:
     # TODO: Configure which fields are required.
     required_fields:
     - address
-    request_object_method: true
-    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      address: globalAddressesAddress
+      address: projectGlobalAddress
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
   - name: compute.globalAddresses.insert
@@ -2429,16 +2121,12 @@ interfaces:
     flattening:
       groups:
       - parameters:
-        - requestId
         - project
         - addressResource
     # TODO: Configure which fields are required.
     required_fields:
-    - requestId
     - project
     - addressResource
-    request_object_method: true
-    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: non_idempotent
     # TODO: Configure the retryable params for this method.
@@ -2457,15 +2145,13 @@ interfaces:
     # TODO: Configure which fields are required.
     required_fields:
     - project
-    request_object_method: true
-    resource_name_treatment: STATIC_TYPES
     page_streaming:
       request:
         page_size_field: maxResults
         token_field: pageToken
       response:
         token_field: nextPageToken
-        resources_field: AddressList
+        resources_field: items
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: idempotent
     # TODO: Configure the retryable params for this method.
@@ -2474,7 +2160,7 @@ interfaces:
       project: project
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
-  # The fully qualified name of the API interface.
+# The fully qualified name of the API interface.
 - name: google.compute.v1.GlobalForwardingRules
   # A list of resource collection configurations.
   # Consists of a name_pattern and an entity_name.
@@ -2487,16 +2173,16 @@ interfaces:
   # The entity_name is the name to be used as a basis for generated methods and
   # classes.
   collections:
-  - name_pattern: projects/{project}
+  - name_pattern: '{project}'
     entity_name: project
-  - name_pattern: projects/{project}/forwardingRules/{forwardingRule}
-    entity_name: globalForwardingRulesForwardingRule
+  - name_pattern: '{project}/global/forwardingRules/{forwardingRule}'
+    entity_name: projectGlobalForwardingRule
   # Definition for retryable codes.
   retry_codes_def:
   - name: idempotent
     retry_codes:
-    - SC_SERVICE_UNAVAILABLE
-    - SC_GATEWAY_TIMEOUT
+    - UNAVAILABLE
+    - DEADLINE_EXCEEDED
   - name: non_idempotent
     retry_codes: []
   # Definition for retry/backoff parameters.
@@ -2522,17 +2208,6 @@ interfaces:
   #       message.
   #   required_fields - Fields that are always required for a request to be
   #       valid.
-  #   request_object_method - Turns on or off the generation of a method whose
-  #       sole parameter is a request object. Not all languages will generate
-  #       this method.
-  #   resource_name_treatment - An enum that specifies how to treat the
-  #       resource name formats defined in the field_name_patterns
-  #       and response_field_name_patterns fields.
-  #       UNSET: default value
-  #       NONE: the collection configs will not be used by the generated code.
-  #       VALIDATE: string fields will be validated by the client against the
-  #           specified resource name formats.
-  #       STATIC_TYPES: the client will use generated types for resource names.
   #   page_streaming - Specifies the configuration for paging.
   #       Describes information for generating a method which transforms a
   #       paging list RPC into a stream of resources.
@@ -2566,20 +2241,16 @@ interfaces:
     flattening:
       groups:
       - parameters:
-        - requestId
         - forwardingRule
     # TODO: Configure which fields are required.
     required_fields:
-    - requestId
     - forwardingRule
-    request_object_method: true
-    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      forwardingRule: globalForwardingRulesForwardingRule
+      forwardingRule: projectGlobalForwardingRule
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
   - name: compute.globalForwardingRules.get
@@ -2592,14 +2263,12 @@ interfaces:
     # TODO: Configure which fields are required.
     required_fields:
     - forwardingRule
-    request_object_method: true
-    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      forwardingRule: globalForwardingRulesForwardingRule
+      forwardingRule: projectGlobalForwardingRule
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
   - name: compute.globalForwardingRules.insert
@@ -2608,16 +2277,12 @@ interfaces:
     flattening:
       groups:
       - parameters:
-        - requestId
         - project
         - forwardingRuleResource
     # TODO: Configure which fields are required.
     required_fields:
-    - requestId
     - project
     - forwardingRuleResource
-    request_object_method: true
-    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: non_idempotent
     # TODO: Configure the retryable params for this method.
@@ -2636,15 +2301,13 @@ interfaces:
     # TODO: Configure which fields are required.
     required_fields:
     - project
-    request_object_method: true
-    resource_name_treatment: STATIC_TYPES
     page_streaming:
       request:
         page_size_field: maxResults
         token_field: pageToken
       response:
         token_field: nextPageToken
-        resources_field: ForwardingRuleList
+        resources_field: items
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: idempotent
     # TODO: Configure the retryable params for this method.
@@ -2659,25 +2322,21 @@ interfaces:
     flattening:
       groups:
       - parameters:
-        - requestId
         - forwardingRule
         - targetReferenceResource
     # TODO: Configure which fields are required.
     required_fields:
-    - requestId
     - forwardingRule
     - targetReferenceResource
-    request_object_method: true
-    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: non_idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      forwardingRule: globalForwardingRulesForwardingRule
+      forwardingRule: projectGlobalForwardingRule
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
-  # The fully qualified name of the API interface.
+# The fully qualified name of the API interface.
 - name: google.compute.v1.GlobalOperations
   # A list of resource collection configurations.
   # Consists of a name_pattern and an entity_name.
@@ -2690,16 +2349,16 @@ interfaces:
   # The entity_name is the name to be used as a basis for generated methods and
   # classes.
   collections:
-  - name_pattern: projects/{project}
+  - name_pattern: '{project}'
     entity_name: project
-  - name_pattern: projects/{project}/operations/{operation}
-    entity_name: globalOperationsOperation
+  - name_pattern: '{project}/global/operations/{operation}'
+    entity_name: projectGlobalOperation
   # Definition for retryable codes.
   retry_codes_def:
   - name: idempotent
     retry_codes:
-    - SC_SERVICE_UNAVAILABLE
-    - SC_GATEWAY_TIMEOUT
+    - UNAVAILABLE
+    - DEADLINE_EXCEEDED
   - name: non_idempotent
     retry_codes: []
   # Definition for retry/backoff parameters.
@@ -2725,17 +2384,6 @@ interfaces:
   #       message.
   #   required_fields - Fields that are always required for a request to be
   #       valid.
-  #   request_object_method - Turns on or off the generation of a method whose
-  #       sole parameter is a request object. Not all languages will generate
-  #       this method.
-  #   resource_name_treatment - An enum that specifies how to treat the
-  #       resource name formats defined in the field_name_patterns
-  #       and response_field_name_patterns fields.
-  #       UNSET: default value
-  #       NONE: the collection configs will not be used by the generated code.
-  #       VALIDATE: string fields will be validated by the client against the
-  #           specified resource name formats.
-  #       STATIC_TYPES: the client will use generated types for resource names.
   #   page_streaming - Specifies the configuration for paging.
   #       Describes information for generating a method which transforms a
   #       paging list RPC into a stream of resources.
@@ -2773,15 +2421,13 @@ interfaces:
     # TODO: Configure which fields are required.
     required_fields:
     - project
-    request_object_method: true
-    resource_name_treatment: STATIC_TYPES
     page_streaming:
       request:
         page_size_field: maxResults
         token_field: pageToken
       response:
         token_field: nextPageToken
-        resources_field: OperationAggregatedList
+        resources_field: items
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: idempotent
     # TODO: Configure the retryable params for this method.
@@ -2800,14 +2446,12 @@ interfaces:
     # TODO: Configure which fields are required.
     required_fields:
     - operation
-    request_object_method: true
-    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      operation: globalOperationsOperation
+      operation: projectGlobalOperation
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
   - name: compute.globalOperations.get
@@ -2820,14 +2464,12 @@ interfaces:
     # TODO: Configure which fields are required.
     required_fields:
     - operation
-    request_object_method: true
-    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      operation: globalOperationsOperation
+      operation: projectGlobalOperation
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
   - name: compute.globalOperations.list
@@ -2840,15 +2482,13 @@ interfaces:
     # TODO: Configure which fields are required.
     required_fields:
     - project
-    request_object_method: true
-    resource_name_treatment: STATIC_TYPES
     page_streaming:
       request:
         page_size_field: maxResults
         token_field: pageToken
       response:
         token_field: nextPageToken
-        resources_field: OperationList
+        resources_field: items
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: idempotent
     # TODO: Configure the retryable params for this method.
@@ -2857,7 +2497,7 @@ interfaces:
       project: project
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
-  # The fully qualified name of the API interface.
+# The fully qualified name of the API interface.
 - name: google.compute.v1.HealthChecks
   # A list of resource collection configurations.
   # Consists of a name_pattern and an entity_name.
@@ -2870,16 +2510,16 @@ interfaces:
   # The entity_name is the name to be used as a basis for generated methods and
   # classes.
   collections:
-  - name_pattern: projects/{project}
+  - name_pattern: '{project}'
     entity_name: project
-  - name_pattern: projects/{project}/healthChecks/{healthCheck}
-    entity_name: healthCheck
+  - name_pattern: '{project}/global/healthChecks/{healthCheck}'
+    entity_name: projectGlobalHealthCheck
   # Definition for retryable codes.
   retry_codes_def:
   - name: idempotent
     retry_codes:
-    - SC_SERVICE_UNAVAILABLE
-    - SC_GATEWAY_TIMEOUT
+    - UNAVAILABLE
+    - DEADLINE_EXCEEDED
   - name: non_idempotent
     retry_codes: []
   # Definition for retry/backoff parameters.
@@ -2905,17 +2545,6 @@ interfaces:
   #       message.
   #   required_fields - Fields that are always required for a request to be
   #       valid.
-  #   request_object_method - Turns on or off the generation of a method whose
-  #       sole parameter is a request object. Not all languages will generate
-  #       this method.
-  #   resource_name_treatment - An enum that specifies how to treat the
-  #       resource name formats defined in the field_name_patterns
-  #       and response_field_name_patterns fields.
-  #       UNSET: default value
-  #       NONE: the collection configs will not be used by the generated code.
-  #       VALIDATE: string fields will be validated by the client against the
-  #           specified resource name formats.
-  #       STATIC_TYPES: the client will use generated types for resource names.
   #   page_streaming - Specifies the configuration for paging.
   #       Describes information for generating a method which transforms a
   #       paging list RPC into a stream of resources.
@@ -2949,20 +2578,16 @@ interfaces:
     flattening:
       groups:
       - parameters:
-        - requestId
         - healthCheck
     # TODO: Configure which fields are required.
     required_fields:
-    - requestId
     - healthCheck
-    request_object_method: true
-    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      healthCheck: healthCheck
+      healthCheck: projectGlobalHealthCheck
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
   - name: compute.healthChecks.get
@@ -2975,14 +2600,12 @@ interfaces:
     # TODO: Configure which fields are required.
     required_fields:
     - healthCheck
-    request_object_method: true
-    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      healthCheck: healthCheck
+      healthCheck: projectGlobalHealthCheck
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
   - name: compute.healthChecks.insert
@@ -2991,16 +2614,12 @@ interfaces:
     flattening:
       groups:
       - parameters:
-        - requestId
         - project
         - healthCheckResource
     # TODO: Configure which fields are required.
     required_fields:
-    - requestId
     - project
     - healthCheckResource
-    request_object_method: true
-    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: non_idempotent
     # TODO: Configure the retryable params for this method.
@@ -3019,15 +2638,13 @@ interfaces:
     # TODO: Configure which fields are required.
     required_fields:
     - project
-    request_object_method: true
-    resource_name_treatment: STATIC_TYPES
     page_streaming:
       request:
         page_size_field: maxResults
         token_field: pageToken
       response:
         token_field: nextPageToken
-        resources_field: HealthCheckList
+        resources_field: items
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: idempotent
     # TODO: Configure the retryable params for this method.
@@ -3042,22 +2659,18 @@ interfaces:
     flattening:
       groups:
       - parameters:
-        - requestId
         - healthCheck
         - healthCheckResource
     # TODO: Configure which fields are required.
     required_fields:
-    - requestId
     - healthCheck
     - healthCheckResource
-    request_object_method: true
-    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: non_idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      healthCheck: healthCheck
+      healthCheck: projectGlobalHealthCheck
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
   - name: compute.healthChecks.update
@@ -3066,25 +2679,21 @@ interfaces:
     flattening:
       groups:
       - parameters:
-        - requestId
         - healthCheck
         - healthCheckResource
     # TODO: Configure which fields are required.
     required_fields:
-    - requestId
     - healthCheck
     - healthCheckResource
-    request_object_method: true
-    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      healthCheck: healthCheck
+      healthCheck: projectGlobalHealthCheck
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
-  # The fully qualified name of the API interface.
+# The fully qualified name of the API interface.
 - name: google.compute.v1.HttpHealthChecks
   # A list of resource collection configurations.
   # Consists of a name_pattern and an entity_name.
@@ -3097,16 +2706,16 @@ interfaces:
   # The entity_name is the name to be used as a basis for generated methods and
   # classes.
   collections:
-  - name_pattern: projects/{project}
+  - name_pattern: '{project}'
     entity_name: project
-  - name_pattern: projects/{project}/httpHealthChecks/{httpHealthCheck}
-    entity_name: httpHealthCheck
+  - name_pattern: '{project}/global/httpHealthChecks/{httpHealthCheck}'
+    entity_name: projectGlobalHttpHealthCheck
   # Definition for retryable codes.
   retry_codes_def:
   - name: idempotent
     retry_codes:
-    - SC_SERVICE_UNAVAILABLE
-    - SC_GATEWAY_TIMEOUT
+    - UNAVAILABLE
+    - DEADLINE_EXCEEDED
   - name: non_idempotent
     retry_codes: []
   # Definition for retry/backoff parameters.
@@ -3132,17 +2741,6 @@ interfaces:
   #       message.
   #   required_fields - Fields that are always required for a request to be
   #       valid.
-  #   request_object_method - Turns on or off the generation of a method whose
-  #       sole parameter is a request object. Not all languages will generate
-  #       this method.
-  #   resource_name_treatment - An enum that specifies how to treat the
-  #       resource name formats defined in the field_name_patterns
-  #       and response_field_name_patterns fields.
-  #       UNSET: default value
-  #       NONE: the collection configs will not be used by the generated code.
-  #       VALIDATE: string fields will be validated by the client against the
-  #           specified resource name formats.
-  #       STATIC_TYPES: the client will use generated types for resource names.
   #   page_streaming - Specifies the configuration for paging.
   #       Describes information for generating a method which transforms a
   #       paging list RPC into a stream of resources.
@@ -3176,20 +2774,16 @@ interfaces:
     flattening:
       groups:
       - parameters:
-        - requestId
         - httpHealthCheck
     # TODO: Configure which fields are required.
     required_fields:
-    - requestId
     - httpHealthCheck
-    request_object_method: true
-    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      httpHealthCheck: httpHealthCheck
+      httpHealthCheck: projectGlobalHttpHealthCheck
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
   - name: compute.httpHealthChecks.get
@@ -3202,14 +2796,12 @@ interfaces:
     # TODO: Configure which fields are required.
     required_fields:
     - httpHealthCheck
-    request_object_method: true
-    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      httpHealthCheck: httpHealthCheck
+      httpHealthCheck: projectGlobalHttpHealthCheck
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
   - name: compute.httpHealthChecks.insert
@@ -3218,16 +2810,12 @@ interfaces:
     flattening:
       groups:
       - parameters:
-        - requestId
         - project
         - httpHealthCheckResource
     # TODO: Configure which fields are required.
     required_fields:
-    - requestId
     - project
     - httpHealthCheckResource
-    request_object_method: true
-    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: non_idempotent
     # TODO: Configure the retryable params for this method.
@@ -3246,15 +2834,13 @@ interfaces:
     # TODO: Configure which fields are required.
     required_fields:
     - project
-    request_object_method: true
-    resource_name_treatment: STATIC_TYPES
     page_streaming:
       request:
         page_size_field: maxResults
         token_field: pageToken
       response:
         token_field: nextPageToken
-        resources_field: HttpHealthCheckList
+        resources_field: items
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: idempotent
     # TODO: Configure the retryable params for this method.
@@ -3269,22 +2855,18 @@ interfaces:
     flattening:
       groups:
       - parameters:
-        - requestId
         - httpHealthCheck
         - httpHealthCheckResource
     # TODO: Configure which fields are required.
     required_fields:
-    - requestId
     - httpHealthCheck
     - httpHealthCheckResource
-    request_object_method: true
-    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: non_idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      httpHealthCheck: httpHealthCheck
+      httpHealthCheck: projectGlobalHttpHealthCheck
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
   - name: compute.httpHealthChecks.update
@@ -3293,25 +2875,21 @@ interfaces:
     flattening:
       groups:
       - parameters:
-        - requestId
         - httpHealthCheck
         - httpHealthCheckResource
     # TODO: Configure which fields are required.
     required_fields:
-    - requestId
     - httpHealthCheck
     - httpHealthCheckResource
-    request_object_method: true
-    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      httpHealthCheck: httpHealthCheck
+      httpHealthCheck: projectGlobalHttpHealthCheck
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
-  # The fully qualified name of the API interface.
+# The fully qualified name of the API interface.
 - name: google.compute.v1.HttpsHealthChecks
   # A list of resource collection configurations.
   # Consists of a name_pattern and an entity_name.
@@ -3324,16 +2902,16 @@ interfaces:
   # The entity_name is the name to be used as a basis for generated methods and
   # classes.
   collections:
-  - name_pattern: projects/{project}
+  - name_pattern: '{project}'
     entity_name: project
-  - name_pattern: projects/{project}/httpsHealthChecks/{httpsHealthCheck}
-    entity_name: httpsHealthCheck
+  - name_pattern: '{project}/global/httpsHealthChecks/{httpsHealthCheck}'
+    entity_name: projectGlobalHttpsHealthCheck
   # Definition for retryable codes.
   retry_codes_def:
   - name: idempotent
     retry_codes:
-    - SC_SERVICE_UNAVAILABLE
-    - SC_GATEWAY_TIMEOUT
+    - UNAVAILABLE
+    - DEADLINE_EXCEEDED
   - name: non_idempotent
     retry_codes: []
   # Definition for retry/backoff parameters.
@@ -3359,17 +2937,6 @@ interfaces:
   #       message.
   #   required_fields - Fields that are always required for a request to be
   #       valid.
-  #   request_object_method - Turns on or off the generation of a method whose
-  #       sole parameter is a request object. Not all languages will generate
-  #       this method.
-  #   resource_name_treatment - An enum that specifies how to treat the
-  #       resource name formats defined in the field_name_patterns
-  #       and response_field_name_patterns fields.
-  #       UNSET: default value
-  #       NONE: the collection configs will not be used by the generated code.
-  #       VALIDATE: string fields will be validated by the client against the
-  #           specified resource name formats.
-  #       STATIC_TYPES: the client will use generated types for resource names.
   #   page_streaming - Specifies the configuration for paging.
   #       Describes information for generating a method which transforms a
   #       paging list RPC into a stream of resources.
@@ -3404,19 +2971,15 @@ interfaces:
       groups:
       - parameters:
         - httpsHealthCheck
-        - requestId
     # TODO: Configure which fields are required.
     required_fields:
     - httpsHealthCheck
-    - requestId
-    request_object_method: true
-    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      httpsHealthCheck: httpsHealthCheck
+      httpsHealthCheck: projectGlobalHttpsHealthCheck
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
   - name: compute.httpsHealthChecks.get
@@ -3429,14 +2992,12 @@ interfaces:
     # TODO: Configure which fields are required.
     required_fields:
     - httpsHealthCheck
-    request_object_method: true
-    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      httpsHealthCheck: httpsHealthCheck
+      httpsHealthCheck: projectGlobalHttpsHealthCheck
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
   - name: compute.httpsHealthChecks.insert
@@ -3445,16 +3006,12 @@ interfaces:
     flattening:
       groups:
       - parameters:
-        - requestId
         - project
         - httpsHealthCheckResource
     # TODO: Configure which fields are required.
     required_fields:
-    - requestId
     - project
     - httpsHealthCheckResource
-    request_object_method: true
-    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: non_idempotent
     # TODO: Configure the retryable params for this method.
@@ -3473,15 +3030,13 @@ interfaces:
     # TODO: Configure which fields are required.
     required_fields:
     - project
-    request_object_method: true
-    resource_name_treatment: STATIC_TYPES
     page_streaming:
       request:
         page_size_field: maxResults
         token_field: pageToken
       response:
         token_field: nextPageToken
-        resources_field: HttpsHealthCheckList
+        resources_field: items
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: idempotent
     # TODO: Configure the retryable params for this method.
@@ -3497,21 +3052,17 @@ interfaces:
       groups:
       - parameters:
         - httpsHealthCheck
-        - requestId
         - httpsHealthCheckResource
     # TODO: Configure which fields are required.
     required_fields:
     - httpsHealthCheck
-    - requestId
     - httpsHealthCheckResource
-    request_object_method: true
-    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: non_idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      httpsHealthCheck: httpsHealthCheck
+      httpsHealthCheck: projectGlobalHttpsHealthCheck
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
   - name: compute.httpsHealthChecks.update
@@ -3521,24 +3072,20 @@ interfaces:
       groups:
       - parameters:
         - httpsHealthCheck
-        - requestId
         - httpsHealthCheckResource
     # TODO: Configure which fields are required.
     required_fields:
     - httpsHealthCheck
-    - requestId
     - httpsHealthCheckResource
-    request_object_method: true
-    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      httpsHealthCheck: httpsHealthCheck
+      httpsHealthCheck: projectGlobalHttpsHealthCheck
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
-  # The fully qualified name of the API interface.
+# The fully qualified name of the API interface.
 - name: google.compute.v1.Images
   # A list of resource collection configurations.
   # Consists of a name_pattern and an entity_name.
@@ -3551,20 +3098,20 @@ interfaces:
   # The entity_name is the name to be used as a basis for generated methods and
   # classes.
   collections:
-  - name_pattern: projects/{project}
+  - name_pattern: '{project}'
     entity_name: project
-  - name_pattern: projects/{project}/family/{family}
-    entity_name: family
-  - name_pattern: projects/{project}/images/{image}
-    entity_name: image
-  - name_pattern: projects/{project}/images/{resource}
-    entity_name: imagesResource
+  - name_pattern: '{project}/global/images/family/{family}'
+    entity_name: projectGlobalImageFamily
+  - name_pattern: '{project}/global/images/{image}'
+    entity_name: projectGlobalImage
+  - name_pattern: '{project}/global/images/{resource}'
+    entity_name: projectGlobalImageResource
   # Definition for retryable codes.
   retry_codes_def:
   - name: idempotent
     retry_codes:
-    - SC_SERVICE_UNAVAILABLE
-    - SC_GATEWAY_TIMEOUT
+    - UNAVAILABLE
+    - DEADLINE_EXCEEDED
   - name: non_idempotent
     retry_codes: []
   # Definition for retry/backoff parameters.
@@ -3590,17 +3137,6 @@ interfaces:
   #       message.
   #   required_fields - Fields that are always required for a request to be
   #       valid.
-  #   request_object_method - Turns on or off the generation of a method whose
-  #       sole parameter is a request object. Not all languages will generate
-  #       this method.
-  #   resource_name_treatment - An enum that specifies how to treat the
-  #       resource name formats defined in the field_name_patterns
-  #       and response_field_name_patterns fields.
-  #       UNSET: default value
-  #       NONE: the collection configs will not be used by the generated code.
-  #       VALIDATE: string fields will be validated by the client against the
-  #           specified resource name formats.
-  #       STATIC_TYPES: the client will use generated types for resource names.
   #   page_streaming - Specifies the configuration for paging.
   #       Describes information for generating a method which transforms a
   #       paging list RPC into a stream of resources.
@@ -3635,19 +3171,15 @@ interfaces:
       groups:
       - parameters:
         - image
-        - requestId
     # TODO: Configure which fields are required.
     required_fields:
     - image
-    - requestId
-    request_object_method: true
-    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      image: image
+      image: projectGlobalImage
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
   - name: compute.images.deprecate
@@ -3657,21 +3189,17 @@ interfaces:
       groups:
       - parameters:
         - image
-        - requestId
         - deprecationStatusResource
     # TODO: Configure which fields are required.
     required_fields:
     - image
-    - requestId
     - deprecationStatusResource
-    request_object_method: true
-    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: non_idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      image: image
+      image: projectGlobalImage
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
   - name: compute.images.get
@@ -3684,14 +3212,12 @@ interfaces:
     # TODO: Configure which fields are required.
     required_fields:
     - image
-    request_object_method: true
-    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      image: image
+      image: projectGlobalImage
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
   - name: compute.images.getFromFamily
@@ -3704,14 +3230,12 @@ interfaces:
     # TODO: Configure which fields are required.
     required_fields:
     - family
-    request_object_method: true
-    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      family: family
+      family: projectGlobalImageFamily
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
   - name: compute.images.getIamPolicy
@@ -3724,14 +3248,12 @@ interfaces:
     # TODO: Configure which fields are required.
     required_fields:
     - resource
-    request_object_method: true
-    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      resource: imagesResource
+      resource: projectGlobalImageResource
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
   - name: compute.images.insert
@@ -3741,17 +3263,13 @@ interfaces:
       groups:
       - parameters:
         - forceCreate
-        - requestId
         - project
         - imageResource
     # TODO: Configure which fields are required.
     required_fields:
     - forceCreate
-    - requestId
     - project
     - imageResource
-    request_object_method: true
-    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: non_idempotent
     # TODO: Configure the retryable params for this method.
@@ -3770,15 +3288,13 @@ interfaces:
     # TODO: Configure which fields are required.
     required_fields:
     - project
-    request_object_method: true
-    resource_name_treatment: STATIC_TYPES
     page_streaming:
       request:
         page_size_field: maxResults
         token_field: pageToken
       response:
         token_field: nextPageToken
-        resources_field: ImageList
+        resources_field: items
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: idempotent
     # TODO: Configure the retryable params for this method.
@@ -3799,14 +3315,12 @@ interfaces:
     required_fields:
     - resource
     - globalSetPolicyRequestResource
-    request_object_method: true
-    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: non_idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      resource: imagesResource
+      resource: projectGlobalImageResource
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
   - name: compute.images.setLabels
@@ -3821,14 +3335,12 @@ interfaces:
     required_fields:
     - resource
     - globalSetLabelsRequestResource
-    request_object_method: true
-    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: non_idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      resource: imagesResource
+      resource: projectGlobalImageResource
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
   - name: compute.images.testIamPermissions
@@ -3843,17 +3355,15 @@ interfaces:
     required_fields:
     - resource
     - testPermissionsRequestResource
-    request_object_method: true
-    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: non_idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      resource: imagesResource
+      resource: projectGlobalImageResource
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
-  # The fully qualified name of the API interface.
+# The fully qualified name of the API interface.
 - name: google.compute.v1.InstanceGroupManagers
   # A list of resource collection configurations.
   # Consists of a name_pattern and an entity_name.
@@ -3866,18 +3376,18 @@ interfaces:
   # The entity_name is the name to be used as a basis for generated methods and
   # classes.
   collections:
-  - name_pattern: projects/{project}
+  - name_pattern: '{project}'
     entity_name: project
-  - name_pattern: projects/{project}/zones/{zone}
-    entity_name: zone
-  - name_pattern: projects/{project}/zones/{zone}/instanceGroupManagers/{instanceGroupManager}
-    entity_name: instanceGroupManager
+  - name_pattern: '{project}/zones/{zone}'
+    entity_name: projectZone
+  - name_pattern: '{project}/zones/{zone}/instanceGroupManagers/{instanceGroupManager}'
+    entity_name: projectZoneInstanceGroupManager
   # Definition for retryable codes.
   retry_codes_def:
   - name: idempotent
     retry_codes:
-    - SC_SERVICE_UNAVAILABLE
-    - SC_GATEWAY_TIMEOUT
+    - UNAVAILABLE
+    - DEADLINE_EXCEEDED
   - name: non_idempotent
     retry_codes: []
   # Definition for retry/backoff parameters.
@@ -3903,17 +3413,6 @@ interfaces:
   #       message.
   #   required_fields - Fields that are always required for a request to be
   #       valid.
-  #   request_object_method - Turns on or off the generation of a method whose
-  #       sole parameter is a request object. Not all languages will generate
-  #       this method.
-  #   resource_name_treatment - An enum that specifies how to treat the
-  #       resource name formats defined in the field_name_patterns
-  #       and response_field_name_patterns fields.
-  #       UNSET: default value
-  #       NONE: the collection configs will not be used by the generated code.
-  #       VALIDATE: string fields will be validated by the client against the
-  #           specified resource name formats.
-  #       STATIC_TYPES: the client will use generated types for resource names.
   #   page_streaming - Specifies the configuration for paging.
   #       Describes information for generating a method which transforms a
   #       paging list RPC into a stream of resources.
@@ -3947,22 +3446,18 @@ interfaces:
     flattening:
       groups:
       - parameters:
-        - requestId
         - instanceGroupManager
         - instanceGroupManagersAbandonInstancesRequestResource
     # TODO: Configure which fields are required.
     required_fields:
-    - requestId
     - instanceGroupManager
     - instanceGroupManagersAbandonInstancesRequestResource
-    request_object_method: true
-    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: non_idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      instanceGroupManager: instanceGroupManager
+      instanceGroupManager: projectZoneInstanceGroupManager
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
   - name: compute.instanceGroupManagers.aggregatedList
@@ -3975,15 +3470,13 @@ interfaces:
     # TODO: Configure which fields are required.
     required_fields:
     - project
-    request_object_method: true
-    resource_name_treatment: STATIC_TYPES
     page_streaming:
       request:
         page_size_field: maxResults
         token_field: pageToken
       response:
         token_field: nextPageToken
-        resources_field: InstanceGroupManagerAggregatedList
+        resources_field: items
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: idempotent
     # TODO: Configure the retryable params for this method.
@@ -3998,20 +3491,16 @@ interfaces:
     flattening:
       groups:
       - parameters:
-        - requestId
         - instanceGroupManager
     # TODO: Configure which fields are required.
     required_fields:
-    - requestId
     - instanceGroupManager
-    request_object_method: true
-    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      instanceGroupManager: instanceGroupManager
+      instanceGroupManager: projectZoneInstanceGroupManager
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
   - name: compute.instanceGroupManagers.deleteInstances
@@ -4020,22 +3509,18 @@ interfaces:
     flattening:
       groups:
       - parameters:
-        - requestId
         - instanceGroupManager
         - instanceGroupManagersDeleteInstancesRequestResource
     # TODO: Configure which fields are required.
     required_fields:
-    - requestId
     - instanceGroupManager
     - instanceGroupManagersDeleteInstancesRequestResource
-    request_object_method: true
-    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: non_idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      instanceGroupManager: instanceGroupManager
+      instanceGroupManager: projectZoneInstanceGroupManager
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
   - name: compute.instanceGroupManagers.get
@@ -4048,14 +3533,12 @@ interfaces:
     # TODO: Configure which fields are required.
     required_fields:
     - instanceGroupManager
-    request_object_method: true
-    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      instanceGroupManager: instanceGroupManager
+      instanceGroupManager: projectZoneInstanceGroupManager
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
   - name: compute.instanceGroupManagers.insert
@@ -4065,21 +3548,17 @@ interfaces:
       groups:
       - parameters:
         - zone
-        - requestId
         - instanceGroupManagerResource
     # TODO: Configure which fields are required.
     required_fields:
     - zone
-    - requestId
     - instanceGroupManagerResource
-    request_object_method: true
-    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: non_idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      zone: zone
+      zone: projectZone
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
   - name: compute.instanceGroupManagers.list
@@ -4092,21 +3571,19 @@ interfaces:
     # TODO: Configure which fields are required.
     required_fields:
     - zone
-    request_object_method: true
-    resource_name_treatment: STATIC_TYPES
     page_streaming:
       request:
         page_size_field: maxResults
         token_field: pageToken
       response:
         token_field: nextPageToken
-        resources_field: InstanceGroupManagerList
+        resources_field: items
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      zone: zone
+      zone: projectZone
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
   - name: compute.instanceGroupManagers.listManagedInstances
@@ -4119,14 +3596,12 @@ interfaces:
     # TODO: Configure which fields are required.
     required_fields:
     - instanceGroupManager
-    request_object_method: true
-    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: non_idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      instanceGroupManager: instanceGroupManager
+      instanceGroupManager: projectZoneInstanceGroupManager
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
   - name: compute.instanceGroupManagers.patch
@@ -4135,22 +3610,18 @@ interfaces:
     flattening:
       groups:
       - parameters:
-        - requestId
         - instanceGroupManager
         - instanceGroupManagerResource
     # TODO: Configure which fields are required.
     required_fields:
-    - requestId
     - instanceGroupManager
     - instanceGroupManagerResource
-    request_object_method: true
-    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: non_idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      instanceGroupManager: instanceGroupManager
+      instanceGroupManager: projectZoneInstanceGroupManager
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
   - name: compute.instanceGroupManagers.recreateInstances
@@ -4159,22 +3630,18 @@ interfaces:
     flattening:
       groups:
       - parameters:
-        - requestId
         - instanceGroupManager
         - instanceGroupManagersRecreateInstancesRequestResource
     # TODO: Configure which fields are required.
     required_fields:
-    - requestId
     - instanceGroupManager
     - instanceGroupManagersRecreateInstancesRequestResource
-    request_object_method: true
-    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: non_idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      instanceGroupManager: instanceGroupManager
+      instanceGroupManager: projectZoneInstanceGroupManager
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
   - name: compute.instanceGroupManagers.resize
@@ -4184,21 +3651,17 @@ interfaces:
       groups:
       - parameters:
         - size
-        - requestId
         - instanceGroupManager
     # TODO: Configure which fields are required.
     required_fields:
     - size
-    - requestId
     - instanceGroupManager
-    request_object_method: true
-    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: non_idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      instanceGroupManager: instanceGroupManager
+      instanceGroupManager: projectZoneInstanceGroupManager
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
   - name: compute.instanceGroupManagers.setInstanceTemplate
@@ -4207,22 +3670,18 @@ interfaces:
     flattening:
       groups:
       - parameters:
-        - requestId
         - instanceGroupManager
         - instanceGroupManagersSetInstanceTemplateRequestResource
     # TODO: Configure which fields are required.
     required_fields:
-    - requestId
     - instanceGroupManager
     - instanceGroupManagersSetInstanceTemplateRequestResource
-    request_object_method: true
-    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: non_idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      instanceGroupManager: instanceGroupManager
+      instanceGroupManager: projectZoneInstanceGroupManager
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
   - name: compute.instanceGroupManagers.setTargetPools
@@ -4231,25 +3690,21 @@ interfaces:
     flattening:
       groups:
       - parameters:
-        - requestId
         - instanceGroupManager
         - instanceGroupManagersSetTargetPoolsRequestResource
     # TODO: Configure which fields are required.
     required_fields:
-    - requestId
     - instanceGroupManager
     - instanceGroupManagersSetTargetPoolsRequestResource
-    request_object_method: true
-    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: non_idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      instanceGroupManager: instanceGroupManager
+      instanceGroupManager: projectZoneInstanceGroupManager
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
-  # The fully qualified name of the API interface.
+# The fully qualified name of the API interface.
 - name: google.compute.v1.InstanceGroups
   # A list of resource collection configurations.
   # Consists of a name_pattern and an entity_name.
@@ -4262,18 +3717,18 @@ interfaces:
   # The entity_name is the name to be used as a basis for generated methods and
   # classes.
   collections:
-  - name_pattern: projects/{project}
+  - name_pattern: '{project}'
     entity_name: project
-  - name_pattern: projects/{project}/zones/{zone}
-    entity_name: zone
-  - name_pattern: projects/{project}/zones/{zone}/instanceGroups/{instanceGroup}
-    entity_name: instanceGroup
+  - name_pattern: '{project}/zones/{zone}'
+    entity_name: projectZone
+  - name_pattern: '{project}/zones/{zone}/instanceGroups/{instanceGroup}'
+    entity_name: projectZoneInstanceGroup
   # Definition for retryable codes.
   retry_codes_def:
   - name: idempotent
     retry_codes:
-    - SC_SERVICE_UNAVAILABLE
-    - SC_GATEWAY_TIMEOUT
+    - UNAVAILABLE
+    - DEADLINE_EXCEEDED
   - name: non_idempotent
     retry_codes: []
   # Definition for retry/backoff parameters.
@@ -4299,17 +3754,6 @@ interfaces:
   #       message.
   #   required_fields - Fields that are always required for a request to be
   #       valid.
-  #   request_object_method - Turns on or off the generation of a method whose
-  #       sole parameter is a request object. Not all languages will generate
-  #       this method.
-  #   resource_name_treatment - An enum that specifies how to treat the
-  #       resource name formats defined in the field_name_patterns
-  #       and response_field_name_patterns fields.
-  #       UNSET: default value
-  #       NONE: the collection configs will not be used by the generated code.
-  #       VALIDATE: string fields will be validated by the client against the
-  #           specified resource name formats.
-  #       STATIC_TYPES: the client will use generated types for resource names.
   #   page_streaming - Specifies the configuration for paging.
   #       Describes information for generating a method which transforms a
   #       paging list RPC into a stream of resources.
@@ -4343,22 +3787,18 @@ interfaces:
     flattening:
       groups:
       - parameters:
-        - requestId
         - instanceGroup
         - instanceGroupsAddInstancesRequestResource
     # TODO: Configure which fields are required.
     required_fields:
-    - requestId
     - instanceGroup
     - instanceGroupsAddInstancesRequestResource
-    request_object_method: true
-    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: non_idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      instanceGroup: instanceGroup
+      instanceGroup: projectZoneInstanceGroup
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
   - name: compute.instanceGroups.aggregatedList
@@ -4371,15 +3811,13 @@ interfaces:
     # TODO: Configure which fields are required.
     required_fields:
     - project
-    request_object_method: true
-    resource_name_treatment: STATIC_TYPES
     page_streaming:
       request:
         page_size_field: maxResults
         token_field: pageToken
       response:
         token_field: nextPageToken
-        resources_field: InstanceGroupAggregatedList
+        resources_field: items
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: idempotent
     # TODO: Configure the retryable params for this method.
@@ -4394,20 +3832,16 @@ interfaces:
     flattening:
       groups:
       - parameters:
-        - requestId
         - instanceGroup
     # TODO: Configure which fields are required.
     required_fields:
-    - requestId
     - instanceGroup
-    request_object_method: true
-    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      instanceGroup: instanceGroup
+      instanceGroup: projectZoneInstanceGroup
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
   - name: compute.instanceGroups.get
@@ -4420,14 +3854,12 @@ interfaces:
     # TODO: Configure which fields are required.
     required_fields:
     - instanceGroup
-    request_object_method: true
-    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      instanceGroup: instanceGroup
+      instanceGroup: projectZoneInstanceGroup
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
   - name: compute.instanceGroups.insert
@@ -4437,21 +3869,17 @@ interfaces:
       groups:
       - parameters:
         - zone
-        - requestId
         - instanceGroupResource
     # TODO: Configure which fields are required.
     required_fields:
     - zone
-    - requestId
     - instanceGroupResource
-    request_object_method: true
-    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: non_idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      zone: zone
+      zone: projectZone
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
   - name: compute.instanceGroups.list
@@ -4464,21 +3892,19 @@ interfaces:
     # TODO: Configure which fields are required.
     required_fields:
     - zone
-    request_object_method: true
-    resource_name_treatment: STATIC_TYPES
     page_streaming:
       request:
         page_size_field: maxResults
         token_field: pageToken
       response:
         token_field: nextPageToken
-        resources_field: InstanceGroupList
+        resources_field: items
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      zone: zone
+      zone: projectZone
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
   - name: compute.instanceGroups.listInstances
@@ -4493,21 +3919,19 @@ interfaces:
     required_fields:
     - instanceGroup
     - instanceGroupsListInstancesRequestResource
-    request_object_method: true
-    resource_name_treatment: STATIC_TYPES
     page_streaming:
       request:
         page_size_field: maxResults
         token_field: pageToken
       response:
         token_field: nextPageToken
-        resources_field: InstanceGroupsListInstances
+        resources_field: items
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: non_idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      instanceGroup: instanceGroup
+      instanceGroup: projectZoneInstanceGroup
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
   - name: compute.instanceGroups.removeInstances
@@ -4516,22 +3940,18 @@ interfaces:
     flattening:
       groups:
       - parameters:
-        - requestId
         - instanceGroup
         - instanceGroupsRemoveInstancesRequestResource
     # TODO: Configure which fields are required.
     required_fields:
-    - requestId
     - instanceGroup
     - instanceGroupsRemoveInstancesRequestResource
-    request_object_method: true
-    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: non_idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      instanceGroup: instanceGroup
+      instanceGroup: projectZoneInstanceGroup
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
   - name: compute.instanceGroups.setNamedPorts
@@ -4540,25 +3960,21 @@ interfaces:
     flattening:
       groups:
       - parameters:
-        - requestId
         - instanceGroup
         - instanceGroupsSetNamedPortsRequestResource
     # TODO: Configure which fields are required.
     required_fields:
-    - requestId
     - instanceGroup
     - instanceGroupsSetNamedPortsRequestResource
-    request_object_method: true
-    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: non_idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      instanceGroup: instanceGroup
+      instanceGroup: projectZoneInstanceGroup
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
-  # The fully qualified name of the API interface.
+# The fully qualified name of the API interface.
 - name: google.compute.v1.InstanceTemplates
   # A list of resource collection configurations.
   # Consists of a name_pattern and an entity_name.
@@ -4571,18 +3987,18 @@ interfaces:
   # The entity_name is the name to be used as a basis for generated methods and
   # classes.
   collections:
-  - name_pattern: projects/{project}
+  - name_pattern: '{project}'
     entity_name: project
-  - name_pattern: projects/{project}/instanceTemplates/{instanceTemplate}
-    entity_name: instanceTemplate
-  - name_pattern: projects/{project}/instanceTemplates/{resource}
-    entity_name: instanceTemplatesResource
+  - name_pattern: '{project}/global/instanceTemplates/{instanceTemplate}'
+    entity_name: projectGlobalInstanceTemplate
+  - name_pattern: '{project}/global/instanceTemplates/{resource}'
+    entity_name: projectGlobalInstanceTemplateResource
   # Definition for retryable codes.
   retry_codes_def:
   - name: idempotent
     retry_codes:
-    - SC_SERVICE_UNAVAILABLE
-    - SC_GATEWAY_TIMEOUT
+    - UNAVAILABLE
+    - DEADLINE_EXCEEDED
   - name: non_idempotent
     retry_codes: []
   # Definition for retry/backoff parameters.
@@ -4608,17 +4024,6 @@ interfaces:
   #       message.
   #   required_fields - Fields that are always required for a request to be
   #       valid.
-  #   request_object_method - Turns on or off the generation of a method whose
-  #       sole parameter is a request object. Not all languages will generate
-  #       this method.
-  #   resource_name_treatment - An enum that specifies how to treat the
-  #       resource name formats defined in the field_name_patterns
-  #       and response_field_name_patterns fields.
-  #       UNSET: default value
-  #       NONE: the collection configs will not be used by the generated code.
-  #       VALIDATE: string fields will be validated by the client against the
-  #           specified resource name formats.
-  #       STATIC_TYPES: the client will use generated types for resource names.
   #   page_streaming - Specifies the configuration for paging.
   #       Describes information for generating a method which transforms a
   #       paging list RPC into a stream of resources.
@@ -4653,19 +4058,15 @@ interfaces:
       groups:
       - parameters:
         - instanceTemplate
-        - requestId
     # TODO: Configure which fields are required.
     required_fields:
     - instanceTemplate
-    - requestId
-    request_object_method: true
-    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      instanceTemplate: instanceTemplate
+      instanceTemplate: projectGlobalInstanceTemplate
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
   - name: compute.instanceTemplates.get
@@ -4678,14 +4079,12 @@ interfaces:
     # TODO: Configure which fields are required.
     required_fields:
     - instanceTemplate
-    request_object_method: true
-    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      instanceTemplate: instanceTemplate
+      instanceTemplate: projectGlobalInstanceTemplate
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
   - name: compute.instanceTemplates.getIamPolicy
@@ -4698,14 +4097,12 @@ interfaces:
     # TODO: Configure which fields are required.
     required_fields:
     - resource
-    request_object_method: true
-    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      resource: instanceTemplatesResource
+      resource: projectGlobalInstanceTemplateResource
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
   - name: compute.instanceTemplates.insert
@@ -4714,16 +4111,12 @@ interfaces:
     flattening:
       groups:
       - parameters:
-        - requestId
         - project
         - instanceTemplateResource
     # TODO: Configure which fields are required.
     required_fields:
-    - requestId
     - project
     - instanceTemplateResource
-    request_object_method: true
-    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: non_idempotent
     # TODO: Configure the retryable params for this method.
@@ -4742,15 +4135,13 @@ interfaces:
     # TODO: Configure which fields are required.
     required_fields:
     - project
-    request_object_method: true
-    resource_name_treatment: STATIC_TYPES
     page_streaming:
       request:
         page_size_field: maxResults
         token_field: pageToken
       response:
         token_field: nextPageToken
-        resources_field: InstanceTemplateList
+        resources_field: items
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: idempotent
     # TODO: Configure the retryable params for this method.
@@ -4771,14 +4162,12 @@ interfaces:
     required_fields:
     - resource
     - globalSetPolicyRequestResource
-    request_object_method: true
-    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: non_idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      resource: instanceTemplatesResource
+      resource: projectGlobalInstanceTemplateResource
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
   - name: compute.instanceTemplates.testIamPermissions
@@ -4793,17 +4182,15 @@ interfaces:
     required_fields:
     - resource
     - testPermissionsRequestResource
-    request_object_method: true
-    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: non_idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      resource: instanceTemplatesResource
+      resource: projectGlobalInstanceTemplateResource
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
-  # The fully qualified name of the API interface.
+# The fully qualified name of the API interface.
 - name: google.compute.v1.Instances
   # A list of resource collection configurations.
   # Consists of a name_pattern and an entity_name.
@@ -4816,20 +4203,20 @@ interfaces:
   # The entity_name is the name to be used as a basis for generated methods and
   # classes.
   collections:
-  - name_pattern: projects/{project}
+  - name_pattern: '{project}'
     entity_name: project
-  - name_pattern: projects/{project}/zones/{zone}
-    entity_name: zone
-  - name_pattern: projects/{project}/zones/{zone}/instances/{instance}
-    entity_name: instance
-  - name_pattern: projects/{project}/zones/{zone}/instances/{resource}
-    entity_name: instancesResource
+  - name_pattern: '{project}/zones/{zone}'
+    entity_name: projectZone
+  - name_pattern: '{project}/zones/{zone}/instances/{instance}'
+    entity_name: projectZoneInstance
+  - name_pattern: '{project}/zones/{zone}/instances/{resource}'
+    entity_name: projectZoneInstanceResource
   # Definition for retryable codes.
   retry_codes_def:
   - name: idempotent
     retry_codes:
-    - SC_SERVICE_UNAVAILABLE
-    - SC_GATEWAY_TIMEOUT
+    - UNAVAILABLE
+    - DEADLINE_EXCEEDED
   - name: non_idempotent
     retry_codes: []
   # Definition for retry/backoff parameters.
@@ -4855,17 +4242,6 @@ interfaces:
   #       message.
   #   required_fields - Fields that are always required for a request to be
   #       valid.
-  #   request_object_method - Turns on or off the generation of a method whose
-  #       sole parameter is a request object. Not all languages will generate
-  #       this method.
-  #   resource_name_treatment - An enum that specifies how to treat the
-  #       resource name formats defined in the field_name_patterns
-  #       and response_field_name_patterns fields.
-  #       UNSET: default value
-  #       NONE: the collection configs will not be used by the generated code.
-  #       VALIDATE: string fields will be validated by the client against the
-  #           specified resource name formats.
-  #       STATIC_TYPES: the client will use generated types for resource names.
   #   page_streaming - Specifies the configuration for paging.
   #       Describes information for generating a method which transforms a
   #       paging list RPC into a stream of resources.
@@ -4901,22 +4277,18 @@ interfaces:
       - parameters:
         - instance
         - networkInterface
-        - requestId
         - accessConfigResource
     # TODO: Configure which fields are required.
     required_fields:
     - instance
     - networkInterface
-    - requestId
     - accessConfigResource
-    request_object_method: true
-    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: non_idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      instance: instance
+      instance: projectZoneInstance
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
   - name: compute.instances.aggregatedList
@@ -4929,15 +4301,13 @@ interfaces:
     # TODO: Configure which fields are required.
     required_fields:
     - project
-    request_object_method: true
-    resource_name_treatment: STATIC_TYPES
     page_streaming:
       request:
         page_size_field: maxResults
         token_field: pageToken
       response:
         token_field: nextPageToken
-        resources_field: InstanceAggregatedList
+        resources_field: items
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: idempotent
     # TODO: Configure the retryable params for this method.
@@ -4953,23 +4323,19 @@ interfaces:
       groups:
       - parameters:
         - instance
-        - requestId
         - forceAttach
         - attachedDiskResource
     # TODO: Configure which fields are required.
     required_fields:
     - instance
-    - requestId
     - forceAttach
     - attachedDiskResource
-    request_object_method: true
-    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: non_idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      instance: instance
+      instance: projectZoneInstance
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
   - name: compute.instances.delete
@@ -4979,19 +4345,15 @@ interfaces:
       groups:
       - parameters:
         - instance
-        - requestId
     # TODO: Configure which fields are required.
     required_fields:
     - instance
-    - requestId
-    request_object_method: true
-    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      instance: instance
+      instance: projectZoneInstance
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
   - name: compute.instances.deleteAccessConfig
@@ -5002,22 +4364,18 @@ interfaces:
       - parameters:
         - instance
         - networkInterface
-        - requestId
         - accessConfig
     # TODO: Configure which fields are required.
     required_fields:
     - instance
     - networkInterface
-    - requestId
     - accessConfig
-    request_object_method: true
-    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: non_idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      instance: instance
+      instance: projectZoneInstance
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
   - name: compute.instances.detachDisk
@@ -5027,21 +4385,17 @@ interfaces:
       groups:
       - parameters:
         - instance
-        - requestId
         - deviceName
     # TODO: Configure which fields are required.
     required_fields:
     - instance
-    - requestId
     - deviceName
-    request_object_method: true
-    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: non_idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      instance: instance
+      instance: projectZoneInstance
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
   - name: compute.instances.get
@@ -5054,14 +4408,12 @@ interfaces:
     # TODO: Configure which fields are required.
     required_fields:
     - instance
-    request_object_method: true
-    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      instance: instance
+      instance: projectZoneInstance
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
   - name: compute.instances.getGuestAttributes
@@ -5078,14 +4430,12 @@ interfaces:
     - instance
     - queryPath
     - variableKey
-    request_object_method: true
-    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      instance: instance
+      instance: projectZoneInstance
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
   - name: compute.instances.getIamPolicy
@@ -5098,14 +4448,12 @@ interfaces:
     # TODO: Configure which fields are required.
     required_fields:
     - resource
-    request_object_method: true
-    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      resource: instancesResource
+      resource: projectZoneInstanceResource
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
   - name: compute.instances.getSerialPortOutput
@@ -5122,14 +4470,12 @@ interfaces:
     - instance
     - port
     - start
-    request_object_method: true
-    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      instance: instance
+      instance: projectZoneInstance
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
   - name: compute.instances.getShieldedInstanceIdentity
@@ -5142,14 +4488,12 @@ interfaces:
     # TODO: Configure which fields are required.
     required_fields:
     - instance
-    request_object_method: true
-    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      instance: instance
+      instance: projectZoneInstance
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
   - name: compute.instances.insert
@@ -5158,24 +4502,18 @@ interfaces:
     flattening:
       groups:
       - parameters:
-        - sourceInstanceTemplate
         - zone
-        - requestId
         - instanceResource
     # TODO: Configure which fields are required.
     required_fields:
-    - sourceInstanceTemplate
     - zone
-    - requestId
     - instanceResource
-    request_object_method: true
-    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: non_idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      zone: zone
+      zone: projectZone
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
   - name: compute.instances.list
@@ -5188,21 +4526,19 @@ interfaces:
     # TODO: Configure which fields are required.
     required_fields:
     - zone
-    request_object_method: true
-    resource_name_treatment: STATIC_TYPES
     page_streaming:
       request:
         page_size_field: maxResults
         token_field: pageToken
       response:
         token_field: nextPageToken
-        resources_field: InstanceList
+        resources_field: items
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      zone: zone
+      zone: projectZone
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
   - name: compute.instances.listReferrers
@@ -5215,21 +4551,19 @@ interfaces:
     # TODO: Configure which fields are required.
     required_fields:
     - instance
-    request_object_method: true
-    resource_name_treatment: STATIC_TYPES
     page_streaming:
       request:
         page_size_field: maxResults
         token_field: pageToken
       response:
         token_field: nextPageToken
-        resources_field: InstanceListReferrers
+        resources_field: items
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      instance: instance
+      instance: projectZoneInstance
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
   - name: compute.instances.reset
@@ -5239,19 +4573,15 @@ interfaces:
       groups:
       - parameters:
         - instance
-        - requestId
     # TODO: Configure which fields are required.
     required_fields:
     - instance
-    - requestId
-    request_object_method: true
-    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: non_idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      instance: instance
+      instance: projectZoneInstance
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
   - name: compute.instances.setDeletionProtection
@@ -5261,21 +4591,17 @@ interfaces:
       groups:
       - parameters:
         - resource
-        - requestId
         - deletionProtection
     # TODO: Configure which fields are required.
     required_fields:
     - resource
-    - requestId
     - deletionProtection
-    request_object_method: true
-    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: non_idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      resource: instancesResource
+      resource: projectZoneInstanceResource
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
   - name: compute.instances.setDiskAutoDelete
@@ -5285,23 +4611,19 @@ interfaces:
       groups:
       - parameters:
         - instance
-        - requestId
         - autoDelete
         - deviceName
     # TODO: Configure which fields are required.
     required_fields:
     - instance
-    - requestId
     - autoDelete
     - deviceName
-    request_object_method: true
-    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: non_idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      instance: instance
+      instance: projectZoneInstance
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
   - name: compute.instances.setIamPolicy
@@ -5316,14 +4638,12 @@ interfaces:
     required_fields:
     - resource
     - zoneSetPolicyRequestResource
-    request_object_method: true
-    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: non_idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      resource: instancesResource
+      resource: projectZoneInstanceResource
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
   - name: compute.instances.setLabels
@@ -5333,21 +4653,17 @@ interfaces:
       groups:
       - parameters:
         - instance
-        - requestId
         - instancesSetLabelsRequestResource
     # TODO: Configure which fields are required.
     required_fields:
     - instance
-    - requestId
     - instancesSetLabelsRequestResource
-    request_object_method: true
-    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: non_idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      instance: instance
+      instance: projectZoneInstance
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
   - name: compute.instances.setMachineResources
@@ -5357,21 +4673,17 @@ interfaces:
       groups:
       - parameters:
         - instance
-        - requestId
         - instancesSetMachineResourcesRequestResource
     # TODO: Configure which fields are required.
     required_fields:
     - instance
-    - requestId
     - instancesSetMachineResourcesRequestResource
-    request_object_method: true
-    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: non_idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      instance: instance
+      instance: projectZoneInstance
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
   - name: compute.instances.setMachineType
@@ -5381,21 +4693,17 @@ interfaces:
       groups:
       - parameters:
         - instance
-        - requestId
         - instancesSetMachineTypeRequestResource
     # TODO: Configure which fields are required.
     required_fields:
     - instance
-    - requestId
     - instancesSetMachineTypeRequestResource
-    request_object_method: true
-    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: non_idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      instance: instance
+      instance: projectZoneInstance
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
   - name: compute.instances.setMetadata
@@ -5405,21 +4713,17 @@ interfaces:
       groups:
       - parameters:
         - instance
-        - requestId
         - metadataResource
     # TODO: Configure which fields are required.
     required_fields:
     - instance
-    - requestId
     - metadataResource
-    request_object_method: true
-    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: non_idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      instance: instance
+      instance: projectZoneInstance
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
   - name: compute.instances.setMinCpuPlatform
@@ -5429,21 +4733,17 @@ interfaces:
       groups:
       - parameters:
         - instance
-        - requestId
         - instancesSetMinCpuPlatformRequestResource
     # TODO: Configure which fields are required.
     required_fields:
     - instance
-    - requestId
     - instancesSetMinCpuPlatformRequestResource
-    request_object_method: true
-    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: non_idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      instance: instance
+      instance: projectZoneInstance
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
   - name: compute.instances.setScheduling
@@ -5453,21 +4753,17 @@ interfaces:
       groups:
       - parameters:
         - instance
-        - requestId
         - schedulingResource
     # TODO: Configure which fields are required.
     required_fields:
     - instance
-    - requestId
     - schedulingResource
-    request_object_method: true
-    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: non_idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      instance: instance
+      instance: projectZoneInstance
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
   - name: compute.instances.setServiceAccount
@@ -5477,21 +4773,17 @@ interfaces:
       groups:
       - parameters:
         - instance
-        - requestId
         - instancesSetServiceAccountRequestResource
     # TODO: Configure which fields are required.
     required_fields:
     - instance
-    - requestId
     - instancesSetServiceAccountRequestResource
-    request_object_method: true
-    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: non_idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      instance: instance
+      instance: projectZoneInstance
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
   - name: compute.instances.setShieldedInstanceIntegrityPolicy
@@ -5501,21 +4793,17 @@ interfaces:
       groups:
       - parameters:
         - instance
-        - requestId
         - shieldedInstanceIntegrityPolicyResource
     # TODO: Configure which fields are required.
     required_fields:
     - instance
-    - requestId
     - shieldedInstanceIntegrityPolicyResource
-    request_object_method: true
-    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: non_idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      instance: instance
+      instance: projectZoneInstance
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
   - name: compute.instances.setTags
@@ -5525,21 +4813,17 @@ interfaces:
       groups:
       - parameters:
         - instance
-        - requestId
         - tagsResource
     # TODO: Configure which fields are required.
     required_fields:
     - instance
-    - requestId
     - tagsResource
-    request_object_method: true
-    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: non_idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      instance: instance
+      instance: projectZoneInstance
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
   - name: compute.instances.simulateMaintenanceEvent
@@ -5552,14 +4836,12 @@ interfaces:
     # TODO: Configure which fields are required.
     required_fields:
     - instance
-    request_object_method: true
-    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: non_idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      instance: instance
+      instance: projectZoneInstance
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
   - name: compute.instances.start
@@ -5569,19 +4851,15 @@ interfaces:
       groups:
       - parameters:
         - instance
-        - requestId
     # TODO: Configure which fields are required.
     required_fields:
     - instance
-    - requestId
-    request_object_method: true
-    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: non_idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      instance: instance
+      instance: projectZoneInstance
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
   - name: compute.instances.startWithEncryptionKey
@@ -5591,21 +4869,17 @@ interfaces:
       groups:
       - parameters:
         - instance
-        - requestId
         - instancesStartWithEncryptionKeyRequestResource
     # TODO: Configure which fields are required.
     required_fields:
     - instance
-    - requestId
     - instancesStartWithEncryptionKeyRequestResource
-    request_object_method: true
-    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: non_idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      instance: instance
+      instance: projectZoneInstance
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
   - name: compute.instances.stop
@@ -5615,19 +4889,15 @@ interfaces:
       groups:
       - parameters:
         - instance
-        - requestId
     # TODO: Configure which fields are required.
     required_fields:
     - instance
-    - requestId
-    request_object_method: true
-    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: non_idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      instance: instance
+      instance: projectZoneInstance
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
   - name: compute.instances.testIamPermissions
@@ -5642,14 +4912,12 @@ interfaces:
     required_fields:
     - resource
     - testPermissionsRequestResource
-    request_object_method: true
-    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: non_idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      resource: instancesResource
+      resource: projectZoneInstanceResource
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
   - name: compute.instances.updateAccessConfig
@@ -5660,22 +4928,18 @@ interfaces:
       - parameters:
         - instance
         - networkInterface
-        - requestId
         - accessConfigResource
     # TODO: Configure which fields are required.
     required_fields:
     - instance
     - networkInterface
-    - requestId
     - accessConfigResource
-    request_object_method: true
-    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: non_idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      instance: instance
+      instance: projectZoneInstance
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
   - name: compute.instances.updateNetworkInterface
@@ -5686,22 +4950,18 @@ interfaces:
       - parameters:
         - instance
         - networkInterface
-        - requestId
         - networkInterfaceResource
     # TODO: Configure which fields are required.
     required_fields:
     - instance
     - networkInterface
-    - requestId
     - networkInterfaceResource
-    request_object_method: true
-    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: non_idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      instance: instance
+      instance: projectZoneInstance
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
   - name: compute.instances.updateShieldedInstanceConfig
@@ -5711,24 +4971,20 @@ interfaces:
       groups:
       - parameters:
         - instance
-        - requestId
         - shieldedInstanceConfigResource
     # TODO: Configure which fields are required.
     required_fields:
     - instance
-    - requestId
     - shieldedInstanceConfigResource
-    request_object_method: true
-    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: non_idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      instance: instance
+      instance: projectZoneInstance
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
-  # The fully qualified name of the API interface.
+# The fully qualified name of the API interface.
 - name: google.compute.v1.InterconnectAttachments
   # A list of resource collection configurations.
   # Consists of a name_pattern and an entity_name.
@@ -5741,18 +4997,18 @@ interfaces:
   # The entity_name is the name to be used as a basis for generated methods and
   # classes.
   collections:
-  - name_pattern: projects/{project}
+  - name_pattern: '{project}'
     entity_name: project
-  - name_pattern: projects/{project}/regions/{region}
-    entity_name: region
-  - name_pattern: projects/{project}/regions/{region}/interconnectAttachments/{interconnectAttachment}
-    entity_name: interconnectAttachment
+  - name_pattern: '{project}/regions/{region}'
+    entity_name: projectRegion
+  - name_pattern: '{project}/regions/{region}/interconnectAttachments/{interconnectAttachment}'
+    entity_name: projectRegionInterconnectAttachment
   # Definition for retryable codes.
   retry_codes_def:
   - name: idempotent
     retry_codes:
-    - SC_SERVICE_UNAVAILABLE
-    - SC_GATEWAY_TIMEOUT
+    - UNAVAILABLE
+    - DEADLINE_EXCEEDED
   - name: non_idempotent
     retry_codes: []
   # Definition for retry/backoff parameters.
@@ -5778,17 +5034,6 @@ interfaces:
   #       message.
   #   required_fields - Fields that are always required for a request to be
   #       valid.
-  #   request_object_method - Turns on or off the generation of a method whose
-  #       sole parameter is a request object. Not all languages will generate
-  #       this method.
-  #   resource_name_treatment - An enum that specifies how to treat the
-  #       resource name formats defined in the field_name_patterns
-  #       and response_field_name_patterns fields.
-  #       UNSET: default value
-  #       NONE: the collection configs will not be used by the generated code.
-  #       VALIDATE: string fields will be validated by the client against the
-  #           specified resource name formats.
-  #       STATIC_TYPES: the client will use generated types for resource names.
   #   page_streaming - Specifies the configuration for paging.
   #       Describes information for generating a method which transforms a
   #       paging list RPC into a stream of resources.
@@ -5826,15 +5071,13 @@ interfaces:
     # TODO: Configure which fields are required.
     required_fields:
     - project
-    request_object_method: true
-    resource_name_treatment: STATIC_TYPES
     page_streaming:
       request:
         page_size_field: maxResults
         token_field: pageToken
       response:
         token_field: nextPageToken
-        resources_field: InterconnectAttachmentAggregatedList
+        resources_field: items
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: idempotent
     # TODO: Configure the retryable params for this method.
@@ -5849,20 +5092,16 @@ interfaces:
     flattening:
       groups:
       - parameters:
-        - requestId
         - interconnectAttachment
     # TODO: Configure which fields are required.
     required_fields:
-    - requestId
     - interconnectAttachment
-    request_object_method: true
-    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      interconnectAttachment: interconnectAttachment
+      interconnectAttachment: projectRegionInterconnectAttachment
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
   - name: compute.interconnectAttachments.get
@@ -5875,14 +5114,12 @@ interfaces:
     # TODO: Configure which fields are required.
     required_fields:
     - interconnectAttachment
-    request_object_method: true
-    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      interconnectAttachment: interconnectAttachment
+      interconnectAttachment: projectRegionInterconnectAttachment
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
   - name: compute.interconnectAttachments.insert
@@ -5891,22 +5128,18 @@ interfaces:
     flattening:
       groups:
       - parameters:
-        - requestId
         - region
         - interconnectAttachmentResource
     # TODO: Configure which fields are required.
     required_fields:
-    - requestId
     - region
     - interconnectAttachmentResource
-    request_object_method: true
-    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: non_idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      region: region
+      region: projectRegion
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
   - name: compute.interconnectAttachments.list
@@ -5919,21 +5152,19 @@ interfaces:
     # TODO: Configure which fields are required.
     required_fields:
     - region
-    request_object_method: true
-    resource_name_treatment: STATIC_TYPES
     page_streaming:
       request:
         page_size_field: maxResults
         token_field: pageToken
       response:
         token_field: nextPageToken
-        resources_field: InterconnectAttachmentList
+        resources_field: items
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      region: region
+      region: projectRegion
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
   - name: compute.interconnectAttachments.patch
@@ -5942,25 +5173,21 @@ interfaces:
     flattening:
       groups:
       - parameters:
-        - requestId
         - interconnectAttachment
         - interconnectAttachmentResource
     # TODO: Configure which fields are required.
     required_fields:
-    - requestId
     - interconnectAttachment
     - interconnectAttachmentResource
-    request_object_method: true
-    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: non_idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      interconnectAttachment: interconnectAttachment
+      interconnectAttachment: projectRegionInterconnectAttachment
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
-  # The fully qualified name of the API interface.
+# The fully qualified name of the API interface.
 - name: google.compute.v1.InterconnectLocations
   # A list of resource collection configurations.
   # Consists of a name_pattern and an entity_name.
@@ -5973,16 +5200,16 @@ interfaces:
   # The entity_name is the name to be used as a basis for generated methods and
   # classes.
   collections:
-  - name_pattern: projects/{project}
+  - name_pattern: '{project}'
     entity_name: project
-  - name_pattern: projects/{project}/interconnectLocations/{interconnectLocation}
-    entity_name: interconnectLocation
+  - name_pattern: '{project}/global/interconnectLocations/{interconnectLocation}'
+    entity_name: projectGlobalInterconnectLocation
   # Definition for retryable codes.
   retry_codes_def:
   - name: idempotent
     retry_codes:
-    - SC_SERVICE_UNAVAILABLE
-    - SC_GATEWAY_TIMEOUT
+    - UNAVAILABLE
+    - DEADLINE_EXCEEDED
   - name: non_idempotent
     retry_codes: []
   # Definition for retry/backoff parameters.
@@ -6008,17 +5235,6 @@ interfaces:
   #       message.
   #   required_fields - Fields that are always required for a request to be
   #       valid.
-  #   request_object_method - Turns on or off the generation of a method whose
-  #       sole parameter is a request object. Not all languages will generate
-  #       this method.
-  #   resource_name_treatment - An enum that specifies how to treat the
-  #       resource name formats defined in the field_name_patterns
-  #       and response_field_name_patterns fields.
-  #       UNSET: default value
-  #       NONE: the collection configs will not be used by the generated code.
-  #       VALIDATE: string fields will be validated by the client against the
-  #           specified resource name formats.
-  #       STATIC_TYPES: the client will use generated types for resource names.
   #   page_streaming - Specifies the configuration for paging.
   #       Describes information for generating a method which transforms a
   #       paging list RPC into a stream of resources.
@@ -6056,14 +5272,12 @@ interfaces:
     # TODO: Configure which fields are required.
     required_fields:
     - interconnectLocation
-    request_object_method: true
-    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      interconnectLocation: interconnectLocation
+      interconnectLocation: projectGlobalInterconnectLocation
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
   - name: compute.interconnectLocations.list
@@ -6076,15 +5290,13 @@ interfaces:
     # TODO: Configure which fields are required.
     required_fields:
     - project
-    request_object_method: true
-    resource_name_treatment: STATIC_TYPES
     page_streaming:
       request:
         page_size_field: maxResults
         token_field: pageToken
       response:
         token_field: nextPageToken
-        resources_field: InterconnectLocationList
+        resources_field: items
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: idempotent
     # TODO: Configure the retryable params for this method.
@@ -6093,7 +5305,7 @@ interfaces:
       project: project
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
-  # The fully qualified name of the API interface.
+# The fully qualified name of the API interface.
 - name: google.compute.v1.Interconnects
   # A list of resource collection configurations.
   # Consists of a name_pattern and an entity_name.
@@ -6106,16 +5318,16 @@ interfaces:
   # The entity_name is the name to be used as a basis for generated methods and
   # classes.
   collections:
-  - name_pattern: projects/{project}
+  - name_pattern: '{project}'
     entity_name: project
-  - name_pattern: projects/{project}/interconnects/{interconnect}
-    entity_name: interconnect
+  - name_pattern: '{project}/global/interconnects/{interconnect}'
+    entity_name: projectGlobalInterconnect
   # Definition for retryable codes.
   retry_codes_def:
   - name: idempotent
     retry_codes:
-    - SC_SERVICE_UNAVAILABLE
-    - SC_GATEWAY_TIMEOUT
+    - UNAVAILABLE
+    - DEADLINE_EXCEEDED
   - name: non_idempotent
     retry_codes: []
   # Definition for retry/backoff parameters.
@@ -6141,17 +5353,6 @@ interfaces:
   #       message.
   #   required_fields - Fields that are always required for a request to be
   #       valid.
-  #   request_object_method - Turns on or off the generation of a method whose
-  #       sole parameter is a request object. Not all languages will generate
-  #       this method.
-  #   resource_name_treatment - An enum that specifies how to treat the
-  #       resource name formats defined in the field_name_patterns
-  #       and response_field_name_patterns fields.
-  #       UNSET: default value
-  #       NONE: the collection configs will not be used by the generated code.
-  #       VALIDATE: string fields will be validated by the client against the
-  #           specified resource name formats.
-  #       STATIC_TYPES: the client will use generated types for resource names.
   #   page_streaming - Specifies the configuration for paging.
   #       Describes information for generating a method which transforms a
   #       paging list RPC into a stream of resources.
@@ -6185,20 +5386,16 @@ interfaces:
     flattening:
       groups:
       - parameters:
-        - requestId
         - interconnect
     # TODO: Configure which fields are required.
     required_fields:
-    - requestId
     - interconnect
-    request_object_method: true
-    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      interconnect: interconnect
+      interconnect: projectGlobalInterconnect
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
   - name: compute.interconnects.get
@@ -6211,14 +5408,12 @@ interfaces:
     # TODO: Configure which fields are required.
     required_fields:
     - interconnect
-    request_object_method: true
-    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      interconnect: interconnect
+      interconnect: projectGlobalInterconnect
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
   - name: compute.interconnects.getDiagnostics
@@ -6231,14 +5426,12 @@ interfaces:
     # TODO: Configure which fields are required.
     required_fields:
     - interconnect
-    request_object_method: true
-    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      interconnect: interconnect
+      interconnect: projectGlobalInterconnect
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
   - name: compute.interconnects.insert
@@ -6247,16 +5440,12 @@ interfaces:
     flattening:
       groups:
       - parameters:
-        - requestId
         - project
         - interconnectResource
     # TODO: Configure which fields are required.
     required_fields:
-    - requestId
     - project
     - interconnectResource
-    request_object_method: true
-    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: non_idempotent
     # TODO: Configure the retryable params for this method.
@@ -6275,15 +5464,13 @@ interfaces:
     # TODO: Configure which fields are required.
     required_fields:
     - project
-    request_object_method: true
-    resource_name_treatment: STATIC_TYPES
     page_streaming:
       request:
         page_size_field: maxResults
         token_field: pageToken
       response:
         token_field: nextPageToken
-        resources_field: InterconnectList
+        resources_field: items
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: idempotent
     # TODO: Configure the retryable params for this method.
@@ -6298,25 +5485,21 @@ interfaces:
     flattening:
       groups:
       - parameters:
-        - requestId
         - interconnect
         - interconnectResource
     # TODO: Configure which fields are required.
     required_fields:
-    - requestId
     - interconnect
     - interconnectResource
-    request_object_method: true
-    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: non_idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      interconnect: interconnect
+      interconnect: projectGlobalInterconnect
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
-  # The fully qualified name of the API interface.
+# The fully qualified name of the API interface.
 - name: google.compute.v1.LicenseCodes
   # A list of resource collection configurations.
   # Consists of a name_pattern and an entity_name.
@@ -6329,16 +5512,16 @@ interfaces:
   # The entity_name is the name to be used as a basis for generated methods and
   # classes.
   collections:
-  - name_pattern: projects/{project}/licenseCodes/{licenseCode}
-    entity_name: licenseCode
-  - name_pattern: projects/{project}/licenseCodes/{resource}
-    entity_name: licenseCodesResource
+  - name_pattern: '{project}/global/licenseCodes/{licenseCode}'
+    entity_name: projectGlobalLicenseCode
+  - name_pattern: '{project}/global/licenseCodes/{resource}'
+    entity_name: projectGlobalLicenseCodeResource
   # Definition for retryable codes.
   retry_codes_def:
   - name: idempotent
     retry_codes:
-    - SC_SERVICE_UNAVAILABLE
-    - SC_GATEWAY_TIMEOUT
+    - UNAVAILABLE
+    - DEADLINE_EXCEEDED
   - name: non_idempotent
     retry_codes: []
   # Definition for retry/backoff parameters.
@@ -6364,17 +5547,6 @@ interfaces:
   #       message.
   #   required_fields - Fields that are always required for a request to be
   #       valid.
-  #   request_object_method - Turns on or off the generation of a method whose
-  #       sole parameter is a request object. Not all languages will generate
-  #       this method.
-  #   resource_name_treatment - An enum that specifies how to treat the
-  #       resource name formats defined in the field_name_patterns
-  #       and response_field_name_patterns fields.
-  #       UNSET: default value
-  #       NONE: the collection configs will not be used by the generated code.
-  #       VALIDATE: string fields will be validated by the client against the
-  #           specified resource name formats.
-  #       STATIC_TYPES: the client will use generated types for resource names.
   #   page_streaming - Specifies the configuration for paging.
   #       Describes information for generating a method which transforms a
   #       paging list RPC into a stream of resources.
@@ -6412,14 +5584,12 @@ interfaces:
     # TODO: Configure which fields are required.
     required_fields:
     - licenseCode
-    request_object_method: true
-    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      licenseCode: licenseCode
+      licenseCode: projectGlobalLicenseCode
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
   - name: compute.licenseCodes.testIamPermissions
@@ -6434,17 +5604,15 @@ interfaces:
     required_fields:
     - resource
     - testPermissionsRequestResource
-    request_object_method: true
-    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: non_idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      resource: licenseCodesResource
+      resource: projectGlobalLicenseCodeResource
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
-  # The fully qualified name of the API interface.
+# The fully qualified name of the API interface.
 - name: google.compute.v1.Licenses
   # A list of resource collection configurations.
   # Consists of a name_pattern and an entity_name.
@@ -6457,18 +5625,18 @@ interfaces:
   # The entity_name is the name to be used as a basis for generated methods and
   # classes.
   collections:
-  - name_pattern: projects/{project}
+  - name_pattern: '{project}'
     entity_name: project
-  - name_pattern: projects/{project}/licenses/{license}
-    entity_name: license
-  - name_pattern: projects/{project}/licenses/{resource}
-    entity_name: licensesResource
+  - name_pattern: '{project}/global/licenses/{license}'
+    entity_name: projectGlobalLicense
+  - name_pattern: '{project}/global/licenses/{resource}'
+    entity_name: projectGlobalLicenseResource
   # Definition for retryable codes.
   retry_codes_def:
   - name: idempotent
     retry_codes:
-    - SC_SERVICE_UNAVAILABLE
-    - SC_GATEWAY_TIMEOUT
+    - UNAVAILABLE
+    - DEADLINE_EXCEEDED
   - name: non_idempotent
     retry_codes: []
   # Definition for retry/backoff parameters.
@@ -6494,17 +5662,6 @@ interfaces:
   #       message.
   #   required_fields - Fields that are always required for a request to be
   #       valid.
-  #   request_object_method - Turns on or off the generation of a method whose
-  #       sole parameter is a request object. Not all languages will generate
-  #       this method.
-  #   resource_name_treatment - An enum that specifies how to treat the
-  #       resource name formats defined in the field_name_patterns
-  #       and response_field_name_patterns fields.
-  #       UNSET: default value
-  #       NONE: the collection configs will not be used by the generated code.
-  #       VALIDATE: string fields will be validated by the client against the
-  #           specified resource name formats.
-  #       STATIC_TYPES: the client will use generated types for resource names.
   #   page_streaming - Specifies the configuration for paging.
   #       Describes information for generating a method which transforms a
   #       paging list RPC into a stream of resources.
@@ -6539,19 +5696,15 @@ interfaces:
       groups:
       - parameters:
         - license
-        - requestId
     # TODO: Configure which fields are required.
     required_fields:
     - license
-    - requestId
-    request_object_method: true
-    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      license: license
+      license: projectGlobalLicense
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
   - name: compute.licenses.get
@@ -6564,14 +5717,12 @@ interfaces:
     # TODO: Configure which fields are required.
     required_fields:
     - license
-    request_object_method: true
-    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      license: license
+      license: projectGlobalLicense
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
   - name: compute.licenses.getIamPolicy
@@ -6584,14 +5735,12 @@ interfaces:
     # TODO: Configure which fields are required.
     required_fields:
     - resource
-    request_object_method: true
-    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      resource: licensesResource
+      resource: projectGlobalLicenseResource
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
   - name: compute.licenses.insert
@@ -6600,16 +5749,12 @@ interfaces:
     flattening:
       groups:
       - parameters:
-        - requestId
         - project
         - licenseResource
     # TODO: Configure which fields are required.
     required_fields:
-    - requestId
     - project
     - licenseResource
-    request_object_method: true
-    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: non_idempotent
     # TODO: Configure the retryable params for this method.
@@ -6628,15 +5773,13 @@ interfaces:
     # TODO: Configure which fields are required.
     required_fields:
     - project
-    request_object_method: true
-    resource_name_treatment: STATIC_TYPES
     page_streaming:
       request:
         page_size_field: maxResults
         token_field: pageToken
       response:
         token_field: nextPageToken
-        resources_field: LicensesListResponse
+        resources_field: items
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: idempotent
     # TODO: Configure the retryable params for this method.
@@ -6657,14 +5800,12 @@ interfaces:
     required_fields:
     - resource
     - globalSetPolicyRequestResource
-    request_object_method: true
-    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: non_idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      resource: licensesResource
+      resource: projectGlobalLicenseResource
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
   - name: compute.licenses.testIamPermissions
@@ -6679,17 +5820,15 @@ interfaces:
     required_fields:
     - resource
     - testPermissionsRequestResource
-    request_object_method: true
-    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: non_idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      resource: licensesResource
+      resource: projectGlobalLicenseResource
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
-  # The fully qualified name of the API interface.
+# The fully qualified name of the API interface.
 - name: google.compute.v1.MachineTypes
   # A list of resource collection configurations.
   # Consists of a name_pattern and an entity_name.
@@ -6702,18 +5841,18 @@ interfaces:
   # The entity_name is the name to be used as a basis for generated methods and
   # classes.
   collections:
-  - name_pattern: projects/{project}
+  - name_pattern: '{project}'
     entity_name: project
-  - name_pattern: projects/{project}/zones/{zone}
-    entity_name: zone
-  - name_pattern: projects/{project}/zones/{zone}/machineTypes/{machineType}
-    entity_name: machineType
+  - name_pattern: '{project}/zones/{zone}'
+    entity_name: projectZone
+  - name_pattern: '{project}/zones/{zone}/machineTypes/{machineType}'
+    entity_name: projectZoneMachineType
   # Definition for retryable codes.
   retry_codes_def:
   - name: idempotent
     retry_codes:
-    - SC_SERVICE_UNAVAILABLE
-    - SC_GATEWAY_TIMEOUT
+    - UNAVAILABLE
+    - DEADLINE_EXCEEDED
   - name: non_idempotent
     retry_codes: []
   # Definition for retry/backoff parameters.
@@ -6739,17 +5878,6 @@ interfaces:
   #       message.
   #   required_fields - Fields that are always required for a request to be
   #       valid.
-  #   request_object_method - Turns on or off the generation of a method whose
-  #       sole parameter is a request object. Not all languages will generate
-  #       this method.
-  #   resource_name_treatment - An enum that specifies how to treat the
-  #       resource name formats defined in the field_name_patterns
-  #       and response_field_name_patterns fields.
-  #       UNSET: default value
-  #       NONE: the collection configs will not be used by the generated code.
-  #       VALIDATE: string fields will be validated by the client against the
-  #           specified resource name formats.
-  #       STATIC_TYPES: the client will use generated types for resource names.
   #   page_streaming - Specifies the configuration for paging.
   #       Describes information for generating a method which transforms a
   #       paging list RPC into a stream of resources.
@@ -6787,15 +5915,13 @@ interfaces:
     # TODO: Configure which fields are required.
     required_fields:
     - project
-    request_object_method: true
-    resource_name_treatment: STATIC_TYPES
     page_streaming:
       request:
         page_size_field: maxResults
         token_field: pageToken
       response:
         token_field: nextPageToken
-        resources_field: MachineTypeAggregatedList
+        resources_field: items
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: idempotent
     # TODO: Configure the retryable params for this method.
@@ -6814,14 +5940,12 @@ interfaces:
     # TODO: Configure which fields are required.
     required_fields:
     - machineType
-    request_object_method: true
-    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      machineType: machineType
+      machineType: projectZoneMachineType
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
   - name: compute.machineTypes.list
@@ -6834,24 +5958,22 @@ interfaces:
     # TODO: Configure which fields are required.
     required_fields:
     - zone
-    request_object_method: true
-    resource_name_treatment: STATIC_TYPES
     page_streaming:
       request:
         page_size_field: maxResults
         token_field: pageToken
       response:
         token_field: nextPageToken
-        resources_field: MachineTypeList
+        resources_field: items
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      zone: zone
+      zone: projectZone
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
-  # The fully qualified name of the API interface.
+# The fully qualified name of the API interface.
 - name: google.compute.v1.NetworkEndpointGroups
   # A list of resource collection configurations.
   # Consists of a name_pattern and an entity_name.
@@ -6864,20 +5986,20 @@ interfaces:
   # The entity_name is the name to be used as a basis for generated methods and
   # classes.
   collections:
-  - name_pattern: projects/{project}
+  - name_pattern: '{project}'
     entity_name: project
-  - name_pattern: projects/{project}/zones/{zone}
-    entity_name: zone
-  - name_pattern: projects/{project}/zones/{zone}/networkEndpointGroups/{networkEndpointGroup}
-    entity_name: networkEndpointGroup
-  - name_pattern: projects/{project}/zones/{zone}/networkEndpointGroups/{resource}
-    entity_name: networkEndpointGroupsResource
+  - name_pattern: '{project}/zones/{zone}'
+    entity_name: projectZone
+  - name_pattern: '{project}/zones/{zone}/networkEndpointGroups/{networkEndpointGroup}'
+    entity_name: projectZoneNetworkEndpointGroup
+  - name_pattern: '{project}/zones/{zone}/networkEndpointGroups/{resource}'
+    entity_name: projectZoneNetworkEndpointGroupResource
   # Definition for retryable codes.
   retry_codes_def:
   - name: idempotent
     retry_codes:
-    - SC_SERVICE_UNAVAILABLE
-    - SC_GATEWAY_TIMEOUT
+    - UNAVAILABLE
+    - DEADLINE_EXCEEDED
   - name: non_idempotent
     retry_codes: []
   # Definition for retry/backoff parameters.
@@ -6903,17 +6025,6 @@ interfaces:
   #       message.
   #   required_fields - Fields that are always required for a request to be
   #       valid.
-  #   request_object_method - Turns on or off the generation of a method whose
-  #       sole parameter is a request object. Not all languages will generate
-  #       this method.
-  #   resource_name_treatment - An enum that specifies how to treat the
-  #       resource name formats defined in the field_name_patterns
-  #       and response_field_name_patterns fields.
-  #       UNSET: default value
-  #       NONE: the collection configs will not be used by the generated code.
-  #       VALIDATE: string fields will be validated by the client against the
-  #           specified resource name formats.
-  #       STATIC_TYPES: the client will use generated types for resource names.
   #   page_streaming - Specifies the configuration for paging.
   #       Describes information for generating a method which transforms a
   #       paging list RPC into a stream of resources.
@@ -6951,15 +6062,13 @@ interfaces:
     # TODO: Configure which fields are required.
     required_fields:
     - project
-    request_object_method: true
-    resource_name_treatment: STATIC_TYPES
     page_streaming:
       request:
         page_size_field: maxResults
         token_field: pageToken
       response:
         token_field: nextPageToken
-        resources_field: NetworkEndpointGroupAggregatedList
+        resources_field: items
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: idempotent
     # TODO: Configure the retryable params for this method.
@@ -6975,21 +6084,17 @@ interfaces:
       groups:
       - parameters:
         - networkEndpointGroup
-        - requestId
         - networkEndpointGroupsAttachEndpointsRequestResource
     # TODO: Configure which fields are required.
     required_fields:
     - networkEndpointGroup
-    - requestId
     - networkEndpointGroupsAttachEndpointsRequestResource
-    request_object_method: true
-    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: non_idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      networkEndpointGroup: networkEndpointGroup
+      networkEndpointGroup: projectZoneNetworkEndpointGroup
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
   - name: compute.networkEndpointGroups.delete
@@ -6999,19 +6104,15 @@ interfaces:
       groups:
       - parameters:
         - networkEndpointGroup
-        - requestId
     # TODO: Configure which fields are required.
     required_fields:
     - networkEndpointGroup
-    - requestId
-    request_object_method: true
-    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      networkEndpointGroup: networkEndpointGroup
+      networkEndpointGroup: projectZoneNetworkEndpointGroup
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
   - name: compute.networkEndpointGroups.detachNetworkEndpoints
@@ -7021,21 +6122,17 @@ interfaces:
       groups:
       - parameters:
         - networkEndpointGroup
-        - requestId
         - networkEndpointGroupsDetachEndpointsRequestResource
     # TODO: Configure which fields are required.
     required_fields:
     - networkEndpointGroup
-    - requestId
     - networkEndpointGroupsDetachEndpointsRequestResource
-    request_object_method: true
-    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: non_idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      networkEndpointGroup: networkEndpointGroup
+      networkEndpointGroup: projectZoneNetworkEndpointGroup
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
   - name: compute.networkEndpointGroups.get
@@ -7048,14 +6145,12 @@ interfaces:
     # TODO: Configure which fields are required.
     required_fields:
     - networkEndpointGroup
-    request_object_method: true
-    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      networkEndpointGroup: networkEndpointGroup
+      networkEndpointGroup: projectZoneNetworkEndpointGroup
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
   - name: compute.networkEndpointGroups.insert
@@ -7065,21 +6160,17 @@ interfaces:
       groups:
       - parameters:
         - zone
-        - requestId
         - networkEndpointGroupResource
     # TODO: Configure which fields are required.
     required_fields:
     - zone
-    - requestId
     - networkEndpointGroupResource
-    request_object_method: true
-    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: non_idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      zone: zone
+      zone: projectZone
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
   - name: compute.networkEndpointGroups.list
@@ -7092,21 +6183,19 @@ interfaces:
     # TODO: Configure which fields are required.
     required_fields:
     - zone
-    request_object_method: true
-    resource_name_treatment: STATIC_TYPES
     page_streaming:
       request:
         page_size_field: maxResults
         token_field: pageToken
       response:
         token_field: nextPageToken
-        resources_field: NetworkEndpointGroupList
+        resources_field: items
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      zone: zone
+      zone: projectZone
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
   - name: compute.networkEndpointGroups.listNetworkEndpoints
@@ -7121,21 +6210,19 @@ interfaces:
     required_fields:
     - networkEndpointGroup
     - networkEndpointGroupsListEndpointsRequestResource
-    request_object_method: true
-    resource_name_treatment: STATIC_TYPES
     page_streaming:
       request:
         page_size_field: maxResults
         token_field: pageToken
       response:
         token_field: nextPageToken
-        resources_field: NetworkEndpointGroupsListNetworkEndpoints
+        resources_field: items
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: non_idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      networkEndpointGroup: networkEndpointGroup
+      networkEndpointGroup: projectZoneNetworkEndpointGroup
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
   - name: compute.networkEndpointGroups.testIamPermissions
@@ -7150,17 +6237,15 @@ interfaces:
     required_fields:
     - resource
     - testPermissionsRequestResource
-    request_object_method: true
-    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: non_idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      resource: networkEndpointGroupsResource
+      resource: projectZoneNetworkEndpointGroupResource
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
-  # The fully qualified name of the API interface.
+# The fully qualified name of the API interface.
 - name: google.compute.v1.Networks
   # A list of resource collection configurations.
   # Consists of a name_pattern and an entity_name.
@@ -7173,16 +6258,16 @@ interfaces:
   # The entity_name is the name to be used as a basis for generated methods and
   # classes.
   collections:
-  - name_pattern: projects/{project}
+  - name_pattern: '{project}'
     entity_name: project
-  - name_pattern: projects/{project}/networks/{network}
-    entity_name: network
+  - name_pattern: '{project}/global/networks/{network}'
+    entity_name: projectGlobalNetwork
   # Definition for retryable codes.
   retry_codes_def:
   - name: idempotent
     retry_codes:
-    - SC_SERVICE_UNAVAILABLE
-    - SC_GATEWAY_TIMEOUT
+    - UNAVAILABLE
+    - DEADLINE_EXCEEDED
   - name: non_idempotent
     retry_codes: []
   # Definition for retry/backoff parameters.
@@ -7208,17 +6293,6 @@ interfaces:
   #       message.
   #   required_fields - Fields that are always required for a request to be
   #       valid.
-  #   request_object_method - Turns on or off the generation of a method whose
-  #       sole parameter is a request object. Not all languages will generate
-  #       this method.
-  #   resource_name_treatment - An enum that specifies how to treat the
-  #       resource name formats defined in the field_name_patterns
-  #       and response_field_name_patterns fields.
-  #       UNSET: default value
-  #       NONE: the collection configs will not be used by the generated code.
-  #       VALIDATE: string fields will be validated by the client against the
-  #           specified resource name formats.
-  #       STATIC_TYPES: the client will use generated types for resource names.
   #   page_streaming - Specifies the configuration for paging.
   #       Describes information for generating a method which transforms a
   #       paging list RPC into a stream of resources.
@@ -7252,22 +6326,18 @@ interfaces:
     flattening:
       groups:
       - parameters:
-        - requestId
         - network
         - networksAddPeeringRequestResource
     # TODO: Configure which fields are required.
     required_fields:
-    - requestId
     - network
     - networksAddPeeringRequestResource
-    request_object_method: true
-    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: non_idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      network: network
+      network: projectGlobalNetwork
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
   - name: compute.networks.delete
@@ -7276,20 +6346,16 @@ interfaces:
     flattening:
       groups:
       - parameters:
-        - requestId
         - network
     # TODO: Configure which fields are required.
     required_fields:
-    - requestId
     - network
-    request_object_method: true
-    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      network: network
+      network: projectGlobalNetwork
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
   - name: compute.networks.get
@@ -7302,14 +6368,12 @@ interfaces:
     # TODO: Configure which fields are required.
     required_fields:
     - network
-    request_object_method: true
-    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      network: network
+      network: projectGlobalNetwork
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
   - name: compute.networks.insert
@@ -7318,16 +6382,12 @@ interfaces:
     flattening:
       groups:
       - parameters:
-        - requestId
         - project
         - networkResource
     # TODO: Configure which fields are required.
     required_fields:
-    - requestId
     - project
     - networkResource
-    request_object_method: true
-    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: non_idempotent
     # TODO: Configure the retryable params for this method.
@@ -7346,15 +6406,13 @@ interfaces:
     # TODO: Configure which fields are required.
     required_fields:
     - project
-    request_object_method: true
-    resource_name_treatment: STATIC_TYPES
     page_streaming:
       request:
         page_size_field: maxResults
         token_field: pageToken
       response:
         token_field: nextPageToken
-        resources_field: NetworkList
+        resources_field: items
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: idempotent
     # TODO: Configure the retryable params for this method.
@@ -7369,22 +6427,18 @@ interfaces:
     flattening:
       groups:
       - parameters:
-        - requestId
         - network
         - networkResource
     # TODO: Configure which fields are required.
     required_fields:
-    - requestId
     - network
     - networkResource
-    request_object_method: true
-    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: non_idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      network: network
+      network: projectGlobalNetwork
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
   - name: compute.networks.removePeering
@@ -7393,22 +6447,18 @@ interfaces:
     flattening:
       groups:
       - parameters:
-        - requestId
         - network
         - networksRemovePeeringRequestResource
     # TODO: Configure which fields are required.
     required_fields:
-    - requestId
     - network
     - networksRemovePeeringRequestResource
-    request_object_method: true
-    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: non_idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      network: network
+      network: projectGlobalNetwork
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
   - name: compute.networks.switchToCustomMode
@@ -7417,23 +6467,19 @@ interfaces:
     flattening:
       groups:
       - parameters:
-        - requestId
         - network
     # TODO: Configure which fields are required.
     required_fields:
-    - requestId
     - network
-    request_object_method: true
-    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: non_idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      network: network
+      network: projectGlobalNetwork
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
-  # The fully qualified name of the API interface.
+# The fully qualified name of the API interface.
 - name: google.compute.v1.NodeGroups
   # A list of resource collection configurations.
   # Consists of a name_pattern and an entity_name.
@@ -7446,20 +6492,20 @@ interfaces:
   # The entity_name is the name to be used as a basis for generated methods and
   # classes.
   collections:
-  - name_pattern: projects/{project}
+  - name_pattern: '{project}'
     entity_name: project
-  - name_pattern: projects/{project}/zones/{zone}
-    entity_name: zone
-  - name_pattern: projects/{project}/zones/{zone}/nodeGroups/{nodeGroup}
-    entity_name: nodeGroup
-  - name_pattern: projects/{project}/zones/{zone}/nodeGroups/{resource}
-    entity_name: nodeGroupsResource
+  - name_pattern: '{project}/zones/{zone}'
+    entity_name: projectZone
+  - name_pattern: '{project}/zones/{zone}/nodeGroups/{nodeGroup}'
+    entity_name: projectZoneNodeGroup
+  - name_pattern: '{project}/zones/{zone}/nodeGroups/{resource}'
+    entity_name: projectZoneNodeGroupResource
   # Definition for retryable codes.
   retry_codes_def:
   - name: idempotent
     retry_codes:
-    - SC_SERVICE_UNAVAILABLE
-    - SC_GATEWAY_TIMEOUT
+    - UNAVAILABLE
+    - DEADLINE_EXCEEDED
   - name: non_idempotent
     retry_codes: []
   # Definition for retry/backoff parameters.
@@ -7485,17 +6531,6 @@ interfaces:
   #       message.
   #   required_fields - Fields that are always required for a request to be
   #       valid.
-  #   request_object_method - Turns on or off the generation of a method whose
-  #       sole parameter is a request object. Not all languages will generate
-  #       this method.
-  #   resource_name_treatment - An enum that specifies how to treat the
-  #       resource name formats defined in the field_name_patterns
-  #       and response_field_name_patterns fields.
-  #       UNSET: default value
-  #       NONE: the collection configs will not be used by the generated code.
-  #       VALIDATE: string fields will be validated by the client against the
-  #           specified resource name formats.
-  #       STATIC_TYPES: the client will use generated types for resource names.
   #   page_streaming - Specifies the configuration for paging.
   #       Describes information for generating a method which transforms a
   #       paging list RPC into a stream of resources.
@@ -7529,22 +6564,18 @@ interfaces:
     flattening:
       groups:
       - parameters:
-        - requestId
         - nodeGroup
         - nodeGroupsAddNodesRequestResource
     # TODO: Configure which fields are required.
     required_fields:
-    - requestId
     - nodeGroup
     - nodeGroupsAddNodesRequestResource
-    request_object_method: true
-    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: non_idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      nodeGroup: nodeGroup
+      nodeGroup: projectZoneNodeGroup
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
   - name: compute.nodeGroups.aggregatedList
@@ -7557,15 +6588,13 @@ interfaces:
     # TODO: Configure which fields are required.
     required_fields:
     - project
-    request_object_method: true
-    resource_name_treatment: STATIC_TYPES
     page_streaming:
       request:
         page_size_field: maxResults
         token_field: pageToken
       response:
         token_field: nextPageToken
-        resources_field: NodeGroupAggregatedList
+        resources_field: items
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: idempotent
     # TODO: Configure the retryable params for this method.
@@ -7580,20 +6609,16 @@ interfaces:
     flattening:
       groups:
       - parameters:
-        - requestId
         - nodeGroup
     # TODO: Configure which fields are required.
     required_fields:
-    - requestId
     - nodeGroup
-    request_object_method: true
-    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      nodeGroup: nodeGroup
+      nodeGroup: projectZoneNodeGroup
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
   - name: compute.nodeGroups.deleteNodes
@@ -7602,22 +6627,18 @@ interfaces:
     flattening:
       groups:
       - parameters:
-        - requestId
         - nodeGroup
         - nodeGroupsDeleteNodesRequestResource
     # TODO: Configure which fields are required.
     required_fields:
-    - requestId
     - nodeGroup
     - nodeGroupsDeleteNodesRequestResource
-    request_object_method: true
-    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: non_idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      nodeGroup: nodeGroup
+      nodeGroup: projectZoneNodeGroup
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
   - name: compute.nodeGroups.get
@@ -7630,14 +6651,12 @@ interfaces:
     # TODO: Configure which fields are required.
     required_fields:
     - nodeGroup
-    request_object_method: true
-    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      nodeGroup: nodeGroup
+      nodeGroup: projectZoneNodeGroup
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
   - name: compute.nodeGroups.getIamPolicy
@@ -7650,14 +6669,12 @@ interfaces:
     # TODO: Configure which fields are required.
     required_fields:
     - resource
-    request_object_method: true
-    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      resource: nodeGroupsResource
+      resource: projectZoneNodeGroupResource
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
   - name: compute.nodeGroups.insert
@@ -7668,22 +6685,18 @@ interfaces:
       - parameters:
         - initialNodeCount
         - zone
-        - requestId
         - nodeGroupResource
     # TODO: Configure which fields are required.
     required_fields:
     - initialNodeCount
     - zone
-    - requestId
     - nodeGroupResource
-    request_object_method: true
-    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: non_idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      zone: zone
+      zone: projectZone
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
   - name: compute.nodeGroups.list
@@ -7696,21 +6709,19 @@ interfaces:
     # TODO: Configure which fields are required.
     required_fields:
     - zone
-    request_object_method: true
-    resource_name_treatment: STATIC_TYPES
     page_streaming:
       request:
         page_size_field: maxResults
         token_field: pageToken
       response:
         token_field: nextPageToken
-        resources_field: NodeGroupList
+        resources_field: items
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      zone: zone
+      zone: projectZone
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
   - name: compute.nodeGroups.listNodes
@@ -7723,21 +6734,19 @@ interfaces:
     # TODO: Configure which fields are required.
     required_fields:
     - nodeGroup
-    request_object_method: true
-    resource_name_treatment: STATIC_TYPES
     page_streaming:
       request:
         page_size_field: maxResults
         token_field: pageToken
       response:
         token_field: nextPageToken
-        resources_field: NodeGroupsListNodes
+        resources_field: items
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: non_idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      nodeGroup: nodeGroup
+      nodeGroup: projectZoneNodeGroup
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
   - name: compute.nodeGroups.setIamPolicy
@@ -7752,14 +6761,12 @@ interfaces:
     required_fields:
     - resource
     - zoneSetPolicyRequestResource
-    request_object_method: true
-    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: non_idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      resource: nodeGroupsResource
+      resource: projectZoneNodeGroupResource
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
   - name: compute.nodeGroups.setNodeTemplate
@@ -7768,22 +6775,18 @@ interfaces:
     flattening:
       groups:
       - parameters:
-        - requestId
         - nodeGroup
         - nodeGroupsSetNodeTemplateRequestResource
     # TODO: Configure which fields are required.
     required_fields:
-    - requestId
     - nodeGroup
     - nodeGroupsSetNodeTemplateRequestResource
-    request_object_method: true
-    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: non_idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      nodeGroup: nodeGroup
+      nodeGroup: projectZoneNodeGroup
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
   - name: compute.nodeGroups.testIamPermissions
@@ -7798,17 +6801,15 @@ interfaces:
     required_fields:
     - resource
     - testPermissionsRequestResource
-    request_object_method: true
-    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: non_idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      resource: nodeGroupsResource
+      resource: projectZoneNodeGroupResource
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
-  # The fully qualified name of the API interface.
+# The fully qualified name of the API interface.
 - name: google.compute.v1.NodeTemplates
   # A list of resource collection configurations.
   # Consists of a name_pattern and an entity_name.
@@ -7821,20 +6822,20 @@ interfaces:
   # The entity_name is the name to be used as a basis for generated methods and
   # classes.
   collections:
-  - name_pattern: projects/{project}
+  - name_pattern: '{project}'
     entity_name: project
-  - name_pattern: projects/{project}/regions/{region}
-    entity_name: region
-  - name_pattern: projects/{project}/regions/{region}/nodeTemplates/{nodeTemplate}
-    entity_name: nodeTemplate
-  - name_pattern: projects/{project}/regions/{region}/nodeTemplates/{resource}
-    entity_name: nodeTemplatesResource
+  - name_pattern: '{project}/regions/{region}'
+    entity_name: projectRegion
+  - name_pattern: '{project}/regions/{region}/nodeTemplates/{nodeTemplate}'
+    entity_name: projectRegionNodeTemplate
+  - name_pattern: '{project}/regions/{region}/nodeTemplates/{resource}'
+    entity_name: projectRegionNodeTemplateResource
   # Definition for retryable codes.
   retry_codes_def:
   - name: idempotent
     retry_codes:
-    - SC_SERVICE_UNAVAILABLE
-    - SC_GATEWAY_TIMEOUT
+    - UNAVAILABLE
+    - DEADLINE_EXCEEDED
   - name: non_idempotent
     retry_codes: []
   # Definition for retry/backoff parameters.
@@ -7860,17 +6861,6 @@ interfaces:
   #       message.
   #   required_fields - Fields that are always required for a request to be
   #       valid.
-  #   request_object_method - Turns on or off the generation of a method whose
-  #       sole parameter is a request object. Not all languages will generate
-  #       this method.
-  #   resource_name_treatment - An enum that specifies how to treat the
-  #       resource name formats defined in the field_name_patterns
-  #       and response_field_name_patterns fields.
-  #       UNSET: default value
-  #       NONE: the collection configs will not be used by the generated code.
-  #       VALIDATE: string fields will be validated by the client against the
-  #           specified resource name formats.
-  #       STATIC_TYPES: the client will use generated types for resource names.
   #   page_streaming - Specifies the configuration for paging.
   #       Describes information for generating a method which transforms a
   #       paging list RPC into a stream of resources.
@@ -7908,15 +6898,13 @@ interfaces:
     # TODO: Configure which fields are required.
     required_fields:
     - project
-    request_object_method: true
-    resource_name_treatment: STATIC_TYPES
     page_streaming:
       request:
         page_size_field: maxResults
         token_field: pageToken
       response:
         token_field: nextPageToken
-        resources_field: NodeTemplateAggregatedList
+        resources_field: items
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: idempotent
     # TODO: Configure the retryable params for this method.
@@ -7931,20 +6919,16 @@ interfaces:
     flattening:
       groups:
       - parameters:
-        - requestId
         - nodeTemplate
     # TODO: Configure which fields are required.
     required_fields:
-    - requestId
     - nodeTemplate
-    request_object_method: true
-    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      nodeTemplate: nodeTemplate
+      nodeTemplate: projectRegionNodeTemplate
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
   - name: compute.nodeTemplates.get
@@ -7957,14 +6941,12 @@ interfaces:
     # TODO: Configure which fields are required.
     required_fields:
     - nodeTemplate
-    request_object_method: true
-    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      nodeTemplate: nodeTemplate
+      nodeTemplate: projectRegionNodeTemplate
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
   - name: compute.nodeTemplates.getIamPolicy
@@ -7977,14 +6959,12 @@ interfaces:
     # TODO: Configure which fields are required.
     required_fields:
     - resource
-    request_object_method: true
-    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      resource: nodeTemplatesResource
+      resource: projectRegionNodeTemplateResource
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
   - name: compute.nodeTemplates.insert
@@ -7993,22 +6973,18 @@ interfaces:
     flattening:
       groups:
       - parameters:
-        - requestId
         - region
         - nodeTemplateResource
     # TODO: Configure which fields are required.
     required_fields:
-    - requestId
     - region
     - nodeTemplateResource
-    request_object_method: true
-    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: non_idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      region: region
+      region: projectRegion
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
   - name: compute.nodeTemplates.list
@@ -8021,21 +6997,19 @@ interfaces:
     # TODO: Configure which fields are required.
     required_fields:
     - region
-    request_object_method: true
-    resource_name_treatment: STATIC_TYPES
     page_streaming:
       request:
         page_size_field: maxResults
         token_field: pageToken
       response:
         token_field: nextPageToken
-        resources_field: NodeTemplateList
+        resources_field: items
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      region: region
+      region: projectRegion
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
   - name: compute.nodeTemplates.setIamPolicy
@@ -8050,14 +7024,12 @@ interfaces:
     required_fields:
     - resource
     - regionSetPolicyRequestResource
-    request_object_method: true
-    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: non_idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      resource: nodeTemplatesResource
+      resource: projectRegionNodeTemplateResource
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
   - name: compute.nodeTemplates.testIamPermissions
@@ -8072,17 +7044,15 @@ interfaces:
     required_fields:
     - resource
     - testPermissionsRequestResource
-    request_object_method: true
-    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: non_idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      resource: nodeTemplatesResource
+      resource: projectRegionNodeTemplateResource
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
-  # The fully qualified name of the API interface.
+# The fully qualified name of the API interface.
 - name: google.compute.v1.NodeTypes
   # A list of resource collection configurations.
   # Consists of a name_pattern and an entity_name.
@@ -8095,18 +7065,18 @@ interfaces:
   # The entity_name is the name to be used as a basis for generated methods and
   # classes.
   collections:
-  - name_pattern: projects/{project}
+  - name_pattern: '{project}'
     entity_name: project
-  - name_pattern: projects/{project}/zones/{zone}
-    entity_name: zone
-  - name_pattern: projects/{project}/zones/{zone}/nodeTypes/{nodeType}
-    entity_name: nodeType
+  - name_pattern: '{project}/zones/{zone}'
+    entity_name: projectZone
+  - name_pattern: '{project}/zones/{zone}/nodeTypes/{nodeType}'
+    entity_name: projectZoneNodeType
   # Definition for retryable codes.
   retry_codes_def:
   - name: idempotent
     retry_codes:
-    - SC_SERVICE_UNAVAILABLE
-    - SC_GATEWAY_TIMEOUT
+    - UNAVAILABLE
+    - DEADLINE_EXCEEDED
   - name: non_idempotent
     retry_codes: []
   # Definition for retry/backoff parameters.
@@ -8132,17 +7102,6 @@ interfaces:
   #       message.
   #   required_fields - Fields that are always required for a request to be
   #       valid.
-  #   request_object_method - Turns on or off the generation of a method whose
-  #       sole parameter is a request object. Not all languages will generate
-  #       this method.
-  #   resource_name_treatment - An enum that specifies how to treat the
-  #       resource name formats defined in the field_name_patterns
-  #       and response_field_name_patterns fields.
-  #       UNSET: default value
-  #       NONE: the collection configs will not be used by the generated code.
-  #       VALIDATE: string fields will be validated by the client against the
-  #           specified resource name formats.
-  #       STATIC_TYPES: the client will use generated types for resource names.
   #   page_streaming - Specifies the configuration for paging.
   #       Describes information for generating a method which transforms a
   #       paging list RPC into a stream of resources.
@@ -8180,15 +7139,13 @@ interfaces:
     # TODO: Configure which fields are required.
     required_fields:
     - project
-    request_object_method: true
-    resource_name_treatment: STATIC_TYPES
     page_streaming:
       request:
         page_size_field: maxResults
         token_field: pageToken
       response:
         token_field: nextPageToken
-        resources_field: NodeTypeAggregatedList
+        resources_field: items
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: idempotent
     # TODO: Configure the retryable params for this method.
@@ -8207,14 +7164,12 @@ interfaces:
     # TODO: Configure which fields are required.
     required_fields:
     - nodeType
-    request_object_method: true
-    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      nodeType: nodeType
+      nodeType: projectZoneNodeType
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
   - name: compute.nodeTypes.list
@@ -8227,24 +7182,22 @@ interfaces:
     # TODO: Configure which fields are required.
     required_fields:
     - zone
-    request_object_method: true
-    resource_name_treatment: STATIC_TYPES
     page_streaming:
       request:
         page_size_field: maxResults
         token_field: pageToken
       response:
         token_field: nextPageToken
-        resources_field: NodeTypeList
+        resources_field: items
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      zone: zone
+      zone: projectZone
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
-  # The fully qualified name of the API interface.
+# The fully qualified name of the API interface.
 - name: google.compute.v1.Projects
   # A list of resource collection configurations.
   # Consists of a name_pattern and an entity_name.
@@ -8257,14 +7210,14 @@ interfaces:
   # The entity_name is the name to be used as a basis for generated methods and
   # classes.
   collections:
-  - name_pattern: projects/{project}
+  - name_pattern: '{project}'
     entity_name: project
   # Definition for retryable codes.
   retry_codes_def:
   - name: idempotent
     retry_codes:
-    - SC_SERVICE_UNAVAILABLE
-    - SC_GATEWAY_TIMEOUT
+    - UNAVAILABLE
+    - DEADLINE_EXCEEDED
   - name: non_idempotent
     retry_codes: []
   # Definition for retry/backoff parameters.
@@ -8290,17 +7243,6 @@ interfaces:
   #       message.
   #   required_fields - Fields that are always required for a request to be
   #       valid.
-  #   request_object_method - Turns on or off the generation of a method whose
-  #       sole parameter is a request object. Not all languages will generate
-  #       this method.
-  #   resource_name_treatment - An enum that specifies how to treat the
-  #       resource name formats defined in the field_name_patterns
-  #       and response_field_name_patterns fields.
-  #       UNSET: default value
-  #       NONE: the collection configs will not be used by the generated code.
-  #       VALIDATE: string fields will be validated by the client against the
-  #           specified resource name formats.
-  #       STATIC_TYPES: the client will use generated types for resource names.
   #   page_streaming - Specifies the configuration for paging.
   #       Describes information for generating a method which transforms a
   #       paging list RPC into a stream of resources.
@@ -8334,14 +7276,10 @@ interfaces:
     flattening:
       groups:
       - parameters:
-        - requestId
         - project
     # TODO: Configure which fields are required.
     required_fields:
-    - requestId
     - project
-    request_object_method: true
-    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: non_idempotent
     # TODO: Configure the retryable params for this method.
@@ -8356,16 +7294,12 @@ interfaces:
     flattening:
       groups:
       - parameters:
-        - requestId
         - project
         - projectsDisableXpnResourceRequestResource
     # TODO: Configure which fields are required.
     required_fields:
-    - requestId
     - project
     - projectsDisableXpnResourceRequestResource
-    request_object_method: true
-    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: non_idempotent
     # TODO: Configure the retryable params for this method.
@@ -8380,14 +7314,10 @@ interfaces:
     flattening:
       groups:
       - parameters:
-        - requestId
         - project
     # TODO: Configure which fields are required.
     required_fields:
-    - requestId
     - project
-    request_object_method: true
-    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: non_idempotent
     # TODO: Configure the retryable params for this method.
@@ -8402,16 +7332,12 @@ interfaces:
     flattening:
       groups:
       - parameters:
-        - requestId
         - project
         - projectsEnableXpnResourceRequestResource
     # TODO: Configure which fields are required.
     required_fields:
-    - requestId
     - project
     - projectsEnableXpnResourceRequestResource
-    request_object_method: true
-    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: non_idempotent
     # TODO: Configure the retryable params for this method.
@@ -8430,8 +7356,6 @@ interfaces:
     # TODO: Configure which fields are required.
     required_fields:
     - project
-    request_object_method: false
-    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: idempotent
     # TODO: Configure the retryable params for this method.
@@ -8450,8 +7374,6 @@ interfaces:
     # TODO: Configure which fields are required.
     required_fields:
     - project
-    request_object_method: false
-    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: idempotent
     # TODO: Configure the retryable params for this method.
@@ -8470,15 +7392,13 @@ interfaces:
     # TODO: Configure which fields are required.
     required_fields:
     - project
-    request_object_method: true
-    resource_name_treatment: STATIC_TYPES
     page_streaming:
       request:
         page_size_field: maxResults
         token_field: pageToken
       response:
         token_field: nextPageToken
-        resources_field: ProjectsGetXpnResources
+        resources_field: resources
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: idempotent
     # TODO: Configure the retryable params for this method.
@@ -8499,15 +7419,13 @@ interfaces:
     required_fields:
     - project
     - projectsListXpnHostsRequestResource
-    request_object_method: true
-    resource_name_treatment: STATIC_TYPES
     page_streaming:
       request:
         page_size_field: maxResults
         token_field: pageToken
       response:
         token_field: nextPageToken
-        resources_field: XpnHostList
+        resources_field: items
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: non_idempotent
     # TODO: Configure the retryable params for this method.
@@ -8522,16 +7440,12 @@ interfaces:
     flattening:
       groups:
       - parameters:
-        - requestId
         - project
         - diskMoveRequestResource
     # TODO: Configure which fields are required.
     required_fields:
-    - requestId
     - project
     - diskMoveRequestResource
-    request_object_method: true
-    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: non_idempotent
     # TODO: Configure the retryable params for this method.
@@ -8546,16 +7460,12 @@ interfaces:
     flattening:
       groups:
       - parameters:
-        - requestId
         - project
         - instanceMoveRequestResource
     # TODO: Configure which fields are required.
     required_fields:
-    - requestId
     - project
     - instanceMoveRequestResource
-    request_object_method: true
-    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: non_idempotent
     # TODO: Configure the retryable params for this method.
@@ -8570,16 +7480,12 @@ interfaces:
     flattening:
       groups:
       - parameters:
-        - requestId
         - project
         - metadataResource
     # TODO: Configure which fields are required.
     required_fields:
-    - requestId
     - project
     - metadataResource
-    request_object_method: true
-    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: non_idempotent
     # TODO: Configure the retryable params for this method.
@@ -8594,16 +7500,12 @@ interfaces:
     flattening:
       groups:
       - parameters:
-        - requestId
         - project
         - projectsSetDefaultNetworkTierRequestResource
     # TODO: Configure which fields are required.
     required_fields:
-    - requestId
     - project
     - projectsSetDefaultNetworkTierRequestResource
-    request_object_method: true
-    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: non_idempotent
     # TODO: Configure the retryable params for this method.
@@ -8618,16 +7520,12 @@ interfaces:
     flattening:
       groups:
       - parameters:
-        - requestId
         - project
         - usageExportLocationResource
     # TODO: Configure which fields are required.
     required_fields:
-    - requestId
     - project
     - usageExportLocationResource
-    request_object_method: true
-    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: non_idempotent
     # TODO: Configure the retryable params for this method.
@@ -8636,7 +7534,7 @@ interfaces:
       project: project
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
-  # The fully qualified name of the API interface.
+# The fully qualified name of the API interface.
 - name: google.compute.v1.RegionAutoscalers
   # A list of resource collection configurations.
   # Consists of a name_pattern and an entity_name.
@@ -8649,16 +7547,16 @@ interfaces:
   # The entity_name is the name to be used as a basis for generated methods and
   # classes.
   collections:
-  - name_pattern: projects/{project}/regions/{region}
-    entity_name: region
-  - name_pattern: projects/{project}/regions/{region}/autoscalers/{autoscaler}
-    entity_name: regionAutoscalersAutoscaler
+  - name_pattern: '{project}/regions/{region}'
+    entity_name: projectRegion
+  - name_pattern: '{project}/regions/{region}/autoscalers/{autoscaler}'
+    entity_name: projectRegionAutoscaler
   # Definition for retryable codes.
   retry_codes_def:
   - name: idempotent
     retry_codes:
-    - SC_SERVICE_UNAVAILABLE
-    - SC_GATEWAY_TIMEOUT
+    - UNAVAILABLE
+    - DEADLINE_EXCEEDED
   - name: non_idempotent
     retry_codes: []
   # Definition for retry/backoff parameters.
@@ -8684,17 +7582,6 @@ interfaces:
   #       message.
   #   required_fields - Fields that are always required for a request to be
   #       valid.
-  #   request_object_method - Turns on or off the generation of a method whose
-  #       sole parameter is a request object. Not all languages will generate
-  #       this method.
-  #   resource_name_treatment - An enum that specifies how to treat the
-  #       resource name formats defined in the field_name_patterns
-  #       and response_field_name_patterns fields.
-  #       UNSET: default value
-  #       NONE: the collection configs will not be used by the generated code.
-  #       VALIDATE: string fields will be validated by the client against the
-  #           specified resource name formats.
-  #       STATIC_TYPES: the client will use generated types for resource names.
   #   page_streaming - Specifies the configuration for paging.
   #       Describes information for generating a method which transforms a
   #       paging list RPC into a stream of resources.
@@ -8729,19 +7616,15 @@ interfaces:
       groups:
       - parameters:
         - autoscaler
-        - requestId
     # TODO: Configure which fields are required.
     required_fields:
     - autoscaler
-    - requestId
-    request_object_method: true
-    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      autoscaler: regionAutoscalersAutoscaler
+      autoscaler: projectRegionAutoscaler
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
   - name: compute.regionAutoscalers.get
@@ -8754,14 +7637,12 @@ interfaces:
     # TODO: Configure which fields are required.
     required_fields:
     - autoscaler
-    request_object_method: true
-    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      autoscaler: regionAutoscalersAutoscaler
+      autoscaler: projectRegionAutoscaler
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
   - name: compute.regionAutoscalers.insert
@@ -8770,22 +7651,18 @@ interfaces:
     flattening:
       groups:
       - parameters:
-        - requestId
         - region
         - autoscalerResource
     # TODO: Configure which fields are required.
     required_fields:
-    - requestId
     - region
     - autoscalerResource
-    request_object_method: true
-    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: non_idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      region: region
+      region: projectRegion
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
   - name: compute.regionAutoscalers.list
@@ -8798,21 +7675,19 @@ interfaces:
     # TODO: Configure which fields are required.
     required_fields:
     - region
-    request_object_method: true
-    resource_name_treatment: STATIC_TYPES
     page_streaming:
       request:
         page_size_field: maxResults
         token_field: pageToken
       response:
         token_field: nextPageToken
-        resources_field: RegionAutoscalerList
+        resources_field: items
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      region: region
+      region: projectRegion
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
   - name: compute.regionAutoscalers.patch
@@ -8822,23 +7697,19 @@ interfaces:
       groups:
       - parameters:
         - autoscaler
-        - requestId
         - region
         - autoscalerResource
     # TODO: Configure which fields are required.
     required_fields:
     - autoscaler
-    - requestId
     - region
     - autoscalerResource
-    request_object_method: true
-    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: non_idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      region: region
+      region: projectRegion
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
   - name: compute.regionAutoscalers.update
@@ -8848,26 +7719,22 @@ interfaces:
       groups:
       - parameters:
         - autoscaler
-        - requestId
         - region
         - autoscalerResource
     # TODO: Configure which fields are required.
     required_fields:
     - autoscaler
-    - requestId
     - region
     - autoscalerResource
-    request_object_method: true
-    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      region: region
+      region: projectRegion
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
-  # The fully qualified name of the API interface.
+# The fully qualified name of the API interface.
 - name: google.compute.v1.RegionBackendServices
   # A list of resource collection configurations.
   # Consists of a name_pattern and an entity_name.
@@ -8880,16 +7747,16 @@ interfaces:
   # The entity_name is the name to be used as a basis for generated methods and
   # classes.
   collections:
-  - name_pattern: projects/{project}/regions/{region}
-    entity_name: region
-  - name_pattern: projects/{project}/regions/{region}/backendServices/{backendService}
-    entity_name: regionBackendServicesBackendService
+  - name_pattern: '{project}/regions/{region}'
+    entity_name: projectRegion
+  - name_pattern: '{project}/regions/{region}/backendServices/{backendService}'
+    entity_name: projectRegionBackendService
   # Definition for retryable codes.
   retry_codes_def:
   - name: idempotent
     retry_codes:
-    - SC_SERVICE_UNAVAILABLE
-    - SC_GATEWAY_TIMEOUT
+    - UNAVAILABLE
+    - DEADLINE_EXCEEDED
   - name: non_idempotent
     retry_codes: []
   # Definition for retry/backoff parameters.
@@ -8915,17 +7782,6 @@ interfaces:
   #       message.
   #   required_fields - Fields that are always required for a request to be
   #       valid.
-  #   request_object_method - Turns on or off the generation of a method whose
-  #       sole parameter is a request object. Not all languages will generate
-  #       this method.
-  #   resource_name_treatment - An enum that specifies how to treat the
-  #       resource name formats defined in the field_name_patterns
-  #       and response_field_name_patterns fields.
-  #       UNSET: default value
-  #       NONE: the collection configs will not be used by the generated code.
-  #       VALIDATE: string fields will be validated by the client against the
-  #           specified resource name formats.
-  #       STATIC_TYPES: the client will use generated types for resource names.
   #   page_streaming - Specifies the configuration for paging.
   #       Describes information for generating a method which transforms a
   #       paging list RPC into a stream of resources.
@@ -8959,20 +7815,16 @@ interfaces:
     flattening:
       groups:
       - parameters:
-        - requestId
         - backendService
     # TODO: Configure which fields are required.
     required_fields:
-    - requestId
     - backendService
-    request_object_method: true
-    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      backendService: regionBackendServicesBackendService
+      backendService: projectRegionBackendService
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
   - name: compute.regionBackendServices.get
@@ -8985,14 +7837,12 @@ interfaces:
     # TODO: Configure which fields are required.
     required_fields:
     - backendService
-    request_object_method: true
-    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      backendService: regionBackendServicesBackendService
+      backendService: projectRegionBackendService
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
   - name: compute.regionBackendServices.getHealth
@@ -9007,14 +7857,12 @@ interfaces:
     required_fields:
     - backendService
     - resourceGroupReferenceResource
-    request_object_method: true
-    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: non_idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      backendService: regionBackendServicesBackendService
+      backendService: projectRegionBackendService
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
   - name: compute.regionBackendServices.insert
@@ -9023,22 +7871,18 @@ interfaces:
     flattening:
       groups:
       - parameters:
-        - requestId
         - region
         - backendServiceResource
     # TODO: Configure which fields are required.
     required_fields:
-    - requestId
     - region
     - backendServiceResource
-    request_object_method: true
-    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: non_idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      region: region
+      region: projectRegion
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
   - name: compute.regionBackendServices.list
@@ -9051,21 +7895,19 @@ interfaces:
     # TODO: Configure which fields are required.
     required_fields:
     - region
-    request_object_method: true
-    resource_name_treatment: STATIC_TYPES
     page_streaming:
       request:
         page_size_field: maxResults
         token_field: pageToken
       response:
         token_field: nextPageToken
-        resources_field: BackendServiceList
+        resources_field: items
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      region: region
+      region: projectRegion
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
   - name: compute.regionBackendServices.patch
@@ -9074,22 +7916,18 @@ interfaces:
     flattening:
       groups:
       - parameters:
-        - requestId
         - backendService
         - backendServiceResource
     # TODO: Configure which fields are required.
     required_fields:
-    - requestId
     - backendService
     - backendServiceResource
-    request_object_method: true
-    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: non_idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      backendService: regionBackendServicesBackendService
+      backendService: projectRegionBackendService
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
   - name: compute.regionBackendServices.update
@@ -9098,25 +7936,21 @@ interfaces:
     flattening:
       groups:
       - parameters:
-        - requestId
         - backendService
         - backendServiceResource
     # TODO: Configure which fields are required.
     required_fields:
-    - requestId
     - backendService
     - backendServiceResource
-    request_object_method: true
-    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      backendService: regionBackendServicesBackendService
+      backendService: projectRegionBackendService
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
-  # The fully qualified name of the API interface.
+# The fully qualified name of the API interface.
 - name: google.compute.v1.RegionCommitments
   # A list of resource collection configurations.
   # Consists of a name_pattern and an entity_name.
@@ -9129,18 +7963,18 @@ interfaces:
   # The entity_name is the name to be used as a basis for generated methods and
   # classes.
   collections:
-  - name_pattern: projects/{project}
+  - name_pattern: '{project}'
     entity_name: project
-  - name_pattern: projects/{project}/regions/{region}
-    entity_name: region
-  - name_pattern: projects/{project}/regions/{region}/commitments/{commitment}
-    entity_name: commitment
+  - name_pattern: '{project}/regions/{region}'
+    entity_name: projectRegion
+  - name_pattern: '{project}/regions/{region}/commitments/{commitment}'
+    entity_name: projectRegionCommitment
   # Definition for retryable codes.
   retry_codes_def:
   - name: idempotent
     retry_codes:
-    - SC_SERVICE_UNAVAILABLE
-    - SC_GATEWAY_TIMEOUT
+    - UNAVAILABLE
+    - DEADLINE_EXCEEDED
   - name: non_idempotent
     retry_codes: []
   # Definition for retry/backoff parameters.
@@ -9166,17 +8000,6 @@ interfaces:
   #       message.
   #   required_fields - Fields that are always required for a request to be
   #       valid.
-  #   request_object_method - Turns on or off the generation of a method whose
-  #       sole parameter is a request object. Not all languages will generate
-  #       this method.
-  #   resource_name_treatment - An enum that specifies how to treat the
-  #       resource name formats defined in the field_name_patterns
-  #       and response_field_name_patterns fields.
-  #       UNSET: default value
-  #       NONE: the collection configs will not be used by the generated code.
-  #       VALIDATE: string fields will be validated by the client against the
-  #           specified resource name formats.
-  #       STATIC_TYPES: the client will use generated types for resource names.
   #   page_streaming - Specifies the configuration for paging.
   #       Describes information for generating a method which transforms a
   #       paging list RPC into a stream of resources.
@@ -9214,15 +8037,13 @@ interfaces:
     # TODO: Configure which fields are required.
     required_fields:
     - project
-    request_object_method: true
-    resource_name_treatment: STATIC_TYPES
     page_streaming:
       request:
         page_size_field: maxResults
         token_field: pageToken
       response:
         token_field: nextPageToken
-        resources_field: CommitmentAggregatedList
+        resources_field: items
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: idempotent
     # TODO: Configure the retryable params for this method.
@@ -9241,14 +8062,12 @@ interfaces:
     # TODO: Configure which fields are required.
     required_fields:
     - commitment
-    request_object_method: true
-    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      commitment: commitment
+      commitment: projectRegionCommitment
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
   - name: compute.regionCommitments.insert
@@ -9257,22 +8076,18 @@ interfaces:
     flattening:
       groups:
       - parameters:
-        - requestId
         - region
         - commitmentResource
     # TODO: Configure which fields are required.
     required_fields:
-    - requestId
     - region
     - commitmentResource
-    request_object_method: true
-    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: non_idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      region: region
+      region: projectRegion
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
   - name: compute.regionCommitments.list
@@ -9285,24 +8100,22 @@ interfaces:
     # TODO: Configure which fields are required.
     required_fields:
     - region
-    request_object_method: true
-    resource_name_treatment: STATIC_TYPES
     page_streaming:
       request:
         page_size_field: maxResults
         token_field: pageToken
       response:
         token_field: nextPageToken
-        resources_field: CommitmentList
+        resources_field: items
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      region: region
+      region: projectRegion
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
-  # The fully qualified name of the API interface.
+# The fully qualified name of the API interface.
 - name: google.compute.v1.RegionDiskTypes
   # A list of resource collection configurations.
   # Consists of a name_pattern and an entity_name.
@@ -9315,16 +8128,16 @@ interfaces:
   # The entity_name is the name to be used as a basis for generated methods and
   # classes.
   collections:
-  - name_pattern: projects/{project}/regions/{region}
-    entity_name: region
-  - name_pattern: projects/{project}/regions/{region}/diskTypes/{diskType}
-    entity_name: regionDiskTypesDiskType
+  - name_pattern: '{project}/regions/{region}'
+    entity_name: projectRegion
+  - name_pattern: '{project}/regions/{region}/diskTypes/{diskType}'
+    entity_name: projectRegionDiskType
   # Definition for retryable codes.
   retry_codes_def:
   - name: idempotent
     retry_codes:
-    - SC_SERVICE_UNAVAILABLE
-    - SC_GATEWAY_TIMEOUT
+    - UNAVAILABLE
+    - DEADLINE_EXCEEDED
   - name: non_idempotent
     retry_codes: []
   # Definition for retry/backoff parameters.
@@ -9350,17 +8163,6 @@ interfaces:
   #       message.
   #   required_fields - Fields that are always required for a request to be
   #       valid.
-  #   request_object_method - Turns on or off the generation of a method whose
-  #       sole parameter is a request object. Not all languages will generate
-  #       this method.
-  #   resource_name_treatment - An enum that specifies how to treat the
-  #       resource name formats defined in the field_name_patterns
-  #       and response_field_name_patterns fields.
-  #       UNSET: default value
-  #       NONE: the collection configs will not be used by the generated code.
-  #       VALIDATE: string fields will be validated by the client against the
-  #           specified resource name formats.
-  #       STATIC_TYPES: the client will use generated types for resource names.
   #   page_streaming - Specifies the configuration for paging.
   #       Describes information for generating a method which transforms a
   #       paging list RPC into a stream of resources.
@@ -9398,14 +8200,12 @@ interfaces:
     # TODO: Configure which fields are required.
     required_fields:
     - diskType
-    request_object_method: true
-    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      diskType: regionDiskTypesDiskType
+      diskType: projectRegionDiskType
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
   - name: compute.regionDiskTypes.list
@@ -9418,24 +8218,22 @@ interfaces:
     # TODO: Configure which fields are required.
     required_fields:
     - region
-    request_object_method: true
-    resource_name_treatment: STATIC_TYPES
     page_streaming:
       request:
         page_size_field: maxResults
         token_field: pageToken
       response:
         token_field: nextPageToken
-        resources_field: RegionDiskTypeList
+        resources_field: items
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      region: region
+      region: projectRegion
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
-  # The fully qualified name of the API interface.
+# The fully qualified name of the API interface.
 - name: google.compute.v1.RegionDisks
   # A list of resource collection configurations.
   # Consists of a name_pattern and an entity_name.
@@ -9448,18 +8246,18 @@ interfaces:
   # The entity_name is the name to be used as a basis for generated methods and
   # classes.
   collections:
-  - name_pattern: projects/{project}/regions/{region}
-    entity_name: region
-  - name_pattern: projects/{project}/regions/{region}/disks/{disk}
-    entity_name: regionDisksDisk
-  - name_pattern: projects/{project}/regions/{region}/disks/{resource}
-    entity_name: regionDisksResource
+  - name_pattern: '{project}/regions/{region}'
+    entity_name: projectRegion
+  - name_pattern: '{project}/regions/{region}/disks/{disk}'
+    entity_name: projectRegionDisk
+  - name_pattern: '{project}/regions/{region}/disks/{resource}'
+    entity_name: projectRegionDiskResource
   # Definition for retryable codes.
   retry_codes_def:
   - name: idempotent
     retry_codes:
-    - SC_SERVICE_UNAVAILABLE
-    - SC_GATEWAY_TIMEOUT
+    - UNAVAILABLE
+    - DEADLINE_EXCEEDED
   - name: non_idempotent
     retry_codes: []
   # Definition for retry/backoff parameters.
@@ -9485,17 +8283,6 @@ interfaces:
   #       message.
   #   required_fields - Fields that are always required for a request to be
   #       valid.
-  #   request_object_method - Turns on or off the generation of a method whose
-  #       sole parameter is a request object. Not all languages will generate
-  #       this method.
-  #   resource_name_treatment - An enum that specifies how to treat the
-  #       resource name formats defined in the field_name_patterns
-  #       and response_field_name_patterns fields.
-  #       UNSET: default value
-  #       NONE: the collection configs will not be used by the generated code.
-  #       VALIDATE: string fields will be validated by the client against the
-  #           specified resource name formats.
-  #       STATIC_TYPES: the client will use generated types for resource names.
   #   page_streaming - Specifies the configuration for paging.
   #       Describes information for generating a method which transforms a
   #       paging list RPC into a stream of resources.
@@ -9530,21 +8317,17 @@ interfaces:
       groups:
       - parameters:
         - disk
-        - requestId
         - regionDisksAddResourcePoliciesRequestResource
     # TODO: Configure which fields are required.
     required_fields:
     - disk
-    - requestId
     - regionDisksAddResourcePoliciesRequestResource
-    request_object_method: true
-    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: non_idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      disk: regionDisksDisk
+      disk: projectRegionDisk
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
   - name: compute.regionDisks.createSnapshot
@@ -9554,21 +8337,17 @@ interfaces:
       groups:
       - parameters:
         - disk
-        - requestId
         - snapshotResource
     # TODO: Configure which fields are required.
     required_fields:
     - disk
-    - requestId
     - snapshotResource
-    request_object_method: true
-    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: non_idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      disk: regionDisksDisk
+      disk: projectRegionDisk
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
   - name: compute.regionDisks.delete
@@ -9578,19 +8357,15 @@ interfaces:
       groups:
       - parameters:
         - disk
-        - requestId
     # TODO: Configure which fields are required.
     required_fields:
     - disk
-    - requestId
-    request_object_method: true
-    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      disk: regionDisksDisk
+      disk: projectRegionDisk
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
   - name: compute.regionDisks.get
@@ -9603,14 +8378,12 @@ interfaces:
     # TODO: Configure which fields are required.
     required_fields:
     - disk
-    request_object_method: true
-    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      disk: regionDisksDisk
+      disk: projectRegionDisk
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
   - name: compute.regionDisks.insert
@@ -9619,24 +8392,18 @@ interfaces:
     flattening:
       groups:
       - parameters:
-        - requestId
-        - sourceImage
         - region
         - diskResource
     # TODO: Configure which fields are required.
     required_fields:
-    - requestId
-    - sourceImage
     - region
     - diskResource
-    request_object_method: true
-    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: non_idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      region: region
+      region: projectRegion
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
   - name: compute.regionDisks.list
@@ -9649,21 +8416,19 @@ interfaces:
     # TODO: Configure which fields are required.
     required_fields:
     - region
-    request_object_method: true
-    resource_name_treatment: STATIC_TYPES
     page_streaming:
       request:
         page_size_field: maxResults
         token_field: pageToken
       response:
         token_field: nextPageToken
-        resources_field: DiskList
+        resources_field: items
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      region: region
+      region: projectRegion
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
   - name: compute.regionDisks.removeResourcePolicies
@@ -9673,21 +8438,17 @@ interfaces:
       groups:
       - parameters:
         - disk
-        - requestId
         - regionDisksRemoveResourcePoliciesRequestResource
     # TODO: Configure which fields are required.
     required_fields:
     - disk
-    - requestId
     - regionDisksRemoveResourcePoliciesRequestResource
-    request_object_method: true
-    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: non_idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      disk: regionDisksDisk
+      disk: projectRegionDisk
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
   - name: compute.regionDisks.resize
@@ -9697,21 +8458,17 @@ interfaces:
       groups:
       - parameters:
         - disk
-        - requestId
         - regionDisksResizeRequestResource
     # TODO: Configure which fields are required.
     required_fields:
     - disk
-    - requestId
     - regionDisksResizeRequestResource
-    request_object_method: true
-    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: non_idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      disk: regionDisksDisk
+      disk: projectRegionDisk
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
   - name: compute.regionDisks.setLabels
@@ -9721,21 +8478,17 @@ interfaces:
       groups:
       - parameters:
         - resource
-        - requestId
         - regionSetLabelsRequestResource
     # TODO: Configure which fields are required.
     required_fields:
     - resource
-    - requestId
     - regionSetLabelsRequestResource
-    request_object_method: true
-    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: non_idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      resource: regionDisksResource
+      resource: projectRegionDiskResource
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
   - name: compute.regionDisks.testIamPermissions
@@ -9750,17 +8503,15 @@ interfaces:
     required_fields:
     - resource
     - testPermissionsRequestResource
-    request_object_method: true
-    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: non_idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      resource: regionDisksResource
+      resource: projectRegionDiskResource
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
-  # The fully qualified name of the API interface.
+# The fully qualified name of the API interface.
 - name: google.compute.v1.RegionInstanceGroupManagers
   # A list of resource collection configurations.
   # Consists of a name_pattern and an entity_name.
@@ -9773,16 +8524,16 @@ interfaces:
   # The entity_name is the name to be used as a basis for generated methods and
   # classes.
   collections:
-  - name_pattern: projects/{project}/regions/{region}
-    entity_name: region
-  - name_pattern: projects/{project}/regions/{region}/instanceGroupManagers/{instanceGroupManager}
-    entity_name: regionInstanceGroupManagersInstanceGroupManager
+  - name_pattern: '{project}/regions/{region}'
+    entity_name: projectRegion
+  - name_pattern: '{project}/regions/{region}/instanceGroupManagers/{instanceGroupManager}'
+    entity_name: projectRegionInstanceGroupManager
   # Definition for retryable codes.
   retry_codes_def:
   - name: idempotent
     retry_codes:
-    - SC_SERVICE_UNAVAILABLE
-    - SC_GATEWAY_TIMEOUT
+    - UNAVAILABLE
+    - DEADLINE_EXCEEDED
   - name: non_idempotent
     retry_codes: []
   # Definition for retry/backoff parameters.
@@ -9808,17 +8559,6 @@ interfaces:
   #       message.
   #   required_fields - Fields that are always required for a request to be
   #       valid.
-  #   request_object_method - Turns on or off the generation of a method whose
-  #       sole parameter is a request object. Not all languages will generate
-  #       this method.
-  #   resource_name_treatment - An enum that specifies how to treat the
-  #       resource name formats defined in the field_name_patterns
-  #       and response_field_name_patterns fields.
-  #       UNSET: default value
-  #       NONE: the collection configs will not be used by the generated code.
-  #       VALIDATE: string fields will be validated by the client against the
-  #           specified resource name formats.
-  #       STATIC_TYPES: the client will use generated types for resource names.
   #   page_streaming - Specifies the configuration for paging.
   #       Describes information for generating a method which transforms a
   #       paging list RPC into a stream of resources.
@@ -9852,22 +8592,18 @@ interfaces:
     flattening:
       groups:
       - parameters:
-        - requestId
         - instanceGroupManager
         - regionInstanceGroupManagersAbandonInstancesRequestResource
     # TODO: Configure which fields are required.
     required_fields:
-    - requestId
     - instanceGroupManager
     - regionInstanceGroupManagersAbandonInstancesRequestResource
-    request_object_method: true
-    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: non_idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      instanceGroupManager: regionInstanceGroupManagersInstanceGroupManager
+      instanceGroupManager: projectRegionInstanceGroupManager
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
   - name: compute.regionInstanceGroupManagers.delete
@@ -9876,20 +8612,16 @@ interfaces:
     flattening:
       groups:
       - parameters:
-        - requestId
         - instanceGroupManager
     # TODO: Configure which fields are required.
     required_fields:
-    - requestId
     - instanceGroupManager
-    request_object_method: true
-    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      instanceGroupManager: regionInstanceGroupManagersInstanceGroupManager
+      instanceGroupManager: projectRegionInstanceGroupManager
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
   - name: compute.regionInstanceGroupManagers.deleteInstances
@@ -9898,22 +8630,18 @@ interfaces:
     flattening:
       groups:
       - parameters:
-        - requestId
         - instanceGroupManager
         - regionInstanceGroupManagersDeleteInstancesRequestResource
     # TODO: Configure which fields are required.
     required_fields:
-    - requestId
     - instanceGroupManager
     - regionInstanceGroupManagersDeleteInstancesRequestResource
-    request_object_method: true
-    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: non_idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      instanceGroupManager: regionInstanceGroupManagersInstanceGroupManager
+      instanceGroupManager: projectRegionInstanceGroupManager
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
   - name: compute.regionInstanceGroupManagers.get
@@ -9926,14 +8654,12 @@ interfaces:
     # TODO: Configure which fields are required.
     required_fields:
     - instanceGroupManager
-    request_object_method: true
-    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      instanceGroupManager: regionInstanceGroupManagersInstanceGroupManager
+      instanceGroupManager: projectRegionInstanceGroupManager
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
   - name: compute.regionInstanceGroupManagers.insert
@@ -9942,22 +8668,18 @@ interfaces:
     flattening:
       groups:
       - parameters:
-        - requestId
         - region
         - instanceGroupManagerResource
     # TODO: Configure which fields are required.
     required_fields:
-    - requestId
     - region
     - instanceGroupManagerResource
-    request_object_method: true
-    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: non_idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      region: region
+      region: projectRegion
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
   - name: compute.regionInstanceGroupManagers.list
@@ -9970,21 +8692,19 @@ interfaces:
     # TODO: Configure which fields are required.
     required_fields:
     - region
-    request_object_method: true
-    resource_name_treatment: STATIC_TYPES
     page_streaming:
       request:
         page_size_field: maxResults
         token_field: pageToken
       response:
         token_field: nextPageToken
-        resources_field: RegionInstanceGroupManagerList
+        resources_field: items
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      region: region
+      region: projectRegion
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
   - name: compute.regionInstanceGroupManagers.listManagedInstances
@@ -9997,14 +8717,12 @@ interfaces:
     # TODO: Configure which fields are required.
     required_fields:
     - instanceGroupManager
-    request_object_method: true
-    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: non_idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      instanceGroupManager: regionInstanceGroupManagersInstanceGroupManager
+      instanceGroupManager: projectRegionInstanceGroupManager
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
   - name: compute.regionInstanceGroupManagers.patch
@@ -10013,22 +8731,18 @@ interfaces:
     flattening:
       groups:
       - parameters:
-        - requestId
         - instanceGroupManager
         - instanceGroupManagerResource
     # TODO: Configure which fields are required.
     required_fields:
-    - requestId
     - instanceGroupManager
     - instanceGroupManagerResource
-    request_object_method: true
-    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: non_idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      instanceGroupManager: regionInstanceGroupManagersInstanceGroupManager
+      instanceGroupManager: projectRegionInstanceGroupManager
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
   - name: compute.regionInstanceGroupManagers.recreateInstances
@@ -10037,22 +8751,18 @@ interfaces:
     flattening:
       groups:
       - parameters:
-        - requestId
         - instanceGroupManager
         - regionInstanceGroupManagersRecreateRequestResource
     # TODO: Configure which fields are required.
     required_fields:
-    - requestId
     - instanceGroupManager
     - regionInstanceGroupManagersRecreateRequestResource
-    request_object_method: true
-    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: non_idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      instanceGroupManager: regionInstanceGroupManagersInstanceGroupManager
+      instanceGroupManager: projectRegionInstanceGroupManager
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
   - name: compute.regionInstanceGroupManagers.resize
@@ -10062,21 +8772,17 @@ interfaces:
       groups:
       - parameters:
         - size
-        - requestId
         - instanceGroupManager
     # TODO: Configure which fields are required.
     required_fields:
     - size
-    - requestId
     - instanceGroupManager
-    request_object_method: true
-    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: non_idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      instanceGroupManager: regionInstanceGroupManagersInstanceGroupManager
+      instanceGroupManager: projectRegionInstanceGroupManager
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
   - name: compute.regionInstanceGroupManagers.setInstanceTemplate
@@ -10085,22 +8791,18 @@ interfaces:
     flattening:
       groups:
       - parameters:
-        - requestId
         - instanceGroupManager
         - regionInstanceGroupManagersSetTemplateRequestResource
     # TODO: Configure which fields are required.
     required_fields:
-    - requestId
     - instanceGroupManager
     - regionInstanceGroupManagersSetTemplateRequestResource
-    request_object_method: true
-    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: non_idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      instanceGroupManager: regionInstanceGroupManagersInstanceGroupManager
+      instanceGroupManager: projectRegionInstanceGroupManager
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
   - name: compute.regionInstanceGroupManagers.setTargetPools
@@ -10109,25 +8811,21 @@ interfaces:
     flattening:
       groups:
       - parameters:
-        - requestId
         - instanceGroupManager
         - regionInstanceGroupManagersSetTargetPoolsRequestResource
     # TODO: Configure which fields are required.
     required_fields:
-    - requestId
     - instanceGroupManager
     - regionInstanceGroupManagersSetTargetPoolsRequestResource
-    request_object_method: true
-    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: non_idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      instanceGroupManager: regionInstanceGroupManagersInstanceGroupManager
+      instanceGroupManager: projectRegionInstanceGroupManager
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
-  # The fully qualified name of the API interface.
+# The fully qualified name of the API interface.
 - name: google.compute.v1.RegionInstanceGroups
   # A list of resource collection configurations.
   # Consists of a name_pattern and an entity_name.
@@ -10140,16 +8838,16 @@ interfaces:
   # The entity_name is the name to be used as a basis for generated methods and
   # classes.
   collections:
-  - name_pattern: projects/{project}/regions/{region}
-    entity_name: region
-  - name_pattern: projects/{project}/regions/{region}/instanceGroups/{instanceGroup}
-    entity_name: regionInstanceGroupsInstanceGroup
+  - name_pattern: '{project}/regions/{region}'
+    entity_name: projectRegion
+  - name_pattern: '{project}/regions/{region}/instanceGroups/{instanceGroup}'
+    entity_name: projectRegionInstanceGroup
   # Definition for retryable codes.
   retry_codes_def:
   - name: idempotent
     retry_codes:
-    - SC_SERVICE_UNAVAILABLE
-    - SC_GATEWAY_TIMEOUT
+    - UNAVAILABLE
+    - DEADLINE_EXCEEDED
   - name: non_idempotent
     retry_codes: []
   # Definition for retry/backoff parameters.
@@ -10175,17 +8873,6 @@ interfaces:
   #       message.
   #   required_fields - Fields that are always required for a request to be
   #       valid.
-  #   request_object_method - Turns on or off the generation of a method whose
-  #       sole parameter is a request object. Not all languages will generate
-  #       this method.
-  #   resource_name_treatment - An enum that specifies how to treat the
-  #       resource name formats defined in the field_name_patterns
-  #       and response_field_name_patterns fields.
-  #       UNSET: default value
-  #       NONE: the collection configs will not be used by the generated code.
-  #       VALIDATE: string fields will be validated by the client against the
-  #           specified resource name formats.
-  #       STATIC_TYPES: the client will use generated types for resource names.
   #   page_streaming - Specifies the configuration for paging.
   #       Describes information for generating a method which transforms a
   #       paging list RPC into a stream of resources.
@@ -10223,14 +8910,12 @@ interfaces:
     # TODO: Configure which fields are required.
     required_fields:
     - instanceGroup
-    request_object_method: true
-    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      instanceGroup: regionInstanceGroupsInstanceGroup
+      instanceGroup: projectRegionInstanceGroup
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
   - name: compute.regionInstanceGroups.list
@@ -10243,21 +8928,19 @@ interfaces:
     # TODO: Configure which fields are required.
     required_fields:
     - region
-    request_object_method: true
-    resource_name_treatment: STATIC_TYPES
     page_streaming:
       request:
         page_size_field: maxResults
         token_field: pageToken
       response:
         token_field: nextPageToken
-        resources_field: RegionInstanceGroupList
+        resources_field: items
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      region: region
+      region: projectRegion
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
   - name: compute.regionInstanceGroups.listInstances
@@ -10272,21 +8955,19 @@ interfaces:
     required_fields:
     - instanceGroup
     - regionInstanceGroupsListInstancesRequestResource
-    request_object_method: true
-    resource_name_treatment: STATIC_TYPES
     page_streaming:
       request:
         page_size_field: maxResults
         token_field: pageToken
       response:
         token_field: nextPageToken
-        resources_field: RegionInstanceGroupsListInstances
+        resources_field: items
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: non_idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      instanceGroup: regionInstanceGroupsInstanceGroup
+      instanceGroup: projectRegionInstanceGroup
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
   - name: compute.regionInstanceGroups.setNamedPorts
@@ -10295,25 +8976,21 @@ interfaces:
     flattening:
       groups:
       - parameters:
-        - requestId
         - instanceGroup
         - regionInstanceGroupsSetNamedPortsRequestResource
     # TODO: Configure which fields are required.
     required_fields:
-    - requestId
     - instanceGroup
     - regionInstanceGroupsSetNamedPortsRequestResource
-    request_object_method: true
-    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: non_idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      instanceGroup: regionInstanceGroupsInstanceGroup
+      instanceGroup: projectRegionInstanceGroup
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
-  # The fully qualified name of the API interface.
+# The fully qualified name of the API interface.
 - name: google.compute.v1.RegionOperations
   # A list of resource collection configurations.
   # Consists of a name_pattern and an entity_name.
@@ -10326,16 +9003,16 @@ interfaces:
   # The entity_name is the name to be used as a basis for generated methods and
   # classes.
   collections:
-  - name_pattern: projects/{project}/regions/{region}
-    entity_name: region
-  - name_pattern: projects/{project}/regions/{region}/operations/{operation}
-    entity_name: regionOperationsOperation
+  - name_pattern: '{project}/regions/{region}'
+    entity_name: projectRegion
+  - name_pattern: '{project}/regions/{region}/operations/{operation}'
+    entity_name: projectRegionOperation
   # Definition for retryable codes.
   retry_codes_def:
   - name: idempotent
     retry_codes:
-    - SC_SERVICE_UNAVAILABLE
-    - SC_GATEWAY_TIMEOUT
+    - UNAVAILABLE
+    - DEADLINE_EXCEEDED
   - name: non_idempotent
     retry_codes: []
   # Definition for retry/backoff parameters.
@@ -10361,17 +9038,6 @@ interfaces:
   #       message.
   #   required_fields - Fields that are always required for a request to be
   #       valid.
-  #   request_object_method - Turns on or off the generation of a method whose
-  #       sole parameter is a request object. Not all languages will generate
-  #       this method.
-  #   resource_name_treatment - An enum that specifies how to treat the
-  #       resource name formats defined in the field_name_patterns
-  #       and response_field_name_patterns fields.
-  #       UNSET: default value
-  #       NONE: the collection configs will not be used by the generated code.
-  #       VALIDATE: string fields will be validated by the client against the
-  #           specified resource name formats.
-  #       STATIC_TYPES: the client will use generated types for resource names.
   #   page_streaming - Specifies the configuration for paging.
   #       Describes information for generating a method which transforms a
   #       paging list RPC into a stream of resources.
@@ -10409,14 +9075,12 @@ interfaces:
     # TODO: Configure which fields are required.
     required_fields:
     - operation
-    request_object_method: true
-    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      operation: regionOperationsOperation
+      operation: projectRegionOperation
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
   - name: compute.regionOperations.get
@@ -10429,14 +9093,12 @@ interfaces:
     # TODO: Configure which fields are required.
     required_fields:
     - operation
-    request_object_method: true
-    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      operation: regionOperationsOperation
+      operation: projectRegionOperation
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
   - name: compute.regionOperations.list
@@ -10449,24 +9111,22 @@ interfaces:
     # TODO: Configure which fields are required.
     required_fields:
     - region
-    request_object_method: true
-    resource_name_treatment: STATIC_TYPES
     page_streaming:
       request:
         page_size_field: maxResults
         token_field: pageToken
       response:
         token_field: nextPageToken
-        resources_field: OperationList
+        resources_field: items
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      region: region
+      region: projectRegion
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
-  # The fully qualified name of the API interface.
+# The fully qualified name of the API interface.
 - name: google.compute.v1.Regions
   # A list of resource collection configurations.
   # Consists of a name_pattern and an entity_name.
@@ -10479,16 +9139,16 @@ interfaces:
   # The entity_name is the name to be used as a basis for generated methods and
   # classes.
   collections:
-  - name_pattern: projects/{project}
+  - name_pattern: '{project}'
     entity_name: project
-  - name_pattern: projects/{project}/regions/{region}
-    entity_name: region
+  - name_pattern: '{project}/regions/{region}'
+    entity_name: projectRegion
   # Definition for retryable codes.
   retry_codes_def:
   - name: idempotent
     retry_codes:
-    - SC_SERVICE_UNAVAILABLE
-    - SC_GATEWAY_TIMEOUT
+    - UNAVAILABLE
+    - DEADLINE_EXCEEDED
   - name: non_idempotent
     retry_codes: []
   # Definition for retry/backoff parameters.
@@ -10514,17 +9174,6 @@ interfaces:
   #       message.
   #   required_fields - Fields that are always required for a request to be
   #       valid.
-  #   request_object_method - Turns on or off the generation of a method whose
-  #       sole parameter is a request object. Not all languages will generate
-  #       this method.
-  #   resource_name_treatment - An enum that specifies how to treat the
-  #       resource name formats defined in the field_name_patterns
-  #       and response_field_name_patterns fields.
-  #       UNSET: default value
-  #       NONE: the collection configs will not be used by the generated code.
-  #       VALIDATE: string fields will be validated by the client against the
-  #           specified resource name formats.
-  #       STATIC_TYPES: the client will use generated types for resource names.
   #   page_streaming - Specifies the configuration for paging.
   #       Describes information for generating a method which transforms a
   #       paging list RPC into a stream of resources.
@@ -10562,14 +9211,12 @@ interfaces:
     # TODO: Configure which fields are required.
     required_fields:
     - region
-    request_object_method: true
-    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      region: region
+      region: projectRegion
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
   - name: compute.regions.list
@@ -10582,15 +9229,13 @@ interfaces:
     # TODO: Configure which fields are required.
     required_fields:
     - project
-    request_object_method: true
-    resource_name_treatment: STATIC_TYPES
     page_streaming:
       request:
         page_size_field: maxResults
         token_field: pageToken
       response:
         token_field: nextPageToken
-        resources_field: RegionList
+        resources_field: items
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: idempotent
     # TODO: Configure the retryable params for this method.
@@ -10599,7 +9244,7 @@ interfaces:
       project: project
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
-  # The fully qualified name of the API interface.
+# The fully qualified name of the API interface.
 - name: google.compute.v1.Reservations
   # A list of resource collection configurations.
   # Consists of a name_pattern and an entity_name.
@@ -10612,20 +9257,20 @@ interfaces:
   # The entity_name is the name to be used as a basis for generated methods and
   # classes.
   collections:
-  - name_pattern: projects/{project}
+  - name_pattern: '{project}'
     entity_name: project
-  - name_pattern: projects/{project}/zones/{zone}
-    entity_name: zone
-  - name_pattern: projects/{project}/zones/{zone}/reservations/{reservation}
-    entity_name: reservation
-  - name_pattern: projects/{project}/zones/{zone}/reservations/{resource}
-    entity_name: reservationsResource
+  - name_pattern: '{project}/zones/{zone}'
+    entity_name: projectZone
+  - name_pattern: '{project}/zones/{zone}/reservations/{reservation}'
+    entity_name: projectZoneReservation
+  - name_pattern: '{project}/zones/{zone}/reservations/{resource}'
+    entity_name: projectZoneReservationResource
   # Definition for retryable codes.
   retry_codes_def:
   - name: idempotent
     retry_codes:
-    - SC_SERVICE_UNAVAILABLE
-    - SC_GATEWAY_TIMEOUT
+    - UNAVAILABLE
+    - DEADLINE_EXCEEDED
   - name: non_idempotent
     retry_codes: []
   # Definition for retry/backoff parameters.
@@ -10651,17 +9296,6 @@ interfaces:
   #       message.
   #   required_fields - Fields that are always required for a request to be
   #       valid.
-  #   request_object_method - Turns on or off the generation of a method whose
-  #       sole parameter is a request object. Not all languages will generate
-  #       this method.
-  #   resource_name_treatment - An enum that specifies how to treat the
-  #       resource name formats defined in the field_name_patterns
-  #       and response_field_name_patterns fields.
-  #       UNSET: default value
-  #       NONE: the collection configs will not be used by the generated code.
-  #       VALIDATE: string fields will be validated by the client against the
-  #           specified resource name formats.
-  #       STATIC_TYPES: the client will use generated types for resource names.
   #   page_streaming - Specifies the configuration for paging.
   #       Describes information for generating a method which transforms a
   #       paging list RPC into a stream of resources.
@@ -10699,15 +9333,13 @@ interfaces:
     # TODO: Configure which fields are required.
     required_fields:
     - project
-    request_object_method: true
-    resource_name_treatment: STATIC_TYPES
     page_streaming:
       request:
         page_size_field: maxResults
         token_field: pageToken
       response:
         token_field: nextPageToken
-        resources_field: ReservationAggregatedList
+        resources_field: items
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: idempotent
     # TODO: Configure the retryable params for this method.
@@ -10722,20 +9354,16 @@ interfaces:
     flattening:
       groups:
       - parameters:
-        - requestId
         - reservation
     # TODO: Configure which fields are required.
     required_fields:
-    - requestId
     - reservation
-    request_object_method: true
-    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      reservation: reservation
+      reservation: projectZoneReservation
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
   - name: compute.reservations.get
@@ -10748,14 +9376,12 @@ interfaces:
     # TODO: Configure which fields are required.
     required_fields:
     - reservation
-    request_object_method: true
-    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      reservation: reservation
+      reservation: projectZoneReservation
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
   - name: compute.reservations.getIamPolicy
@@ -10768,14 +9394,12 @@ interfaces:
     # TODO: Configure which fields are required.
     required_fields:
     - resource
-    request_object_method: true
-    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      resource: reservationsResource
+      resource: projectZoneReservationResource
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
   - name: compute.reservations.insert
@@ -10785,21 +9409,17 @@ interfaces:
       groups:
       - parameters:
         - zone
-        - requestId
         - reservationResource
     # TODO: Configure which fields are required.
     required_fields:
     - zone
-    - requestId
     - reservationResource
-    request_object_method: true
-    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: non_idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      zone: zone
+      zone: projectZone
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
   - name: compute.reservations.list
@@ -10812,21 +9432,19 @@ interfaces:
     # TODO: Configure which fields are required.
     required_fields:
     - zone
-    request_object_method: true
-    resource_name_treatment: STATIC_TYPES
     page_streaming:
       request:
         page_size_field: maxResults
         token_field: pageToken
       response:
         token_field: nextPageToken
-        resources_field: ReservationList
+        resources_field: items
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      zone: zone
+      zone: projectZone
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
   - name: compute.reservations.resize
@@ -10835,22 +9453,18 @@ interfaces:
     flattening:
       groups:
       - parameters:
-        - requestId
         - reservation
         - reservationsResizeRequestResource
     # TODO: Configure which fields are required.
     required_fields:
-    - requestId
     - reservation
     - reservationsResizeRequestResource
-    request_object_method: true
-    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: non_idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      reservation: reservation
+      reservation: projectZoneReservation
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
   - name: compute.reservations.setIamPolicy
@@ -10865,14 +9479,12 @@ interfaces:
     required_fields:
     - resource
     - zoneSetPolicyRequestResource
-    request_object_method: true
-    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: non_idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      resource: reservationsResource
+      resource: projectZoneReservationResource
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
   - name: compute.reservations.testIamPermissions
@@ -10887,17 +9499,15 @@ interfaces:
     required_fields:
     - resource
     - testPermissionsRequestResource
-    request_object_method: true
-    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: non_idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      resource: reservationsResource
+      resource: projectZoneReservationResource
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
-  # The fully qualified name of the API interface.
+# The fully qualified name of the API interface.
 - name: google.compute.v1.ResourcePolicies
   # A list of resource collection configurations.
   # Consists of a name_pattern and an entity_name.
@@ -10910,20 +9520,20 @@ interfaces:
   # The entity_name is the name to be used as a basis for generated methods and
   # classes.
   collections:
-  - name_pattern: projects/{project}
+  - name_pattern: '{project}'
     entity_name: project
-  - name_pattern: projects/{project}/regions/{region}
-    entity_name: region
-  - name_pattern: projects/{project}/regions/{region}/resourcePolicies/{resourcePolicy}
-    entity_name: resourcePolicy
-  - name_pattern: projects/{project}/regions/{region}/resourcePolicies/{resource}
-    entity_name: resourcePoliciesResource
+  - name_pattern: '{project}/regions/{region}'
+    entity_name: projectRegion
+  - name_pattern: '{project}/regions/{region}/resourcePolicies/{resourcePolicy}'
+    entity_name: projectRegionResourcePolicy
+  - name_pattern: '{project}/regions/{region}/resourcePolicies/{resource}'
+    entity_name: projectRegionResourcePolicyResource
   # Definition for retryable codes.
   retry_codes_def:
   - name: idempotent
     retry_codes:
-    - SC_SERVICE_UNAVAILABLE
-    - SC_GATEWAY_TIMEOUT
+    - UNAVAILABLE
+    - DEADLINE_EXCEEDED
   - name: non_idempotent
     retry_codes: []
   # Definition for retry/backoff parameters.
@@ -10949,17 +9559,6 @@ interfaces:
   #       message.
   #   required_fields - Fields that are always required for a request to be
   #       valid.
-  #   request_object_method - Turns on or off the generation of a method whose
-  #       sole parameter is a request object. Not all languages will generate
-  #       this method.
-  #   resource_name_treatment - An enum that specifies how to treat the
-  #       resource name formats defined in the field_name_patterns
-  #       and response_field_name_patterns fields.
-  #       UNSET: default value
-  #       NONE: the collection configs will not be used by the generated code.
-  #       VALIDATE: string fields will be validated by the client against the
-  #           specified resource name formats.
-  #       STATIC_TYPES: the client will use generated types for resource names.
   #   page_streaming - Specifies the configuration for paging.
   #       Describes information for generating a method which transforms a
   #       paging list RPC into a stream of resources.
@@ -10997,15 +9596,13 @@ interfaces:
     # TODO: Configure which fields are required.
     required_fields:
     - project
-    request_object_method: true
-    resource_name_treatment: STATIC_TYPES
     page_streaming:
       request:
         page_size_field: maxResults
         token_field: pageToken
       response:
         token_field: nextPageToken
-        resources_field: ResourcePolicyAggregatedList
+        resources_field: items
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: idempotent
     # TODO: Configure the retryable params for this method.
@@ -11021,19 +9618,15 @@ interfaces:
       groups:
       - parameters:
         - resourcePolicy
-        - requestId
     # TODO: Configure which fields are required.
     required_fields:
     - resourcePolicy
-    - requestId
-    request_object_method: true
-    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      resourcePolicy: resourcePolicy
+      resourcePolicy: projectRegionResourcePolicy
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
   - name: compute.resourcePolicies.get
@@ -11046,14 +9639,12 @@ interfaces:
     # TODO: Configure which fields are required.
     required_fields:
     - resourcePolicy
-    request_object_method: true
-    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      resourcePolicy: resourcePolicy
+      resourcePolicy: projectRegionResourcePolicy
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
   - name: compute.resourcePolicies.getIamPolicy
@@ -11066,14 +9657,12 @@ interfaces:
     # TODO: Configure which fields are required.
     required_fields:
     - resource
-    request_object_method: true
-    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      resource: resourcePoliciesResource
+      resource: projectRegionResourcePolicyResource
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
   - name: compute.resourcePolicies.insert
@@ -11082,22 +9671,18 @@ interfaces:
     flattening:
       groups:
       - parameters:
-        - requestId
         - region
         - resourcePolicyResource
     # TODO: Configure which fields are required.
     required_fields:
-    - requestId
     - region
     - resourcePolicyResource
-    request_object_method: true
-    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: non_idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      region: region
+      region: projectRegion
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
   - name: compute.resourcePolicies.list
@@ -11110,21 +9695,19 @@ interfaces:
     # TODO: Configure which fields are required.
     required_fields:
     - region
-    request_object_method: true
-    resource_name_treatment: STATIC_TYPES
     page_streaming:
       request:
         page_size_field: maxResults
         token_field: pageToken
       response:
         token_field: nextPageToken
-        resources_field: ResourcePolicyList
+        resources_field: items
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      region: region
+      region: projectRegion
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
   - name: compute.resourcePolicies.setIamPolicy
@@ -11139,14 +9722,12 @@ interfaces:
     required_fields:
     - resource
     - regionSetPolicyRequestResource
-    request_object_method: true
-    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: non_idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      resource: resourcePoliciesResource
+      resource: projectRegionResourcePolicyResource
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
   - name: compute.resourcePolicies.testIamPermissions
@@ -11161,17 +9742,15 @@ interfaces:
     required_fields:
     - resource
     - testPermissionsRequestResource
-    request_object_method: true
-    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: non_idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      resource: resourcePoliciesResource
+      resource: projectRegionResourcePolicyResource
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
-  # The fully qualified name of the API interface.
+# The fully qualified name of the API interface.
 - name: google.compute.v1.Routers
   # A list of resource collection configurations.
   # Consists of a name_pattern and an entity_name.
@@ -11184,18 +9763,18 @@ interfaces:
   # The entity_name is the name to be used as a basis for generated methods and
   # classes.
   collections:
-  - name_pattern: projects/{project}
+  - name_pattern: '{project}'
     entity_name: project
-  - name_pattern: projects/{project}/regions/{region}
-    entity_name: region
-  - name_pattern: projects/{project}/regions/{region}/routers/{router}
-    entity_name: router
+  - name_pattern: '{project}/regions/{region}'
+    entity_name: projectRegion
+  - name_pattern: '{project}/regions/{region}/routers/{router}'
+    entity_name: projectRegionRouter
   # Definition for retryable codes.
   retry_codes_def:
   - name: idempotent
     retry_codes:
-    - SC_SERVICE_UNAVAILABLE
-    - SC_GATEWAY_TIMEOUT
+    - UNAVAILABLE
+    - DEADLINE_EXCEEDED
   - name: non_idempotent
     retry_codes: []
   # Definition for retry/backoff parameters.
@@ -11221,17 +9800,6 @@ interfaces:
   #       message.
   #   required_fields - Fields that are always required for a request to be
   #       valid.
-  #   request_object_method - Turns on or off the generation of a method whose
-  #       sole parameter is a request object. Not all languages will generate
-  #       this method.
-  #   resource_name_treatment - An enum that specifies how to treat the
-  #       resource name formats defined in the field_name_patterns
-  #       and response_field_name_patterns fields.
-  #       UNSET: default value
-  #       NONE: the collection configs will not be used by the generated code.
-  #       VALIDATE: string fields will be validated by the client against the
-  #           specified resource name formats.
-  #       STATIC_TYPES: the client will use generated types for resource names.
   #   page_streaming - Specifies the configuration for paging.
   #       Describes information for generating a method which transforms a
   #       paging list RPC into a stream of resources.
@@ -11269,15 +9837,13 @@ interfaces:
     # TODO: Configure which fields are required.
     required_fields:
     - project
-    request_object_method: true
-    resource_name_treatment: STATIC_TYPES
     page_streaming:
       request:
         page_size_field: maxResults
         token_field: pageToken
       response:
         token_field: nextPageToken
-        resources_field: RouterAggregatedList
+        resources_field: items
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: idempotent
     # TODO: Configure the retryable params for this method.
@@ -11293,19 +9859,15 @@ interfaces:
       groups:
       - parameters:
         - router
-        - requestId
     # TODO: Configure which fields are required.
     required_fields:
     - router
-    - requestId
-    request_object_method: true
-    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      router: router
+      router: projectRegionRouter
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
   - name: compute.routers.get
@@ -11318,14 +9880,12 @@ interfaces:
     # TODO: Configure which fields are required.
     required_fields:
     - router
-    request_object_method: true
-    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      router: router
+      router: projectRegionRouter
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
   - name: compute.routers.getNatMappingInfo
@@ -11338,21 +9898,19 @@ interfaces:
     # TODO: Configure which fields are required.
     required_fields:
     - router
-    request_object_method: true
-    resource_name_treatment: STATIC_TYPES
     page_streaming:
       request:
         page_size_field: maxResults
         token_field: pageToken
       response:
         token_field: nextPageToken
-        resources_field: VmEndpointNatMappingsList
+        resources_field: result
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      router: router
+      router: projectRegionRouter
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
   - name: compute.routers.getRouterStatus
@@ -11365,14 +9923,12 @@ interfaces:
     # TODO: Configure which fields are required.
     required_fields:
     - router
-    request_object_method: true
-    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      router: router
+      router: projectRegionRouter
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
   - name: compute.routers.insert
@@ -11381,22 +9937,18 @@ interfaces:
     flattening:
       groups:
       - parameters:
-        - requestId
         - region
         - routerResource
     # TODO: Configure which fields are required.
     required_fields:
-    - requestId
     - region
     - routerResource
-    request_object_method: true
-    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: non_idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      region: region
+      region: projectRegion
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
   - name: compute.routers.list
@@ -11409,21 +9961,19 @@ interfaces:
     # TODO: Configure which fields are required.
     required_fields:
     - region
-    request_object_method: true
-    resource_name_treatment: STATIC_TYPES
     page_streaming:
       request:
         page_size_field: maxResults
         token_field: pageToken
       response:
         token_field: nextPageToken
-        resources_field: RouterList
+        resources_field: items
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      region: region
+      region: projectRegion
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
   - name: compute.routers.patch
@@ -11433,21 +9983,17 @@ interfaces:
       groups:
       - parameters:
         - router
-        - requestId
         - routerResource
     # TODO: Configure which fields are required.
     required_fields:
     - router
-    - requestId
     - routerResource
-    request_object_method: true
-    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: non_idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      router: router
+      router: projectRegionRouter
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
   - name: compute.routers.preview
@@ -11462,14 +10008,12 @@ interfaces:
     required_fields:
     - router
     - routerResource
-    request_object_method: true
-    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: non_idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      router: router
+      router: projectRegionRouter
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
   - name: compute.routers.update
@@ -11479,24 +10023,20 @@ interfaces:
       groups:
       - parameters:
         - router
-        - requestId
         - routerResource
     # TODO: Configure which fields are required.
     required_fields:
     - router
-    - requestId
     - routerResource
-    request_object_method: true
-    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      router: router
+      router: projectRegionRouter
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
-  # The fully qualified name of the API interface.
+# The fully qualified name of the API interface.
 - name: google.compute.v1.Routes
   # A list of resource collection configurations.
   # Consists of a name_pattern and an entity_name.
@@ -11509,16 +10049,16 @@ interfaces:
   # The entity_name is the name to be used as a basis for generated methods and
   # classes.
   collections:
-  - name_pattern: projects/{project}
+  - name_pattern: '{project}'
     entity_name: project
-  - name_pattern: projects/{project}/routes/{route}
-    entity_name: route
+  - name_pattern: '{project}/global/routes/{route}'
+    entity_name: projectGlobalRoute
   # Definition for retryable codes.
   retry_codes_def:
   - name: idempotent
     retry_codes:
-    - SC_SERVICE_UNAVAILABLE
-    - SC_GATEWAY_TIMEOUT
+    - UNAVAILABLE
+    - DEADLINE_EXCEEDED
   - name: non_idempotent
     retry_codes: []
   # Definition for retry/backoff parameters.
@@ -11544,17 +10084,6 @@ interfaces:
   #       message.
   #   required_fields - Fields that are always required for a request to be
   #       valid.
-  #   request_object_method - Turns on or off the generation of a method whose
-  #       sole parameter is a request object. Not all languages will generate
-  #       this method.
-  #   resource_name_treatment - An enum that specifies how to treat the
-  #       resource name formats defined in the field_name_patterns
-  #       and response_field_name_patterns fields.
-  #       UNSET: default value
-  #       NONE: the collection configs will not be used by the generated code.
-  #       VALIDATE: string fields will be validated by the client against the
-  #           specified resource name formats.
-  #       STATIC_TYPES: the client will use generated types for resource names.
   #   page_streaming - Specifies the configuration for paging.
   #       Describes information for generating a method which transforms a
   #       paging list RPC into a stream of resources.
@@ -11589,19 +10118,15 @@ interfaces:
       groups:
       - parameters:
         - route
-        - requestId
     # TODO: Configure which fields are required.
     required_fields:
     - route
-    - requestId
-    request_object_method: true
-    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      route: route
+      route: projectGlobalRoute
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
   - name: compute.routes.get
@@ -11614,14 +10139,12 @@ interfaces:
     # TODO: Configure which fields are required.
     required_fields:
     - route
-    request_object_method: true
-    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      route: route
+      route: projectGlobalRoute
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
   - name: compute.routes.insert
@@ -11630,16 +10153,12 @@ interfaces:
     flattening:
       groups:
       - parameters:
-        - requestId
         - project
         - routeResource
     # TODO: Configure which fields are required.
     required_fields:
-    - requestId
     - project
     - routeResource
-    request_object_method: true
-    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: non_idempotent
     # TODO: Configure the retryable params for this method.
@@ -11658,15 +10177,13 @@ interfaces:
     # TODO: Configure which fields are required.
     required_fields:
     - project
-    request_object_method: true
-    resource_name_treatment: STATIC_TYPES
     page_streaming:
       request:
         page_size_field: maxResults
         token_field: pageToken
       response:
         token_field: nextPageToken
-        resources_field: RouteList
+        resources_field: items
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: idempotent
     # TODO: Configure the retryable params for this method.
@@ -11675,7 +10192,7 @@ interfaces:
       project: project
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
-  # The fully qualified name of the API interface.
+# The fully qualified name of the API interface.
 - name: google.compute.v1.SecurityPolicies
   # A list of resource collection configurations.
   # Consists of a name_pattern and an entity_name.
@@ -11688,16 +10205,16 @@ interfaces:
   # The entity_name is the name to be used as a basis for generated methods and
   # classes.
   collections:
-  - name_pattern: projects/{project}
+  - name_pattern: '{project}'
     entity_name: project
-  - name_pattern: projects/{project}/securityPolicies/{securityPolicy}
-    entity_name: securityPolicy
+  - name_pattern: '{project}/global/securityPolicies/{securityPolicy}'
+    entity_name: projectGlobalSecurityPolicy
   # Definition for retryable codes.
   retry_codes_def:
   - name: idempotent
     retry_codes:
-    - SC_SERVICE_UNAVAILABLE
-    - SC_GATEWAY_TIMEOUT
+    - UNAVAILABLE
+    - DEADLINE_EXCEEDED
   - name: non_idempotent
     retry_codes: []
   # Definition for retry/backoff parameters.
@@ -11723,17 +10240,6 @@ interfaces:
   #       message.
   #   required_fields - Fields that are always required for a request to be
   #       valid.
-  #   request_object_method - Turns on or off the generation of a method whose
-  #       sole parameter is a request object. Not all languages will generate
-  #       this method.
-  #   resource_name_treatment - An enum that specifies how to treat the
-  #       resource name formats defined in the field_name_patterns
-  #       and response_field_name_patterns fields.
-  #       UNSET: default value
-  #       NONE: the collection configs will not be used by the generated code.
-  #       VALIDATE: string fields will be validated by the client against the
-  #           specified resource name formats.
-  #       STATIC_TYPES: the client will use generated types for resource names.
   #   page_streaming - Specifies the configuration for paging.
   #       Describes information for generating a method which transforms a
   #       paging list RPC into a stream of resources.
@@ -11773,14 +10279,12 @@ interfaces:
     required_fields:
     - securityPolicy
     - securityPolicyRuleResource
-    request_object_method: true
-    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: non_idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      securityPolicy: securityPolicy
+      securityPolicy: projectGlobalSecurityPolicy
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
   - name: compute.securityPolicies.delete
@@ -11789,20 +10293,16 @@ interfaces:
     flattening:
       groups:
       - parameters:
-        - requestId
         - securityPolicy
     # TODO: Configure which fields are required.
     required_fields:
-    - requestId
     - securityPolicy
-    request_object_method: true
-    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      securityPolicy: securityPolicy
+      securityPolicy: projectGlobalSecurityPolicy
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
   - name: compute.securityPolicies.get
@@ -11815,14 +10315,12 @@ interfaces:
     # TODO: Configure which fields are required.
     required_fields:
     - securityPolicy
-    request_object_method: true
-    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      securityPolicy: securityPolicy
+      securityPolicy: projectGlobalSecurityPolicy
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
   - name: compute.securityPolicies.getRule
@@ -11837,14 +10335,12 @@ interfaces:
     required_fields:
     - priority
     - securityPolicy
-    request_object_method: true
-    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      securityPolicy: securityPolicy
+      securityPolicy: projectGlobalSecurityPolicy
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
   - name: compute.securityPolicies.insert
@@ -11853,16 +10349,12 @@ interfaces:
     flattening:
       groups:
       - parameters:
-        - requestId
         - project
         - securityPolicyResource
     # TODO: Configure which fields are required.
     required_fields:
-    - requestId
     - project
     - securityPolicyResource
-    request_object_method: true
-    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: non_idempotent
     # TODO: Configure the retryable params for this method.
@@ -11881,15 +10373,13 @@ interfaces:
     # TODO: Configure which fields are required.
     required_fields:
     - project
-    request_object_method: true
-    resource_name_treatment: STATIC_TYPES
     page_streaming:
       request:
         page_size_field: maxResults
         token_field: pageToken
       response:
         token_field: nextPageToken
-        resources_field: SecurityPolicyList
+        resources_field: items
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: idempotent
     # TODO: Configure the retryable params for this method.
@@ -11904,22 +10394,18 @@ interfaces:
     flattening:
       groups:
       - parameters:
-        - requestId
         - securityPolicy
         - securityPolicyResource
     # TODO: Configure which fields are required.
     required_fields:
-    - requestId
     - securityPolicy
     - securityPolicyResource
-    request_object_method: true
-    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: non_idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      securityPolicy: securityPolicy
+      securityPolicy: projectGlobalSecurityPolicy
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
   - name: compute.securityPolicies.patchRule
@@ -11936,14 +10422,12 @@ interfaces:
     - priority
     - securityPolicy
     - securityPolicyRuleResource
-    request_object_method: true
-    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: non_idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      securityPolicy: securityPolicy
+      securityPolicy: projectGlobalSecurityPolicy
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
   - name: compute.securityPolicies.removeRule
@@ -11958,17 +10442,15 @@ interfaces:
     required_fields:
     - priority
     - securityPolicy
-    request_object_method: true
-    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: non_idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      securityPolicy: securityPolicy
+      securityPolicy: projectGlobalSecurityPolicy
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
-  # The fully qualified name of the API interface.
+# The fully qualified name of the API interface.
 - name: google.compute.v1.Snapshots
   # A list of resource collection configurations.
   # Consists of a name_pattern and an entity_name.
@@ -11981,18 +10463,18 @@ interfaces:
   # The entity_name is the name to be used as a basis for generated methods and
   # classes.
   collections:
-  - name_pattern: projects/{project}
+  - name_pattern: '{project}'
     entity_name: project
-  - name_pattern: projects/{project}/snapshots/{resource}
-    entity_name: snapshotsResource
-  - name_pattern: projects/{project}/snapshots/{snapshot}
-    entity_name: snapshot
+  - name_pattern: '{project}/global/snapshots/{resource}'
+    entity_name: projectGlobalSnapshotResource
+  - name_pattern: '{project}/global/snapshots/{snapshot}'
+    entity_name: projectGlobalSnapshot
   # Definition for retryable codes.
   retry_codes_def:
   - name: idempotent
     retry_codes:
-    - SC_SERVICE_UNAVAILABLE
-    - SC_GATEWAY_TIMEOUT
+    - UNAVAILABLE
+    - DEADLINE_EXCEEDED
   - name: non_idempotent
     retry_codes: []
   # Definition for retry/backoff parameters.
@@ -12018,17 +10500,6 @@ interfaces:
   #       message.
   #   required_fields - Fields that are always required for a request to be
   #       valid.
-  #   request_object_method - Turns on or off the generation of a method whose
-  #       sole parameter is a request object. Not all languages will generate
-  #       this method.
-  #   resource_name_treatment - An enum that specifies how to treat the
-  #       resource name formats defined in the field_name_patterns
-  #       and response_field_name_patterns fields.
-  #       UNSET: default value
-  #       NONE: the collection configs will not be used by the generated code.
-  #       VALIDATE: string fields will be validated by the client against the
-  #           specified resource name formats.
-  #       STATIC_TYPES: the client will use generated types for resource names.
   #   page_streaming - Specifies the configuration for paging.
   #       Describes information for generating a method which transforms a
   #       paging list RPC into a stream of resources.
@@ -12062,20 +10533,16 @@ interfaces:
     flattening:
       groups:
       - parameters:
-        - requestId
         - snapshot
     # TODO: Configure which fields are required.
     required_fields:
-    - requestId
     - snapshot
-    request_object_method: true
-    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      snapshot: snapshot
+      snapshot: projectGlobalSnapshot
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
   - name: compute.snapshots.get
@@ -12088,14 +10555,12 @@ interfaces:
     # TODO: Configure which fields are required.
     required_fields:
     - snapshot
-    request_object_method: true
-    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      snapshot: snapshot
+      snapshot: projectGlobalSnapshot
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
   - name: compute.snapshots.getIamPolicy
@@ -12108,14 +10573,12 @@ interfaces:
     # TODO: Configure which fields are required.
     required_fields:
     - resource
-    request_object_method: true
-    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      resource: snapshotsResource
+      resource: projectGlobalSnapshotResource
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
   - name: compute.snapshots.list
@@ -12128,15 +10591,13 @@ interfaces:
     # TODO: Configure which fields are required.
     required_fields:
     - project
-    request_object_method: true
-    resource_name_treatment: STATIC_TYPES
     page_streaming:
       request:
         page_size_field: maxResults
         token_field: pageToken
       response:
         token_field: nextPageToken
-        resources_field: SnapshotList
+        resources_field: items
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: idempotent
     # TODO: Configure the retryable params for this method.
@@ -12157,14 +10618,12 @@ interfaces:
     required_fields:
     - resource
     - globalSetPolicyRequestResource
-    request_object_method: true
-    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: non_idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      resource: snapshotsResource
+      resource: projectGlobalSnapshotResource
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
   - name: compute.snapshots.setLabels
@@ -12179,14 +10638,12 @@ interfaces:
     required_fields:
     - resource
     - globalSetLabelsRequestResource
-    request_object_method: true
-    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: non_idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      resource: snapshotsResource
+      resource: projectGlobalSnapshotResource
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
   - name: compute.snapshots.testIamPermissions
@@ -12201,17 +10658,15 @@ interfaces:
     required_fields:
     - resource
     - testPermissionsRequestResource
-    request_object_method: true
-    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: non_idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      resource: snapshotsResource
+      resource: projectGlobalSnapshotResource
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
-  # The fully qualified name of the API interface.
+# The fully qualified name of the API interface.
 - name: google.compute.v1.SslCertificates
   # A list of resource collection configurations.
   # Consists of a name_pattern and an entity_name.
@@ -12224,16 +10679,16 @@ interfaces:
   # The entity_name is the name to be used as a basis for generated methods and
   # classes.
   collections:
-  - name_pattern: projects/{project}
+  - name_pattern: '{project}'
     entity_name: project
-  - name_pattern: projects/{project}/sslCertificates/{sslCertificate}
-    entity_name: sslCertificate
+  - name_pattern: '{project}/global/sslCertificates/{sslCertificate}'
+    entity_name: projectGlobalSslCertificate
   # Definition for retryable codes.
   retry_codes_def:
   - name: idempotent
     retry_codes:
-    - SC_SERVICE_UNAVAILABLE
-    - SC_GATEWAY_TIMEOUT
+    - UNAVAILABLE
+    - DEADLINE_EXCEEDED
   - name: non_idempotent
     retry_codes: []
   # Definition for retry/backoff parameters.
@@ -12259,17 +10714,6 @@ interfaces:
   #       message.
   #   required_fields - Fields that are always required for a request to be
   #       valid.
-  #   request_object_method - Turns on or off the generation of a method whose
-  #       sole parameter is a request object. Not all languages will generate
-  #       this method.
-  #   resource_name_treatment - An enum that specifies how to treat the
-  #       resource name formats defined in the field_name_patterns
-  #       and response_field_name_patterns fields.
-  #       UNSET: default value
-  #       NONE: the collection configs will not be used by the generated code.
-  #       VALIDATE: string fields will be validated by the client against the
-  #           specified resource name formats.
-  #       STATIC_TYPES: the client will use generated types for resource names.
   #   page_streaming - Specifies the configuration for paging.
   #       Describes information for generating a method which transforms a
   #       paging list RPC into a stream of resources.
@@ -12304,19 +10748,15 @@ interfaces:
       groups:
       - parameters:
         - sslCertificate
-        - requestId
     # TODO: Configure which fields are required.
     required_fields:
     - sslCertificate
-    - requestId
-    request_object_method: true
-    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      sslCertificate: sslCertificate
+      sslCertificate: projectGlobalSslCertificate
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
   - name: compute.sslCertificates.get
@@ -12329,14 +10769,12 @@ interfaces:
     # TODO: Configure which fields are required.
     required_fields:
     - sslCertificate
-    request_object_method: true
-    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      sslCertificate: sslCertificate
+      sslCertificate: projectGlobalSslCertificate
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
   - name: compute.sslCertificates.insert
@@ -12345,16 +10783,12 @@ interfaces:
     flattening:
       groups:
       - parameters:
-        - requestId
         - project
         - sslCertificateResource
     # TODO: Configure which fields are required.
     required_fields:
-    - requestId
     - project
     - sslCertificateResource
-    request_object_method: true
-    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: non_idempotent
     # TODO: Configure the retryable params for this method.
@@ -12373,15 +10807,13 @@ interfaces:
     # TODO: Configure which fields are required.
     required_fields:
     - project
-    request_object_method: true
-    resource_name_treatment: STATIC_TYPES
     page_streaming:
       request:
         page_size_field: maxResults
         token_field: pageToken
       response:
         token_field: nextPageToken
-        resources_field: SslCertificateList
+        resources_field: items
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: idempotent
     # TODO: Configure the retryable params for this method.
@@ -12390,7 +10822,7 @@ interfaces:
       project: project
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
-  # The fully qualified name of the API interface.
+# The fully qualified name of the API interface.
 - name: google.compute.v1.SslPolicies
   # A list of resource collection configurations.
   # Consists of a name_pattern and an entity_name.
@@ -12403,16 +10835,16 @@ interfaces:
   # The entity_name is the name to be used as a basis for generated methods and
   # classes.
   collections:
-  - name_pattern: projects/{project}
+  - name_pattern: '{project}'
     entity_name: project
-  - name_pattern: projects/{project}/sslPolicies/{sslPolicy}
-    entity_name: sslPolicy
+  - name_pattern: '{project}/global/sslPolicies/{sslPolicy}'
+    entity_name: projectGlobalSslPolicy
   # Definition for retryable codes.
   retry_codes_def:
   - name: idempotent
     retry_codes:
-    - SC_SERVICE_UNAVAILABLE
-    - SC_GATEWAY_TIMEOUT
+    - UNAVAILABLE
+    - DEADLINE_EXCEEDED
   - name: non_idempotent
     retry_codes: []
   # Definition for retry/backoff parameters.
@@ -12438,17 +10870,6 @@ interfaces:
   #       message.
   #   required_fields - Fields that are always required for a request to be
   #       valid.
-  #   request_object_method - Turns on or off the generation of a method whose
-  #       sole parameter is a request object. Not all languages will generate
-  #       this method.
-  #   resource_name_treatment - An enum that specifies how to treat the
-  #       resource name formats defined in the field_name_patterns
-  #       and response_field_name_patterns fields.
-  #       UNSET: default value
-  #       NONE: the collection configs will not be used by the generated code.
-  #       VALIDATE: string fields will be validated by the client against the
-  #           specified resource name formats.
-  #       STATIC_TYPES: the client will use generated types for resource names.
   #   page_streaming - Specifies the configuration for paging.
   #       Describes information for generating a method which transforms a
   #       paging list RPC into a stream of resources.
@@ -12482,20 +10903,16 @@ interfaces:
     flattening:
       groups:
       - parameters:
-        - requestId
         - sslPolicy
     # TODO: Configure which fields are required.
     required_fields:
-    - requestId
     - sslPolicy
-    request_object_method: true
-    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      sslPolicy: sslPolicy
+      sslPolicy: projectGlobalSslPolicy
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
   - name: compute.sslPolicies.get
@@ -12508,14 +10925,12 @@ interfaces:
     # TODO: Configure which fields are required.
     required_fields:
     - sslPolicy
-    request_object_method: true
-    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      sslPolicy: sslPolicy
+      sslPolicy: projectGlobalSslPolicy
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
   - name: compute.sslPolicies.insert
@@ -12524,16 +10939,12 @@ interfaces:
     flattening:
       groups:
       - parameters:
-        - requestId
         - project
         - sslPolicyResource
     # TODO: Configure which fields are required.
     required_fields:
-    - requestId
     - project
     - sslPolicyResource
-    request_object_method: true
-    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: non_idempotent
     # TODO: Configure the retryable params for this method.
@@ -12552,15 +10963,13 @@ interfaces:
     # TODO: Configure which fields are required.
     required_fields:
     - project
-    request_object_method: true
-    resource_name_treatment: STATIC_TYPES
     page_streaming:
       request:
         page_size_field: maxResults
         token_field: pageToken
       response:
         token_field: nextPageToken
-        resources_field: SslPoliciesList
+        resources_field: items
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: idempotent
     # TODO: Configure the retryable params for this method.
@@ -12579,8 +10988,6 @@ interfaces:
     # TODO: Configure which fields are required.
     required_fields:
     - project
-    request_object_method: true
-    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: idempotent
     # TODO: Configure the retryable params for this method.
@@ -12595,25 +11002,21 @@ interfaces:
     flattening:
       groups:
       - parameters:
-        - requestId
         - sslPolicy
         - sslPolicyResource
     # TODO: Configure which fields are required.
     required_fields:
-    - requestId
     - sslPolicy
     - sslPolicyResource
-    request_object_method: true
-    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: non_idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      sslPolicy: sslPolicy
+      sslPolicy: projectGlobalSslPolicy
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
-  # The fully qualified name of the API interface.
+# The fully qualified name of the API interface.
 - name: google.compute.v1.Subnetworks
   # A list of resource collection configurations.
   # Consists of a name_pattern and an entity_name.
@@ -12626,20 +11029,20 @@ interfaces:
   # The entity_name is the name to be used as a basis for generated methods and
   # classes.
   collections:
-  - name_pattern: projects/{project}
+  - name_pattern: '{project}'
     entity_name: project
-  - name_pattern: projects/{project}/regions/{region}
-    entity_name: region
-  - name_pattern: projects/{project}/regions/{region}/subnetworks/{resource}
-    entity_name: subnetworksResource
-  - name_pattern: projects/{project}/regions/{region}/subnetworks/{subnetwork}
-    entity_name: subnetwork
+  - name_pattern: '{project}/regions/{region}'
+    entity_name: projectRegion
+  - name_pattern: '{project}/regions/{region}/subnetworks/{resource}'
+    entity_name: projectRegionSubnetworkResource
+  - name_pattern: '{project}/regions/{region}/subnetworks/{subnetwork}'
+    entity_name: projectRegionSubnetwork
   # Definition for retryable codes.
   retry_codes_def:
   - name: idempotent
     retry_codes:
-    - SC_SERVICE_UNAVAILABLE
-    - SC_GATEWAY_TIMEOUT
+    - UNAVAILABLE
+    - DEADLINE_EXCEEDED
   - name: non_idempotent
     retry_codes: []
   # Definition for retry/backoff parameters.
@@ -12665,17 +11068,6 @@ interfaces:
   #       message.
   #   required_fields - Fields that are always required for a request to be
   #       valid.
-  #   request_object_method - Turns on or off the generation of a method whose
-  #       sole parameter is a request object. Not all languages will generate
-  #       this method.
-  #   resource_name_treatment - An enum that specifies how to treat the
-  #       resource name formats defined in the field_name_patterns
-  #       and response_field_name_patterns fields.
-  #       UNSET: default value
-  #       NONE: the collection configs will not be used by the generated code.
-  #       VALIDATE: string fields will be validated by the client against the
-  #           specified resource name formats.
-  #       STATIC_TYPES: the client will use generated types for resource names.
   #   page_streaming - Specifies the configuration for paging.
   #       Describes information for generating a method which transforms a
   #       paging list RPC into a stream of resources.
@@ -12713,15 +11105,13 @@ interfaces:
     # TODO: Configure which fields are required.
     required_fields:
     - project
-    request_object_method: true
-    resource_name_treatment: STATIC_TYPES
     page_streaming:
       request:
         page_size_field: maxResults
         token_field: pageToken
       response:
         token_field: nextPageToken
-        resources_field: SubnetworkAggregatedList
+        resources_field: items
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: idempotent
     # TODO: Configure the retryable params for this method.
@@ -12736,20 +11126,16 @@ interfaces:
     flattening:
       groups:
       - parameters:
-        - requestId
         - subnetwork
     # TODO: Configure which fields are required.
     required_fields:
-    - requestId
     - subnetwork
-    request_object_method: true
-    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      subnetwork: subnetwork
+      subnetwork: projectRegionSubnetwork
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
   - name: compute.subnetworks.expandIpCidrRange
@@ -12758,22 +11144,18 @@ interfaces:
     flattening:
       groups:
       - parameters:
-        - requestId
         - subnetwork
         - subnetworksExpandIpCidrRangeRequestResource
     # TODO: Configure which fields are required.
     required_fields:
-    - requestId
     - subnetwork
     - subnetworksExpandIpCidrRangeRequestResource
-    request_object_method: true
-    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: non_idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      subnetwork: subnetwork
+      subnetwork: projectRegionSubnetwork
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
   - name: compute.subnetworks.get
@@ -12786,14 +11168,12 @@ interfaces:
     # TODO: Configure which fields are required.
     required_fields:
     - subnetwork
-    request_object_method: true
-    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      subnetwork: subnetwork
+      subnetwork: projectRegionSubnetwork
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
   - name: compute.subnetworks.getIamPolicy
@@ -12806,14 +11186,12 @@ interfaces:
     # TODO: Configure which fields are required.
     required_fields:
     - resource
-    request_object_method: true
-    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      resource: subnetworksResource
+      resource: projectRegionSubnetworkResource
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
   - name: compute.subnetworks.insert
@@ -12822,22 +11200,18 @@ interfaces:
     flattening:
       groups:
       - parameters:
-        - requestId
         - region
         - subnetworkResource
     # TODO: Configure which fields are required.
     required_fields:
-    - requestId
     - region
     - subnetworkResource
-    request_object_method: true
-    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: non_idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      region: region
+      region: projectRegion
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
   - name: compute.subnetworks.list
@@ -12850,21 +11224,19 @@ interfaces:
     # TODO: Configure which fields are required.
     required_fields:
     - region
-    request_object_method: true
-    resource_name_treatment: STATIC_TYPES
     page_streaming:
       request:
         page_size_field: maxResults
         token_field: pageToken
       response:
         token_field: nextPageToken
-        resources_field: SubnetworkList
+        resources_field: items
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      region: region
+      region: projectRegion
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
   - name: compute.subnetworks.listUsable
@@ -12877,15 +11249,13 @@ interfaces:
     # TODO: Configure which fields are required.
     required_fields:
     - project
-    request_object_method: true
-    resource_name_treatment: STATIC_TYPES
     page_streaming:
       request:
         page_size_field: maxResults
         token_field: pageToken
       response:
         token_field: nextPageToken
-        resources_field: UsableSubnetworksAggregatedList
+        resources_field: items
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: idempotent
     # TODO: Configure the retryable params for this method.
@@ -12900,22 +11270,18 @@ interfaces:
     flattening:
       groups:
       - parameters:
-        - requestId
         - subnetwork
         - subnetworkResource
     # TODO: Configure which fields are required.
     required_fields:
-    - requestId
     - subnetwork
     - subnetworkResource
-    request_object_method: true
-    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: non_idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      subnetwork: subnetwork
+      subnetwork: projectRegionSubnetwork
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
   - name: compute.subnetworks.setIamPolicy
@@ -12930,14 +11296,12 @@ interfaces:
     required_fields:
     - resource
     - regionSetPolicyRequestResource
-    request_object_method: true
-    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: non_idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      resource: subnetworksResource
+      resource: projectRegionSubnetworkResource
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
   - name: compute.subnetworks.setPrivateIpGoogleAccess
@@ -12946,22 +11310,18 @@ interfaces:
     flattening:
       groups:
       - parameters:
-        - requestId
         - subnetwork
         - subnetworksSetPrivateIpGoogleAccessRequestResource
     # TODO: Configure which fields are required.
     required_fields:
-    - requestId
     - subnetwork
     - subnetworksSetPrivateIpGoogleAccessRequestResource
-    request_object_method: true
-    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: non_idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      subnetwork: subnetwork
+      subnetwork: projectRegionSubnetwork
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
   - name: compute.subnetworks.testIamPermissions
@@ -12976,17 +11336,15 @@ interfaces:
     required_fields:
     - resource
     - testPermissionsRequestResource
-    request_object_method: true
-    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: non_idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      resource: subnetworksResource
+      resource: projectRegionSubnetworkResource
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
-  # The fully qualified name of the API interface.
+# The fully qualified name of the API interface.
 - name: google.compute.v1.TargetHttpProxies
   # A list of resource collection configurations.
   # Consists of a name_pattern and an entity_name.
@@ -12999,16 +11357,18 @@ interfaces:
   # The entity_name is the name to be used as a basis for generated methods and
   # classes.
   collections:
-  - name_pattern: projects/{project}
+  - name_pattern: '{project}'
     entity_name: project
-  - name_pattern: projects/{project}/targetHttpProxies/{targetHttpProxy}
-    entity_name: targetHttpProxy
+  - name_pattern: '{project}/global/targetHttpProxies/{targetHttpProxy}'
+    entity_name: projectGlobalTargetHttpProxy
+  - name_pattern: '{project}/targetHttpProxies/{targetHttpProxy}'
+    entity_name: projectTargetHttpProxy
   # Definition for retryable codes.
   retry_codes_def:
   - name: idempotent
     retry_codes:
-    - SC_SERVICE_UNAVAILABLE
-    - SC_GATEWAY_TIMEOUT
+    - UNAVAILABLE
+    - DEADLINE_EXCEEDED
   - name: non_idempotent
     retry_codes: []
   # Definition for retry/backoff parameters.
@@ -13034,17 +11394,6 @@ interfaces:
   #       message.
   #   required_fields - Fields that are always required for a request to be
   #       valid.
-  #   request_object_method - Turns on or off the generation of a method whose
-  #       sole parameter is a request object. Not all languages will generate
-  #       this method.
-  #   resource_name_treatment - An enum that specifies how to treat the
-  #       resource name formats defined in the field_name_patterns
-  #       and response_field_name_patterns fields.
-  #       UNSET: default value
-  #       NONE: the collection configs will not be used by the generated code.
-  #       VALIDATE: string fields will be validated by the client against the
-  #           specified resource name formats.
-  #       STATIC_TYPES: the client will use generated types for resource names.
   #   page_streaming - Specifies the configuration for paging.
   #       Describes information for generating a method which transforms a
   #       paging list RPC into a stream of resources.
@@ -13078,20 +11427,16 @@ interfaces:
     flattening:
       groups:
       - parameters:
-        - requestId
         - targetHttpProxy
     # TODO: Configure which fields are required.
     required_fields:
-    - requestId
     - targetHttpProxy
-    request_object_method: true
-    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      targetHttpProxy: targetHttpProxy
+      targetHttpProxy: projectGlobalTargetHttpProxy
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
   - name: compute.targetHttpProxies.get
@@ -13104,14 +11449,12 @@ interfaces:
     # TODO: Configure which fields are required.
     required_fields:
     - targetHttpProxy
-    request_object_method: true
-    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      targetHttpProxy: targetHttpProxy
+      targetHttpProxy: projectGlobalTargetHttpProxy
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
   - name: compute.targetHttpProxies.insert
@@ -13120,16 +11463,12 @@ interfaces:
     flattening:
       groups:
       - parameters:
-        - requestId
         - project
         - targetHttpProxyResource
     # TODO: Configure which fields are required.
     required_fields:
-    - requestId
     - project
     - targetHttpProxyResource
-    request_object_method: true
-    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: non_idempotent
     # TODO: Configure the retryable params for this method.
@@ -13148,15 +11487,13 @@ interfaces:
     # TODO: Configure which fields are required.
     required_fields:
     - project
-    request_object_method: true
-    resource_name_treatment: STATIC_TYPES
     page_streaming:
       request:
         page_size_field: maxResults
         token_field: pageToken
       response:
         token_field: nextPageToken
-        resources_field: TargetHttpProxyList
+        resources_field: items
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: idempotent
     # TODO: Configure the retryable params for this method.
@@ -13171,25 +11508,21 @@ interfaces:
     flattening:
       groups:
       - parameters:
-        - requestId
         - targetHttpProxy
         - urlMapReferenceResource
     # TODO: Configure which fields are required.
     required_fields:
-    - requestId
     - targetHttpProxy
     - urlMapReferenceResource
-    request_object_method: true
-    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: non_idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      targetHttpProxy: targetHttpProxy
+      targetHttpProxy: projectTargetHttpProxy
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
-  # The fully qualified name of the API interface.
+# The fully qualified name of the API interface.
 - name: google.compute.v1.TargetHttpsProxies
   # A list of resource collection configurations.
   # Consists of a name_pattern and an entity_name.
@@ -13202,16 +11535,18 @@ interfaces:
   # The entity_name is the name to be used as a basis for generated methods and
   # classes.
   collections:
-  - name_pattern: projects/{project}
+  - name_pattern: '{project}'
     entity_name: project
-  - name_pattern: projects/{project}/targetHttpsProxies/{targetHttpsProxy}
-    entity_name: targetHttpsProxy
+  - name_pattern: '{project}/global/targetHttpsProxies/{targetHttpsProxy}'
+    entity_name: projectGlobalTargetHttpsProxy
+  - name_pattern: '{project}/targetHttpsProxies/{targetHttpsProxy}'
+    entity_name: projectTargetHttpsProxy
   # Definition for retryable codes.
   retry_codes_def:
   - name: idempotent
     retry_codes:
-    - SC_SERVICE_UNAVAILABLE
-    - SC_GATEWAY_TIMEOUT
+    - UNAVAILABLE
+    - DEADLINE_EXCEEDED
   - name: non_idempotent
     retry_codes: []
   # Definition for retry/backoff parameters.
@@ -13237,17 +11572,6 @@ interfaces:
   #       message.
   #   required_fields - Fields that are always required for a request to be
   #       valid.
-  #   request_object_method - Turns on or off the generation of a method whose
-  #       sole parameter is a request object. Not all languages will generate
-  #       this method.
-  #   resource_name_treatment - An enum that specifies how to treat the
-  #       resource name formats defined in the field_name_patterns
-  #       and response_field_name_patterns fields.
-  #       UNSET: default value
-  #       NONE: the collection configs will not be used by the generated code.
-  #       VALIDATE: string fields will be validated by the client against the
-  #           specified resource name formats.
-  #       STATIC_TYPES: the client will use generated types for resource names.
   #   page_streaming - Specifies the configuration for paging.
   #       Describes information for generating a method which transforms a
   #       paging list RPC into a stream of resources.
@@ -13282,19 +11606,15 @@ interfaces:
       groups:
       - parameters:
         - targetHttpsProxy
-        - requestId
     # TODO: Configure which fields are required.
     required_fields:
     - targetHttpsProxy
-    - requestId
-    request_object_method: true
-    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      targetHttpsProxy: targetHttpsProxy
+      targetHttpsProxy: projectGlobalTargetHttpsProxy
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
   - name: compute.targetHttpsProxies.get
@@ -13307,14 +11627,12 @@ interfaces:
     # TODO: Configure which fields are required.
     required_fields:
     - targetHttpsProxy
-    request_object_method: true
-    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      targetHttpsProxy: targetHttpsProxy
+      targetHttpsProxy: projectGlobalTargetHttpsProxy
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
   - name: compute.targetHttpsProxies.insert
@@ -13323,16 +11641,12 @@ interfaces:
     flattening:
       groups:
       - parameters:
-        - requestId
         - project
         - targetHttpsProxyResource
     # TODO: Configure which fields are required.
     required_fields:
-    - requestId
     - project
     - targetHttpsProxyResource
-    request_object_method: true
-    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: non_idempotent
     # TODO: Configure the retryable params for this method.
@@ -13351,15 +11665,13 @@ interfaces:
     # TODO: Configure which fields are required.
     required_fields:
     - project
-    request_object_method: true
-    resource_name_treatment: STATIC_TYPES
     page_streaming:
       request:
         page_size_field: maxResults
         token_field: pageToken
       response:
         token_field: nextPageToken
-        resources_field: TargetHttpsProxyList
+        resources_field: items
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: idempotent
     # TODO: Configure the retryable params for this method.
@@ -13375,21 +11687,17 @@ interfaces:
       groups:
       - parameters:
         - targetHttpsProxy
-        - requestId
         - targetHttpsProxiesSetQuicOverrideRequestResource
     # TODO: Configure which fields are required.
     required_fields:
     - targetHttpsProxy
-    - requestId
     - targetHttpsProxiesSetQuicOverrideRequestResource
-    request_object_method: true
-    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: non_idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      targetHttpsProxy: targetHttpsProxy
+      targetHttpsProxy: projectGlobalTargetHttpsProxy
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
   - name: compute.targetHttpsProxies.setSslCertificates
@@ -13399,21 +11707,17 @@ interfaces:
       groups:
       - parameters:
         - targetHttpsProxy
-        - requestId
         - targetHttpsProxiesSetSslCertificatesRequestResource
     # TODO: Configure which fields are required.
     required_fields:
     - targetHttpsProxy
-    - requestId
     - targetHttpsProxiesSetSslCertificatesRequestResource
-    request_object_method: true
-    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: non_idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      targetHttpsProxy: targetHttpsProxy
+      targetHttpsProxy: projectTargetHttpsProxy
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
   - name: compute.targetHttpsProxies.setSslPolicy
@@ -13423,21 +11727,17 @@ interfaces:
       groups:
       - parameters:
         - targetHttpsProxy
-        - requestId
         - sslPolicyReferenceResource
     # TODO: Configure which fields are required.
     required_fields:
     - targetHttpsProxy
-    - requestId
     - sslPolicyReferenceResource
-    request_object_method: true
-    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: non_idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      targetHttpsProxy: targetHttpsProxy
+      targetHttpsProxy: projectGlobalTargetHttpsProxy
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
   - name: compute.targetHttpsProxies.setUrlMap
@@ -13447,24 +11747,20 @@ interfaces:
       groups:
       - parameters:
         - targetHttpsProxy
-        - requestId
         - urlMapReferenceResource
     # TODO: Configure which fields are required.
     required_fields:
     - targetHttpsProxy
-    - requestId
     - urlMapReferenceResource
-    request_object_method: true
-    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: non_idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      targetHttpsProxy: targetHttpsProxy
+      targetHttpsProxy: projectTargetHttpsProxy
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
-  # The fully qualified name of the API interface.
+# The fully qualified name of the API interface.
 - name: google.compute.v1.TargetInstances
   # A list of resource collection configurations.
   # Consists of a name_pattern and an entity_name.
@@ -13477,18 +11773,18 @@ interfaces:
   # The entity_name is the name to be used as a basis for generated methods and
   # classes.
   collections:
-  - name_pattern: projects/{project}
+  - name_pattern: '{project}'
     entity_name: project
-  - name_pattern: projects/{project}/zones/{zone}
-    entity_name: zone
-  - name_pattern: projects/{project}/zones/{zone}/targetInstances/{targetInstance}
-    entity_name: targetInstance
+  - name_pattern: '{project}/zones/{zone}'
+    entity_name: projectZone
+  - name_pattern: '{project}/zones/{zone}/targetInstances/{targetInstance}'
+    entity_name: projectZoneTargetInstance
   # Definition for retryable codes.
   retry_codes_def:
   - name: idempotent
     retry_codes:
-    - SC_SERVICE_UNAVAILABLE
-    - SC_GATEWAY_TIMEOUT
+    - UNAVAILABLE
+    - DEADLINE_EXCEEDED
   - name: non_idempotent
     retry_codes: []
   # Definition for retry/backoff parameters.
@@ -13514,17 +11810,6 @@ interfaces:
   #       message.
   #   required_fields - Fields that are always required for a request to be
   #       valid.
-  #   request_object_method - Turns on or off the generation of a method whose
-  #       sole parameter is a request object. Not all languages will generate
-  #       this method.
-  #   resource_name_treatment - An enum that specifies how to treat the
-  #       resource name formats defined in the field_name_patterns
-  #       and response_field_name_patterns fields.
-  #       UNSET: default value
-  #       NONE: the collection configs will not be used by the generated code.
-  #       VALIDATE: string fields will be validated by the client against the
-  #           specified resource name formats.
-  #       STATIC_TYPES: the client will use generated types for resource names.
   #   page_streaming - Specifies the configuration for paging.
   #       Describes information for generating a method which transforms a
   #       paging list RPC into a stream of resources.
@@ -13562,15 +11847,13 @@ interfaces:
     # TODO: Configure which fields are required.
     required_fields:
     - project
-    request_object_method: true
-    resource_name_treatment: STATIC_TYPES
     page_streaming:
       request:
         page_size_field: maxResults
         token_field: pageToken
       response:
         token_field: nextPageToken
-        resources_field: TargetInstanceAggregatedList
+        resources_field: items
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: idempotent
     # TODO: Configure the retryable params for this method.
@@ -13585,20 +11868,16 @@ interfaces:
     flattening:
       groups:
       - parameters:
-        - requestId
         - targetInstance
     # TODO: Configure which fields are required.
     required_fields:
-    - requestId
     - targetInstance
-    request_object_method: true
-    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      targetInstance: targetInstance
+      targetInstance: projectZoneTargetInstance
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
   - name: compute.targetInstances.get
@@ -13611,14 +11890,12 @@ interfaces:
     # TODO: Configure which fields are required.
     required_fields:
     - targetInstance
-    request_object_method: true
-    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      targetInstance: targetInstance
+      targetInstance: projectZoneTargetInstance
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
   - name: compute.targetInstances.insert
@@ -13628,21 +11905,17 @@ interfaces:
       groups:
       - parameters:
         - zone
-        - requestId
         - targetInstanceResource
     # TODO: Configure which fields are required.
     required_fields:
     - zone
-    - requestId
     - targetInstanceResource
-    request_object_method: true
-    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: non_idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      zone: zone
+      zone: projectZone
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
   - name: compute.targetInstances.list
@@ -13655,24 +11928,22 @@ interfaces:
     # TODO: Configure which fields are required.
     required_fields:
     - zone
-    request_object_method: true
-    resource_name_treatment: STATIC_TYPES
     page_streaming:
       request:
         page_size_field: maxResults
         token_field: pageToken
       response:
         token_field: nextPageToken
-        resources_field: TargetInstanceList
+        resources_field: items
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      zone: zone
+      zone: projectZone
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
-  # The fully qualified name of the API interface.
+# The fully qualified name of the API interface.
 - name: google.compute.v1.TargetPools
   # A list of resource collection configurations.
   # Consists of a name_pattern and an entity_name.
@@ -13685,18 +11956,18 @@ interfaces:
   # The entity_name is the name to be used as a basis for generated methods and
   # classes.
   collections:
-  - name_pattern: projects/{project}
+  - name_pattern: '{project}'
     entity_name: project
-  - name_pattern: projects/{project}/regions/{region}
-    entity_name: region
-  - name_pattern: projects/{project}/regions/{region}/targetPools/{targetPool}
-    entity_name: targetPool
+  - name_pattern: '{project}/regions/{region}'
+    entity_name: projectRegion
+  - name_pattern: '{project}/regions/{region}/targetPools/{targetPool}'
+    entity_name: projectRegionTargetPool
   # Definition for retryable codes.
   retry_codes_def:
   - name: idempotent
     retry_codes:
-    - SC_SERVICE_UNAVAILABLE
-    - SC_GATEWAY_TIMEOUT
+    - UNAVAILABLE
+    - DEADLINE_EXCEEDED
   - name: non_idempotent
     retry_codes: []
   # Definition for retry/backoff parameters.
@@ -13722,17 +11993,6 @@ interfaces:
   #       message.
   #   required_fields - Fields that are always required for a request to be
   #       valid.
-  #   request_object_method - Turns on or off the generation of a method whose
-  #       sole parameter is a request object. Not all languages will generate
-  #       this method.
-  #   resource_name_treatment - An enum that specifies how to treat the
-  #       resource name formats defined in the field_name_patterns
-  #       and response_field_name_patterns fields.
-  #       UNSET: default value
-  #       NONE: the collection configs will not be used by the generated code.
-  #       VALIDATE: string fields will be validated by the client against the
-  #           specified resource name formats.
-  #       STATIC_TYPES: the client will use generated types for resource names.
   #   page_streaming - Specifies the configuration for paging.
   #       Describes information for generating a method which transforms a
   #       paging list RPC into a stream of resources.
@@ -13767,21 +12027,17 @@ interfaces:
       groups:
       - parameters:
         - targetPool
-        - requestId
         - targetPoolsAddHealthCheckRequestResource
     # TODO: Configure which fields are required.
     required_fields:
     - targetPool
-    - requestId
     - targetPoolsAddHealthCheckRequestResource
-    request_object_method: true
-    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: non_idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      targetPool: targetPool
+      targetPool: projectRegionTargetPool
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
   - name: compute.targetPools.addInstance
@@ -13791,21 +12047,17 @@ interfaces:
       groups:
       - parameters:
         - targetPool
-        - requestId
         - targetPoolsAddInstanceRequestResource
     # TODO: Configure which fields are required.
     required_fields:
     - targetPool
-    - requestId
     - targetPoolsAddInstanceRequestResource
-    request_object_method: true
-    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: non_idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      targetPool: targetPool
+      targetPool: projectRegionTargetPool
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
   - name: compute.targetPools.aggregatedList
@@ -13818,15 +12070,13 @@ interfaces:
     # TODO: Configure which fields are required.
     required_fields:
     - project
-    request_object_method: true
-    resource_name_treatment: STATIC_TYPES
     page_streaming:
       request:
         page_size_field: maxResults
         token_field: pageToken
       response:
         token_field: nextPageToken
-        resources_field: TargetPoolAggregatedList
+        resources_field: items
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: idempotent
     # TODO: Configure the retryable params for this method.
@@ -13842,19 +12092,15 @@ interfaces:
       groups:
       - parameters:
         - targetPool
-        - requestId
     # TODO: Configure which fields are required.
     required_fields:
     - targetPool
-    - requestId
-    request_object_method: true
-    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      targetPool: targetPool
+      targetPool: projectRegionTargetPool
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
   - name: compute.targetPools.get
@@ -13867,14 +12113,12 @@ interfaces:
     # TODO: Configure which fields are required.
     required_fields:
     - targetPool
-    request_object_method: true
-    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      targetPool: targetPool
+      targetPool: projectRegionTargetPool
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
   - name: compute.targetPools.getHealth
@@ -13889,14 +12133,12 @@ interfaces:
     required_fields:
     - targetPool
     - instanceReferenceResource
-    request_object_method: true
-    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: non_idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      targetPool: targetPool
+      targetPool: projectRegionTargetPool
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
   - name: compute.targetPools.insert
@@ -13905,22 +12147,16 @@ interfaces:
     flattening:
       groups:
       - parameters:
-        - requestId
         - region
-        - targetPoolResource
     # TODO: Configure which fields are required.
     required_fields:
-    - requestId
     - region
-    - targetPoolResource
-    request_object_method: true
-    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: non_idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      region: region
+      region: projectRegion
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
   - name: compute.targetPools.list
@@ -13933,21 +12169,19 @@ interfaces:
     # TODO: Configure which fields are required.
     required_fields:
     - region
-    request_object_method: true
-    resource_name_treatment: STATIC_TYPES
     page_streaming:
       request:
         page_size_field: maxResults
         token_field: pageToken
       response:
         token_field: nextPageToken
-        resources_field: TargetPoolList
+        resources_field: items
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      region: region
+      region: projectRegion
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
   - name: compute.targetPools.removeHealthCheck
@@ -13957,21 +12191,17 @@ interfaces:
       groups:
       - parameters:
         - targetPool
-        - requestId
         - targetPoolsRemoveHealthCheckRequestResource
     # TODO: Configure which fields are required.
     required_fields:
     - targetPool
-    - requestId
     - targetPoolsRemoveHealthCheckRequestResource
-    request_object_method: true
-    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: non_idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      targetPool: targetPool
+      targetPool: projectRegionTargetPool
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
   - name: compute.targetPools.removeInstance
@@ -13981,21 +12211,17 @@ interfaces:
       groups:
       - parameters:
         - targetPool
-        - requestId
         - targetPoolsRemoveInstanceRequestResource
     # TODO: Configure which fields are required.
     required_fields:
     - targetPool
-    - requestId
     - targetPoolsRemoveInstanceRequestResource
-    request_object_method: true
-    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: non_idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      targetPool: targetPool
+      targetPool: projectRegionTargetPool
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
   - name: compute.targetPools.setBackup
@@ -14005,26 +12231,22 @@ interfaces:
       groups:
       - parameters:
         - targetPool
-        - requestId
         - failoverRatio
         - targetReferenceResource
     # TODO: Configure which fields are required.
     required_fields:
     - targetPool
-    - requestId
     - failoverRatio
     - targetReferenceResource
-    request_object_method: true
-    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: non_idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      targetPool: targetPool
+      targetPool: projectRegionTargetPool
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
-  # The fully qualified name of the API interface.
+# The fully qualified name of the API interface.
 - name: google.compute.v1.TargetSslProxies
   # A list of resource collection configurations.
   # Consists of a name_pattern and an entity_name.
@@ -14037,16 +12259,16 @@ interfaces:
   # The entity_name is the name to be used as a basis for generated methods and
   # classes.
   collections:
-  - name_pattern: projects/{project}
+  - name_pattern: '{project}'
     entity_name: project
-  - name_pattern: projects/{project}/targetSslProxies/{targetSslProxy}
-    entity_name: targetSslProxy
+  - name_pattern: '{project}/global/targetSslProxies/{targetSslProxy}'
+    entity_name: projectGlobalTargetSslProxy
   # Definition for retryable codes.
   retry_codes_def:
   - name: idempotent
     retry_codes:
-    - SC_SERVICE_UNAVAILABLE
-    - SC_GATEWAY_TIMEOUT
+    - UNAVAILABLE
+    - DEADLINE_EXCEEDED
   - name: non_idempotent
     retry_codes: []
   # Definition for retry/backoff parameters.
@@ -14072,17 +12294,6 @@ interfaces:
   #       message.
   #   required_fields - Fields that are always required for a request to be
   #       valid.
-  #   request_object_method - Turns on or off the generation of a method whose
-  #       sole parameter is a request object. Not all languages will generate
-  #       this method.
-  #   resource_name_treatment - An enum that specifies how to treat the
-  #       resource name formats defined in the field_name_patterns
-  #       and response_field_name_patterns fields.
-  #       UNSET: default value
-  #       NONE: the collection configs will not be used by the generated code.
-  #       VALIDATE: string fields will be validated by the client against the
-  #           specified resource name formats.
-  #       STATIC_TYPES: the client will use generated types for resource names.
   #   page_streaming - Specifies the configuration for paging.
   #       Describes information for generating a method which transforms a
   #       paging list RPC into a stream of resources.
@@ -14117,19 +12328,15 @@ interfaces:
       groups:
       - parameters:
         - targetSslProxy
-        - requestId
     # TODO: Configure which fields are required.
     required_fields:
     - targetSslProxy
-    - requestId
-    request_object_method: true
-    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      targetSslProxy: targetSslProxy
+      targetSslProxy: projectGlobalTargetSslProxy
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
   - name: compute.targetSslProxies.get
@@ -14142,14 +12349,12 @@ interfaces:
     # TODO: Configure which fields are required.
     required_fields:
     - targetSslProxy
-    request_object_method: true
-    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      targetSslProxy: targetSslProxy
+      targetSslProxy: projectGlobalTargetSslProxy
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
   - name: compute.targetSslProxies.insert
@@ -14158,16 +12363,12 @@ interfaces:
     flattening:
       groups:
       - parameters:
-        - requestId
         - project
         - targetSslProxyResource
     # TODO: Configure which fields are required.
     required_fields:
-    - requestId
     - project
     - targetSslProxyResource
-    request_object_method: true
-    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: non_idempotent
     # TODO: Configure the retryable params for this method.
@@ -14186,15 +12387,13 @@ interfaces:
     # TODO: Configure which fields are required.
     required_fields:
     - project
-    request_object_method: true
-    resource_name_treatment: STATIC_TYPES
     page_streaming:
       request:
         page_size_field: maxResults
         token_field: pageToken
       response:
         token_field: nextPageToken
-        resources_field: TargetSslProxyList
+        resources_field: items
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: idempotent
     # TODO: Configure the retryable params for this method.
@@ -14210,21 +12409,17 @@ interfaces:
       groups:
       - parameters:
         - targetSslProxy
-        - requestId
         - targetSslProxiesSetBackendServiceRequestResource
     # TODO: Configure which fields are required.
     required_fields:
     - targetSslProxy
-    - requestId
     - targetSslProxiesSetBackendServiceRequestResource
-    request_object_method: true
-    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: non_idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      targetSslProxy: targetSslProxy
+      targetSslProxy: projectGlobalTargetSslProxy
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
   - name: compute.targetSslProxies.setProxyHeader
@@ -14234,21 +12429,17 @@ interfaces:
       groups:
       - parameters:
         - targetSslProxy
-        - requestId
         - targetSslProxiesSetProxyHeaderRequestResource
     # TODO: Configure which fields are required.
     required_fields:
     - targetSslProxy
-    - requestId
     - targetSslProxiesSetProxyHeaderRequestResource
-    request_object_method: true
-    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: non_idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      targetSslProxy: targetSslProxy
+      targetSslProxy: projectGlobalTargetSslProxy
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
   - name: compute.targetSslProxies.setSslCertificates
@@ -14258,21 +12449,17 @@ interfaces:
       groups:
       - parameters:
         - targetSslProxy
-        - requestId
         - targetSslProxiesSetSslCertificatesRequestResource
     # TODO: Configure which fields are required.
     required_fields:
     - targetSslProxy
-    - requestId
     - targetSslProxiesSetSslCertificatesRequestResource
-    request_object_method: true
-    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: non_idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      targetSslProxy: targetSslProxy
+      targetSslProxy: projectGlobalTargetSslProxy
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
   - name: compute.targetSslProxies.setSslPolicy
@@ -14282,24 +12469,20 @@ interfaces:
       groups:
       - parameters:
         - targetSslProxy
-        - requestId
         - sslPolicyReferenceResource
     # TODO: Configure which fields are required.
     required_fields:
     - targetSslProxy
-    - requestId
     - sslPolicyReferenceResource
-    request_object_method: true
-    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: non_idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      targetSslProxy: targetSslProxy
+      targetSslProxy: projectGlobalTargetSslProxy
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
-  # The fully qualified name of the API interface.
+# The fully qualified name of the API interface.
 - name: google.compute.v1.TargetTcpProxies
   # A list of resource collection configurations.
   # Consists of a name_pattern and an entity_name.
@@ -14312,16 +12495,16 @@ interfaces:
   # The entity_name is the name to be used as a basis for generated methods and
   # classes.
   collections:
-  - name_pattern: projects/{project}
+  - name_pattern: '{project}'
     entity_name: project
-  - name_pattern: projects/{project}/targetTcpProxies/{targetTcpProxy}
-    entity_name: targetTcpProxy
+  - name_pattern: '{project}/global/targetTcpProxies/{targetTcpProxy}'
+    entity_name: projectGlobalTargetTcpProxy
   # Definition for retryable codes.
   retry_codes_def:
   - name: idempotent
     retry_codes:
-    - SC_SERVICE_UNAVAILABLE
-    - SC_GATEWAY_TIMEOUT
+    - UNAVAILABLE
+    - DEADLINE_EXCEEDED
   - name: non_idempotent
     retry_codes: []
   # Definition for retry/backoff parameters.
@@ -14347,17 +12530,6 @@ interfaces:
   #       message.
   #   required_fields - Fields that are always required for a request to be
   #       valid.
-  #   request_object_method - Turns on or off the generation of a method whose
-  #       sole parameter is a request object. Not all languages will generate
-  #       this method.
-  #   resource_name_treatment - An enum that specifies how to treat the
-  #       resource name formats defined in the field_name_patterns
-  #       and response_field_name_patterns fields.
-  #       UNSET: default value
-  #       NONE: the collection configs will not be used by the generated code.
-  #       VALIDATE: string fields will be validated by the client against the
-  #           specified resource name formats.
-  #       STATIC_TYPES: the client will use generated types for resource names.
   #   page_streaming - Specifies the configuration for paging.
   #       Describes information for generating a method which transforms a
   #       paging list RPC into a stream of resources.
@@ -14391,20 +12563,16 @@ interfaces:
     flattening:
       groups:
       - parameters:
-        - requestId
         - targetTcpProxy
     # TODO: Configure which fields are required.
     required_fields:
-    - requestId
     - targetTcpProxy
-    request_object_method: true
-    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      targetTcpProxy: targetTcpProxy
+      targetTcpProxy: projectGlobalTargetTcpProxy
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
   - name: compute.targetTcpProxies.get
@@ -14417,14 +12585,12 @@ interfaces:
     # TODO: Configure which fields are required.
     required_fields:
     - targetTcpProxy
-    request_object_method: true
-    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      targetTcpProxy: targetTcpProxy
+      targetTcpProxy: projectGlobalTargetTcpProxy
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
   - name: compute.targetTcpProxies.insert
@@ -14433,16 +12599,12 @@ interfaces:
     flattening:
       groups:
       - parameters:
-        - requestId
         - project
         - targetTcpProxyResource
     # TODO: Configure which fields are required.
     required_fields:
-    - requestId
     - project
     - targetTcpProxyResource
-    request_object_method: true
-    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: non_idempotent
     # TODO: Configure the retryable params for this method.
@@ -14461,15 +12623,13 @@ interfaces:
     # TODO: Configure which fields are required.
     required_fields:
     - project
-    request_object_method: true
-    resource_name_treatment: STATIC_TYPES
     page_streaming:
       request:
         page_size_field: maxResults
         token_field: pageToken
       response:
         token_field: nextPageToken
-        resources_field: TargetTcpProxyList
+        resources_field: items
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: idempotent
     # TODO: Configure the retryable params for this method.
@@ -14484,22 +12644,18 @@ interfaces:
     flattening:
       groups:
       - parameters:
-        - requestId
         - targetTcpProxy
         - targetTcpProxiesSetBackendServiceRequestResource
     # TODO: Configure which fields are required.
     required_fields:
-    - requestId
     - targetTcpProxy
     - targetTcpProxiesSetBackendServiceRequestResource
-    request_object_method: true
-    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: non_idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      targetTcpProxy: targetTcpProxy
+      targetTcpProxy: projectGlobalTargetTcpProxy
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
   - name: compute.targetTcpProxies.setProxyHeader
@@ -14508,25 +12664,21 @@ interfaces:
     flattening:
       groups:
       - parameters:
-        - requestId
         - targetTcpProxy
         - targetTcpProxiesSetProxyHeaderRequestResource
     # TODO: Configure which fields are required.
     required_fields:
-    - requestId
     - targetTcpProxy
     - targetTcpProxiesSetProxyHeaderRequestResource
-    request_object_method: true
-    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: non_idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      targetTcpProxy: targetTcpProxy
+      targetTcpProxy: projectGlobalTargetTcpProxy
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
-  # The fully qualified name of the API interface.
+# The fully qualified name of the API interface.
 - name: google.compute.v1.TargetVpnGateways
   # A list of resource collection configurations.
   # Consists of a name_pattern and an entity_name.
@@ -14539,18 +12691,18 @@ interfaces:
   # The entity_name is the name to be used as a basis for generated methods and
   # classes.
   collections:
-  - name_pattern: projects/{project}
+  - name_pattern: '{project}'
     entity_name: project
-  - name_pattern: projects/{project}/regions/{region}
-    entity_name: region
-  - name_pattern: projects/{project}/regions/{region}/targetVpnGateways/{targetVpnGateway}
-    entity_name: targetVpnGateway
+  - name_pattern: '{project}/regions/{region}'
+    entity_name: projectRegion
+  - name_pattern: '{project}/regions/{region}/targetVpnGateways/{targetVpnGateway}'
+    entity_name: projectRegionTargetVpnGateway
   # Definition for retryable codes.
   retry_codes_def:
   - name: idempotent
     retry_codes:
-    - SC_SERVICE_UNAVAILABLE
-    - SC_GATEWAY_TIMEOUT
+    - UNAVAILABLE
+    - DEADLINE_EXCEEDED
   - name: non_idempotent
     retry_codes: []
   # Definition for retry/backoff parameters.
@@ -14576,17 +12728,6 @@ interfaces:
   #       message.
   #   required_fields - Fields that are always required for a request to be
   #       valid.
-  #   request_object_method - Turns on or off the generation of a method whose
-  #       sole parameter is a request object. Not all languages will generate
-  #       this method.
-  #   resource_name_treatment - An enum that specifies how to treat the
-  #       resource name formats defined in the field_name_patterns
-  #       and response_field_name_patterns fields.
-  #       UNSET: default value
-  #       NONE: the collection configs will not be used by the generated code.
-  #       VALIDATE: string fields will be validated by the client against the
-  #           specified resource name formats.
-  #       STATIC_TYPES: the client will use generated types for resource names.
   #   page_streaming - Specifies the configuration for paging.
   #       Describes information for generating a method which transforms a
   #       paging list RPC into a stream of resources.
@@ -14624,15 +12765,13 @@ interfaces:
     # TODO: Configure which fields are required.
     required_fields:
     - project
-    request_object_method: true
-    resource_name_treatment: STATIC_TYPES
     page_streaming:
       request:
         page_size_field: maxResults
         token_field: pageToken
       response:
         token_field: nextPageToken
-        resources_field: TargetVpnGatewayAggregatedList
+        resources_field: items
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: idempotent
     # TODO: Configure the retryable params for this method.
@@ -14647,20 +12786,16 @@ interfaces:
     flattening:
       groups:
       - parameters:
-        - requestId
         - targetVpnGateway
     # TODO: Configure which fields are required.
     required_fields:
-    - requestId
     - targetVpnGateway
-    request_object_method: true
-    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      targetVpnGateway: targetVpnGateway
+      targetVpnGateway: projectRegionTargetVpnGateway
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
   - name: compute.targetVpnGateways.get
@@ -14673,14 +12808,12 @@ interfaces:
     # TODO: Configure which fields are required.
     required_fields:
     - targetVpnGateway
-    request_object_method: true
-    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      targetVpnGateway: targetVpnGateway
+      targetVpnGateway: projectRegionTargetVpnGateway
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
   - name: compute.targetVpnGateways.insert
@@ -14689,22 +12822,18 @@ interfaces:
     flattening:
       groups:
       - parameters:
-        - requestId
         - region
         - targetVpnGatewayResource
     # TODO: Configure which fields are required.
     required_fields:
-    - requestId
     - region
     - targetVpnGatewayResource
-    request_object_method: true
-    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: non_idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      region: region
+      region: projectRegion
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
   - name: compute.targetVpnGateways.list
@@ -14717,24 +12846,22 @@ interfaces:
     # TODO: Configure which fields are required.
     required_fields:
     - region
-    request_object_method: true
-    resource_name_treatment: STATIC_TYPES
     page_streaming:
       request:
         page_size_field: maxResults
         token_field: pageToken
       response:
         token_field: nextPageToken
-        resources_field: TargetVpnGatewayList
+        resources_field: items
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      region: region
+      region: projectRegion
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
-  # The fully qualified name of the API interface.
+# The fully qualified name of the API interface.
 - name: google.compute.v1.UrlMaps
   # A list of resource collection configurations.
   # Consists of a name_pattern and an entity_name.
@@ -14747,16 +12874,16 @@ interfaces:
   # The entity_name is the name to be used as a basis for generated methods and
   # classes.
   collections:
-  - name_pattern: projects/{project}
+  - name_pattern: '{project}'
     entity_name: project
-  - name_pattern: projects/{project}/urlMaps/{urlMap}
-    entity_name: urlMap
+  - name_pattern: '{project}/global/urlMaps/{urlMap}'
+    entity_name: projectGlobalUrlMap
   # Definition for retryable codes.
   retry_codes_def:
   - name: idempotent
     retry_codes:
-    - SC_SERVICE_UNAVAILABLE
-    - SC_GATEWAY_TIMEOUT
+    - UNAVAILABLE
+    - DEADLINE_EXCEEDED
   - name: non_idempotent
     retry_codes: []
   # Definition for retry/backoff parameters.
@@ -14782,17 +12909,6 @@ interfaces:
   #       message.
   #   required_fields - Fields that are always required for a request to be
   #       valid.
-  #   request_object_method - Turns on or off the generation of a method whose
-  #       sole parameter is a request object. Not all languages will generate
-  #       this method.
-  #   resource_name_treatment - An enum that specifies how to treat the
-  #       resource name formats defined in the field_name_patterns
-  #       and response_field_name_patterns fields.
-  #       UNSET: default value
-  #       NONE: the collection configs will not be used by the generated code.
-  #       VALIDATE: string fields will be validated by the client against the
-  #           specified resource name formats.
-  #       STATIC_TYPES: the client will use generated types for resource names.
   #   page_streaming - Specifies the configuration for paging.
   #       Describes information for generating a method which transforms a
   #       paging list RPC into a stream of resources.
@@ -14827,19 +12943,15 @@ interfaces:
       groups:
       - parameters:
         - urlMap
-        - requestId
     # TODO: Configure which fields are required.
     required_fields:
     - urlMap
-    - requestId
-    request_object_method: true
-    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      urlMap: urlMap
+      urlMap: projectGlobalUrlMap
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
   - name: compute.urlMaps.get
@@ -14852,14 +12964,12 @@ interfaces:
     # TODO: Configure which fields are required.
     required_fields:
     - urlMap
-    request_object_method: true
-    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      urlMap: urlMap
+      urlMap: projectGlobalUrlMap
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
   - name: compute.urlMaps.insert
@@ -14868,16 +12978,12 @@ interfaces:
     flattening:
       groups:
       - parameters:
-        - requestId
         - project
         - urlMapResource
     # TODO: Configure which fields are required.
     required_fields:
-    - requestId
     - project
     - urlMapResource
-    request_object_method: true
-    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: non_idempotent
     # TODO: Configure the retryable params for this method.
@@ -14893,21 +12999,17 @@ interfaces:
       groups:
       - parameters:
         - urlMap
-        - requestId
         - cacheInvalidationRuleResource
     # TODO: Configure which fields are required.
     required_fields:
     - urlMap
-    - requestId
     - cacheInvalidationRuleResource
-    request_object_method: true
-    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: non_idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      urlMap: urlMap
+      urlMap: projectGlobalUrlMap
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
   - name: compute.urlMaps.list
@@ -14920,15 +13022,13 @@ interfaces:
     # TODO: Configure which fields are required.
     required_fields:
     - project
-    request_object_method: true
-    resource_name_treatment: STATIC_TYPES
     page_streaming:
       request:
         page_size_field: maxResults
         token_field: pageToken
       response:
         token_field: nextPageToken
-        resources_field: UrlMapList
+        resources_field: items
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: idempotent
     # TODO: Configure the retryable params for this method.
@@ -14944,21 +13044,17 @@ interfaces:
       groups:
       - parameters:
         - urlMap
-        - requestId
         - urlMapResource
     # TODO: Configure which fields are required.
     required_fields:
     - urlMap
-    - requestId
     - urlMapResource
-    request_object_method: true
-    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: non_idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      urlMap: urlMap
+      urlMap: projectGlobalUrlMap
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
   - name: compute.urlMaps.update
@@ -14968,21 +13064,17 @@ interfaces:
       groups:
       - parameters:
         - urlMap
-        - requestId
         - urlMapResource
     # TODO: Configure which fields are required.
     required_fields:
     - urlMap
-    - requestId
     - urlMapResource
-    request_object_method: true
-    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      urlMap: urlMap
+      urlMap: projectGlobalUrlMap
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
   - name: compute.urlMaps.validate
@@ -14997,17 +13089,15 @@ interfaces:
     required_fields:
     - urlMap
     - urlMapsValidateRequestResource
-    request_object_method: true
-    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: non_idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      urlMap: urlMap
+      urlMap: projectGlobalUrlMap
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
-  # The fully qualified name of the API interface.
+# The fully qualified name of the API interface.
 - name: google.compute.v1.VpnTunnels
   # A list of resource collection configurations.
   # Consists of a name_pattern and an entity_name.
@@ -15020,18 +13110,18 @@ interfaces:
   # The entity_name is the name to be used as a basis for generated methods and
   # classes.
   collections:
-  - name_pattern: projects/{project}
+  - name_pattern: '{project}'
     entity_name: project
-  - name_pattern: projects/{project}/regions/{region}
-    entity_name: region
-  - name_pattern: projects/{project}/regions/{region}/vpnTunnels/{vpnTunnel}
-    entity_name: vpnTunnel
+  - name_pattern: '{project}/regions/{region}'
+    entity_name: projectRegion
+  - name_pattern: '{project}/regions/{region}/vpnTunnels/{vpnTunnel}'
+    entity_name: projectRegionVpnTunnel
   # Definition for retryable codes.
   retry_codes_def:
   - name: idempotent
     retry_codes:
-    - SC_SERVICE_UNAVAILABLE
-    - SC_GATEWAY_TIMEOUT
+    - UNAVAILABLE
+    - DEADLINE_EXCEEDED
   - name: non_idempotent
     retry_codes: []
   # Definition for retry/backoff parameters.
@@ -15057,17 +13147,6 @@ interfaces:
   #       message.
   #   required_fields - Fields that are always required for a request to be
   #       valid.
-  #   request_object_method - Turns on or off the generation of a method whose
-  #       sole parameter is a request object. Not all languages will generate
-  #       this method.
-  #   resource_name_treatment - An enum that specifies how to treat the
-  #       resource name formats defined in the field_name_patterns
-  #       and response_field_name_patterns fields.
-  #       UNSET: default value
-  #       NONE: the collection configs will not be used by the generated code.
-  #       VALIDATE: string fields will be validated by the client against the
-  #           specified resource name formats.
-  #       STATIC_TYPES: the client will use generated types for resource names.
   #   page_streaming - Specifies the configuration for paging.
   #       Describes information for generating a method which transforms a
   #       paging list RPC into a stream of resources.
@@ -15105,15 +13184,13 @@ interfaces:
     # TODO: Configure which fields are required.
     required_fields:
     - project
-    request_object_method: true
-    resource_name_treatment: STATIC_TYPES
     page_streaming:
       request:
         page_size_field: maxResults
         token_field: pageToken
       response:
         token_field: nextPageToken
-        resources_field: VpnTunnelAggregatedList
+        resources_field: items
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: idempotent
     # TODO: Configure the retryable params for this method.
@@ -15128,20 +13205,16 @@ interfaces:
     flattening:
       groups:
       - parameters:
-        - requestId
         - vpnTunnel
     # TODO: Configure which fields are required.
     required_fields:
-    - requestId
     - vpnTunnel
-    request_object_method: true
-    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      vpnTunnel: vpnTunnel
+      vpnTunnel: projectRegionVpnTunnel
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
   - name: compute.vpnTunnels.get
@@ -15154,14 +13227,12 @@ interfaces:
     # TODO: Configure which fields are required.
     required_fields:
     - vpnTunnel
-    request_object_method: true
-    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      vpnTunnel: vpnTunnel
+      vpnTunnel: projectRegionVpnTunnel
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
   - name: compute.vpnTunnels.insert
@@ -15170,22 +13241,18 @@ interfaces:
     flattening:
       groups:
       - parameters:
-        - requestId
         - region
         - vpnTunnelResource
     # TODO: Configure which fields are required.
     required_fields:
-    - requestId
     - region
     - vpnTunnelResource
-    request_object_method: true
-    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: non_idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      region: region
+      region: projectRegion
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
   - name: compute.vpnTunnels.list
@@ -15198,24 +13265,22 @@ interfaces:
     # TODO: Configure which fields are required.
     required_fields:
     - region
-    request_object_method: true
-    resource_name_treatment: STATIC_TYPES
     page_streaming:
       request:
         page_size_field: maxResults
         token_field: pageToken
       response:
         token_field: nextPageToken
-        resources_field: VpnTunnelList
+        resources_field: items
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      region: region
+      region: projectRegion
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
-  # The fully qualified name of the API interface.
+# The fully qualified name of the API interface.
 - name: google.compute.v1.ZoneOperations
   # A list of resource collection configurations.
   # Consists of a name_pattern and an entity_name.
@@ -15228,16 +13293,16 @@ interfaces:
   # The entity_name is the name to be used as a basis for generated methods and
   # classes.
   collections:
-  - name_pattern: projects/{project}/zones/{zone}
-    entity_name: zone
-  - name_pattern: projects/{project}/zones/{zone}/operations/{operation}
-    entity_name: zoneOperationsOperation
+  - name_pattern: '{project}/zones/{zone}'
+    entity_name: projectZone
+  - name_pattern: '{project}/zones/{zone}/operations/{operation}'
+    entity_name: projectZoneOperation
   # Definition for retryable codes.
   retry_codes_def:
   - name: idempotent
     retry_codes:
-    - SC_SERVICE_UNAVAILABLE
-    - SC_GATEWAY_TIMEOUT
+    - UNAVAILABLE
+    - DEADLINE_EXCEEDED
   - name: non_idempotent
     retry_codes: []
   # Definition for retry/backoff parameters.
@@ -15263,17 +13328,6 @@ interfaces:
   #       message.
   #   required_fields - Fields that are always required for a request to be
   #       valid.
-  #   request_object_method - Turns on or off the generation of a method whose
-  #       sole parameter is a request object. Not all languages will generate
-  #       this method.
-  #   resource_name_treatment - An enum that specifies how to treat the
-  #       resource name formats defined in the field_name_patterns
-  #       and response_field_name_patterns fields.
-  #       UNSET: default value
-  #       NONE: the collection configs will not be used by the generated code.
-  #       VALIDATE: string fields will be validated by the client against the
-  #           specified resource name formats.
-  #       STATIC_TYPES: the client will use generated types for resource names.
   #   page_streaming - Specifies the configuration for paging.
   #       Describes information for generating a method which transforms a
   #       paging list RPC into a stream of resources.
@@ -15311,14 +13365,12 @@ interfaces:
     # TODO: Configure which fields are required.
     required_fields:
     - operation
-    request_object_method: true
-    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      operation: zoneOperationsOperation
+      operation: projectZoneOperation
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
   - name: compute.zoneOperations.get
@@ -15331,14 +13383,12 @@ interfaces:
     # TODO: Configure which fields are required.
     required_fields:
     - operation
-    request_object_method: true
-    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      operation: zoneOperationsOperation
+      operation: projectZoneOperation
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
   - name: compute.zoneOperations.list
@@ -15351,24 +13401,22 @@ interfaces:
     # TODO: Configure which fields are required.
     required_fields:
     - zone
-    request_object_method: true
-    resource_name_treatment: STATIC_TYPES
     page_streaming:
       request:
         page_size_field: maxResults
         token_field: pageToken
       response:
         token_field: nextPageToken
-        resources_field: OperationList
+        resources_field: items
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      zone: zone
+      zone: projectZone
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
-  # The fully qualified name of the API interface.
+# The fully qualified name of the API interface.
 - name: google.compute.v1.Zones
   # A list of resource collection configurations.
   # Consists of a name_pattern and an entity_name.
@@ -15381,16 +13429,16 @@ interfaces:
   # The entity_name is the name to be used as a basis for generated methods and
   # classes.
   collections:
-  - name_pattern: projects/{project}
+  - name_pattern: '{project}'
     entity_name: project
-  - name_pattern: projects/{project}/zones/{zone}
-    entity_name: zone
+  - name_pattern: '{project}/zones/{zone}'
+    entity_name: projectZone
   # Definition for retryable codes.
   retry_codes_def:
   - name: idempotent
     retry_codes:
-    - SC_SERVICE_UNAVAILABLE
-    - SC_GATEWAY_TIMEOUT
+    - UNAVAILABLE
+    - DEADLINE_EXCEEDED
   - name: non_idempotent
     retry_codes: []
   # Definition for retry/backoff parameters.
@@ -15416,17 +13464,6 @@ interfaces:
   #       message.
   #   required_fields - Fields that are always required for a request to be
   #       valid.
-  #   request_object_method - Turns on or off the generation of a method whose
-  #       sole parameter is a request object. Not all languages will generate
-  #       this method.
-  #   resource_name_treatment - An enum that specifies how to treat the
-  #       resource name formats defined in the field_name_patterns
-  #       and response_field_name_patterns fields.
-  #       UNSET: default value
-  #       NONE: the collection configs will not be used by the generated code.
-  #       VALIDATE: string fields will be validated by the client against the
-  #           specified resource name formats.
-  #       STATIC_TYPES: the client will use generated types for resource names.
   #   page_streaming - Specifies the configuration for paging.
   #       Describes information for generating a method which transforms a
   #       paging list RPC into a stream of resources.
@@ -15464,14 +13501,12 @@ interfaces:
     # TODO: Configure which fields are required.
     required_fields:
     - zone
-    request_object_method: true
-    resource_name_treatment: STATIC_TYPES
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
-      zone: zone
+      zone: projectZone
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
   - name: compute.zones.list
@@ -15484,15 +13519,13 @@ interfaces:
     # TODO: Configure which fields are required.
     required_fields:
     - project
-    request_object_method: true
-    resource_name_treatment: STATIC_TYPES
     page_streaming:
       request:
         page_size_field: maxResults
         token_field: pageToken
       response:
         token_field: nextPageToken
-        resources_field: ZoneList
+        resources_field: items
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: idempotent
     # TODO: Configure the retryable params for this method.
@@ -15507,58 +13540,58 @@ resource_name_generation:
     project: project
 - message_name: GetAcceleratorTypeHttpRequest
   field_entity_map:
-    acceleratorType: acceleratorType
+    acceleratorType: projectZoneAcceleratorType
 - message_name: ListAcceleratorTypesHttpRequest
   field_entity_map:
-    zone: zone
+    zone: projectZone
 - message_name: AggregatedListAddressesHttpRequest
   field_entity_map:
     project: project
 - message_name: DeleteAddressHttpRequest
   field_entity_map:
-    address: address
+    address: projectRegionAddress
 - message_name: GetAddressHttpRequest
   field_entity_map:
-    address: address
+    address: projectRegionAddress
 - message_name: InsertAddressHttpRequest
   field_entity_map:
-    region: region
+    region: projectRegion
 - message_name: ListAddressesHttpRequest
   field_entity_map:
-    region: region
+    region: projectRegion
 - message_name: AggregatedListAutoscalersHttpRequest
   field_entity_map:
     project: project
 - message_name: DeleteAutoscalerHttpRequest
   field_entity_map:
-    autoscaler: autoscaler
+    autoscaler: projectZoneAutoscaler
 - message_name: GetAutoscalerHttpRequest
   field_entity_map:
-    autoscaler: autoscaler
+    autoscaler: projectZoneAutoscaler
 - message_name: InsertAutoscalerHttpRequest
   field_entity_map:
-    zone: zone
+    zone: projectZone
 - message_name: ListAutoscalersHttpRequest
   field_entity_map:
-    zone: zone
+    zone: projectZone
 - message_name: PatchAutoscalerHttpRequest
   field_entity_map:
-    zone: zone
+    zone: projectZone
 - message_name: UpdateAutoscalerHttpRequest
   field_entity_map:
-    zone: zone
+    zone: projectZone
 - message_name: AddSignedUrlKeyBackendBucketHttpRequest
   field_entity_map:
-    backendBucket: backendBucket
+    backendBucket: projectGlobalBackendBucket
 - message_name: DeleteBackendBucketHttpRequest
   field_entity_map:
-    backendBucket: backendBucket
+    backendBucket: projectGlobalBackendBucket
 - message_name: DeleteSignedUrlKeyBackendBucketHttpRequest
   field_entity_map:
-    backendBucket: backendBucket
+    backendBucket: projectGlobalBackendBucket
 - message_name: GetBackendBucketHttpRequest
   field_entity_map:
-    backendBucket: backendBucket
+    backendBucket: projectGlobalBackendBucket
 - message_name: InsertBackendBucketHttpRequest
   field_entity_map:
     project: project
@@ -15567,28 +13600,28 @@ resource_name_generation:
     project: project
 - message_name: PatchBackendBucketHttpRequest
   field_entity_map:
-    backendBucket: backendBucket
+    backendBucket: projectGlobalBackendBucket
 - message_name: UpdateBackendBucketHttpRequest
   field_entity_map:
-    backendBucket: backendBucket
+    backendBucket: projectGlobalBackendBucket
 - message_name: AddSignedUrlKeyBackendServiceHttpRequest
   field_entity_map:
-    backendService: backendService
+    backendService: projectGlobalBackendService
 - message_name: AggregatedListBackendServicesHttpRequest
   field_entity_map:
     project: project
 - message_name: DeleteBackendServiceHttpRequest
   field_entity_map:
-    backendService: backendService
+    backendService: projectGlobalBackendService
 - message_name: DeleteSignedUrlKeyBackendServiceHttpRequest
   field_entity_map:
-    backendService: backendService
+    backendService: projectGlobalBackendService
 - message_name: GetBackendServiceHttpRequest
   field_entity_map:
-    backendService: backendService
+    backendService: projectGlobalBackendService
 - message_name: GetHealthBackendServiceHttpRequest
   field_entity_map:
-    backendService: backendService
+    backendService: projectGlobalBackendService
 - message_name: InsertBackendServiceHttpRequest
   field_entity_map:
     project: project
@@ -15597,67 +13630,67 @@ resource_name_generation:
     project: project
 - message_name: PatchBackendServiceHttpRequest
   field_entity_map:
-    backendService: backendService
+    backendService: projectGlobalBackendService
 - message_name: SetSecurityPolicyBackendServiceHttpRequest
   field_entity_map:
-    backendService: backendService
+    backendService: projectGlobalBackendService
 - message_name: UpdateBackendServiceHttpRequest
   field_entity_map:
-    backendService: backendService
+    backendService: projectGlobalBackendService
 - message_name: AggregatedListDiskTypesHttpRequest
   field_entity_map:
     project: project
 - message_name: GetDiskTypeHttpRequest
   field_entity_map:
-    diskType: diskType
+    diskType: projectZoneDiskType
 - message_name: ListDiskTypesHttpRequest
   field_entity_map:
-    zone: zone
+    zone: projectZone
 - message_name: AddResourcePoliciesDiskHttpRequest
   field_entity_map:
-    disk: disk
+    disk: projectZoneDisk
 - message_name: AggregatedListDisksHttpRequest
   field_entity_map:
     project: project
 - message_name: CreateSnapshotDiskHttpRequest
   field_entity_map:
-    disk: disk
+    disk: projectZoneDisk
 - message_name: DeleteDiskHttpRequest
   field_entity_map:
-    disk: disk
+    disk: projectZoneDisk
 - message_name: GetDiskHttpRequest
   field_entity_map:
-    disk: disk
+    disk: projectZoneDisk
 - message_name: GetIamPolicyDiskHttpRequest
   field_entity_map:
-    resource: disksResource
+    resource: projectZoneDiskResource
 - message_name: InsertDiskHttpRequest
   field_entity_map:
-    zone: zone
+    zone: projectZone
 - message_name: ListDisksHttpRequest
   field_entity_map:
-    zone: zone
+    zone: projectZone
 - message_name: RemoveResourcePoliciesDiskHttpRequest
   field_entity_map:
-    disk: disk
+    disk: projectZoneDisk
 - message_name: ResizeDiskHttpRequest
   field_entity_map:
-    disk: disk
+    disk: projectZoneDisk
 - message_name: SetIamPolicyDiskHttpRequest
   field_entity_map:
-    resource: disksResource
+    resource: projectZoneDiskResource
 - message_name: SetLabelsDiskHttpRequest
   field_entity_map:
-    resource: disksResource
+    resource: projectZoneDiskResource
 - message_name: TestIamPermissionsDiskHttpRequest
   field_entity_map:
-    resource: disksResource
+    resource: projectZoneDiskResource
 - message_name: DeleteFirewallHttpRequest
   field_entity_map:
-    firewall: firewall
+    firewall: projectGlobalFirewall
 - message_name: GetFirewallHttpRequest
   field_entity_map:
-    firewall: firewall
+    firewall: projectGlobalFirewall
 - message_name: InsertFirewallHttpRequest
   field_entity_map:
     project: project
@@ -15666,34 +13699,34 @@ resource_name_generation:
     project: project
 - message_name: PatchFirewallHttpRequest
   field_entity_map:
-    firewall: firewall
+    firewall: projectGlobalFirewall
 - message_name: UpdateFirewallHttpRequest
   field_entity_map:
-    firewall: firewall
+    firewall: projectGlobalFirewall
 - message_name: AggregatedListForwardingRulesHttpRequest
   field_entity_map:
     project: project
 - message_name: DeleteForwardingRuleHttpRequest
   field_entity_map:
-    forwardingRule: forwardingRule
+    forwardingRule: projectRegionForwardingRule
 - message_name: GetForwardingRuleHttpRequest
   field_entity_map:
-    forwardingRule: forwardingRule
+    forwardingRule: projectRegionForwardingRule
 - message_name: InsertForwardingRuleHttpRequest
   field_entity_map:
-    region: region
+    region: projectRegion
 - message_name: ListForwardingRulesHttpRequest
   field_entity_map:
-    region: region
+    region: projectRegion
 - message_name: SetTargetForwardingRuleHttpRequest
   field_entity_map:
-    forwardingRule: forwardingRule
+    forwardingRule: projectRegionForwardingRule
 - message_name: DeleteGlobalAddressHttpRequest
   field_entity_map:
-    address: globalAddressesAddress
+    address: projectGlobalAddress
 - message_name: GetGlobalAddressHttpRequest
   field_entity_map:
-    address: globalAddressesAddress
+    address: projectGlobalAddress
 - message_name: InsertGlobalAddressHttpRequest
   field_entity_map:
     project: project
@@ -15702,10 +13735,10 @@ resource_name_generation:
     project: project
 - message_name: DeleteGlobalForwardingRuleHttpRequest
   field_entity_map:
-    forwardingRule: globalForwardingRulesForwardingRule
+    forwardingRule: projectGlobalForwardingRule
 - message_name: GetGlobalForwardingRuleHttpRequest
   field_entity_map:
-    forwardingRule: globalForwardingRulesForwardingRule
+    forwardingRule: projectGlobalForwardingRule
 - message_name: InsertGlobalForwardingRuleHttpRequest
   field_entity_map:
     project: project
@@ -15714,25 +13747,25 @@ resource_name_generation:
     project: project
 - message_name: SetTargetGlobalForwardingRuleHttpRequest
   field_entity_map:
-    forwardingRule: globalForwardingRulesForwardingRule
+    forwardingRule: projectGlobalForwardingRule
 - message_name: AggregatedListGlobalOperationsHttpRequest
   field_entity_map:
     project: project
 - message_name: DeleteGlobalOperationHttpRequest
   field_entity_map:
-    operation: globalOperationsOperation
+    operation: projectGlobalOperation
 - message_name: GetGlobalOperationHttpRequest
   field_entity_map:
-    operation: globalOperationsOperation
+    operation: projectGlobalOperation
 - message_name: ListGlobalOperationsHttpRequest
   field_entity_map:
     project: project
 - message_name: DeleteHealthCheckHttpRequest
   field_entity_map:
-    healthCheck: healthCheck
+    healthCheck: projectGlobalHealthCheck
 - message_name: GetHealthCheckHttpRequest
   field_entity_map:
-    healthCheck: healthCheck
+    healthCheck: projectGlobalHealthCheck
 - message_name: InsertHealthCheckHttpRequest
   field_entity_map:
     project: project
@@ -15741,16 +13774,16 @@ resource_name_generation:
     project: project
 - message_name: PatchHealthCheckHttpRequest
   field_entity_map:
-    healthCheck: healthCheck
+    healthCheck: projectGlobalHealthCheck
 - message_name: UpdateHealthCheckHttpRequest
   field_entity_map:
-    healthCheck: healthCheck
+    healthCheck: projectGlobalHealthCheck
 - message_name: DeleteHttpHealthCheckHttpRequest
   field_entity_map:
-    httpHealthCheck: httpHealthCheck
+    httpHealthCheck: projectGlobalHttpHealthCheck
 - message_name: GetHttpHealthCheckHttpRequest
   field_entity_map:
-    httpHealthCheck: httpHealthCheck
+    httpHealthCheck: projectGlobalHttpHealthCheck
 - message_name: InsertHttpHealthCheckHttpRequest
   field_entity_map:
     project: project
@@ -15759,16 +13792,16 @@ resource_name_generation:
     project: project
 - message_name: PatchHttpHealthCheckHttpRequest
   field_entity_map:
-    httpHealthCheck: httpHealthCheck
+    httpHealthCheck: projectGlobalHttpHealthCheck
 - message_name: UpdateHttpHealthCheckHttpRequest
   field_entity_map:
-    httpHealthCheck: httpHealthCheck
+    httpHealthCheck: projectGlobalHttpHealthCheck
 - message_name: DeleteHttpsHealthCheckHttpRequest
   field_entity_map:
-    httpsHealthCheck: httpsHealthCheck
+    httpsHealthCheck: projectGlobalHttpsHealthCheck
 - message_name: GetHttpsHealthCheckHttpRequest
   field_entity_map:
-    httpsHealthCheck: httpsHealthCheck
+    httpsHealthCheck: projectGlobalHttpsHealthCheck
 - message_name: InsertHttpsHealthCheckHttpRequest
   field_entity_map:
     project: project
@@ -15777,25 +13810,25 @@ resource_name_generation:
     project: project
 - message_name: PatchHttpsHealthCheckHttpRequest
   field_entity_map:
-    httpsHealthCheck: httpsHealthCheck
+    httpsHealthCheck: projectGlobalHttpsHealthCheck
 - message_name: UpdateHttpsHealthCheckHttpRequest
   field_entity_map:
-    httpsHealthCheck: httpsHealthCheck
+    httpsHealthCheck: projectGlobalHttpsHealthCheck
 - message_name: DeleteImageHttpRequest
   field_entity_map:
-    image: image
+    image: projectGlobalImage
 - message_name: DeprecateImageHttpRequest
   field_entity_map:
-    image: image
+    image: projectGlobalImage
 - message_name: GetImageHttpRequest
   field_entity_map:
-    image: image
+    image: projectGlobalImage
 - message_name: GetFromFamilyImageHttpRequest
   field_entity_map:
-    family: family
+    family: projectGlobalImageFamily
 - message_name: GetIamPolicyImageHttpRequest
   field_entity_map:
-    resource: imagesResource
+    resource: projectGlobalImageResource
 - message_name: InsertImageHttpRequest
   field_entity_map:
     project: project
@@ -15804,88 +13837,88 @@ resource_name_generation:
     project: project
 - message_name: SetIamPolicyImageHttpRequest
   field_entity_map:
-    resource: imagesResource
+    resource: projectGlobalImageResource
 - message_name: SetLabelsImageHttpRequest
   field_entity_map:
-    resource: imagesResource
+    resource: projectGlobalImageResource
 - message_name: TestIamPermissionsImageHttpRequest
   field_entity_map:
-    resource: imagesResource
+    resource: projectGlobalImageResource
 - message_name: AbandonInstancesInstanceGroupManagerHttpRequest
   field_entity_map:
-    instanceGroupManager: instanceGroupManager
+    instanceGroupManager: projectZoneInstanceGroupManager
 - message_name: AggregatedListInstanceGroupManagersHttpRequest
   field_entity_map:
     project: project
 - message_name: DeleteInstanceGroupManagerHttpRequest
   field_entity_map:
-    instanceGroupManager: instanceGroupManager
+    instanceGroupManager: projectZoneInstanceGroupManager
 - message_name: DeleteInstancesInstanceGroupManagerHttpRequest
   field_entity_map:
-    instanceGroupManager: instanceGroupManager
+    instanceGroupManager: projectZoneInstanceGroupManager
 - message_name: GetInstanceGroupManagerHttpRequest
   field_entity_map:
-    instanceGroupManager: instanceGroupManager
+    instanceGroupManager: projectZoneInstanceGroupManager
 - message_name: InsertInstanceGroupManagerHttpRequest
   field_entity_map:
-    zone: zone
+    zone: projectZone
 - message_name: ListInstanceGroupManagersHttpRequest
   field_entity_map:
-    zone: zone
+    zone: projectZone
 - message_name: ListManagedInstancesInstanceGroupManagersHttpRequest
   field_entity_map:
-    instanceGroupManager: instanceGroupManager
+    instanceGroupManager: projectZoneInstanceGroupManager
 - message_name: PatchInstanceGroupManagerHttpRequest
   field_entity_map:
-    instanceGroupManager: instanceGroupManager
+    instanceGroupManager: projectZoneInstanceGroupManager
 - message_name: RecreateInstancesInstanceGroupManagerHttpRequest
   field_entity_map:
-    instanceGroupManager: instanceGroupManager
+    instanceGroupManager: projectZoneInstanceGroupManager
 - message_name: ResizeInstanceGroupManagerHttpRequest
   field_entity_map:
-    instanceGroupManager: instanceGroupManager
+    instanceGroupManager: projectZoneInstanceGroupManager
 - message_name: SetInstanceTemplateInstanceGroupManagerHttpRequest
   field_entity_map:
-    instanceGroupManager: instanceGroupManager
+    instanceGroupManager: projectZoneInstanceGroupManager
 - message_name: SetTargetPoolsInstanceGroupManagerHttpRequest
   field_entity_map:
-    instanceGroupManager: instanceGroupManager
+    instanceGroupManager: projectZoneInstanceGroupManager
 - message_name: AddInstancesInstanceGroupHttpRequest
   field_entity_map:
-    instanceGroup: instanceGroup
+    instanceGroup: projectZoneInstanceGroup
 - message_name: AggregatedListInstanceGroupsHttpRequest
   field_entity_map:
     project: project
 - message_name: DeleteInstanceGroupHttpRequest
   field_entity_map:
-    instanceGroup: instanceGroup
+    instanceGroup: projectZoneInstanceGroup
 - message_name: GetInstanceGroupHttpRequest
   field_entity_map:
-    instanceGroup: instanceGroup
+    instanceGroup: projectZoneInstanceGroup
 - message_name: InsertInstanceGroupHttpRequest
   field_entity_map:
-    zone: zone
+    zone: projectZone
 - message_name: ListInstanceGroupsHttpRequest
   field_entity_map:
-    zone: zone
+    zone: projectZone
 - message_name: ListInstancesInstanceGroupsHttpRequest
   field_entity_map:
-    instanceGroup: instanceGroup
+    instanceGroup: projectZoneInstanceGroup
 - message_name: RemoveInstancesInstanceGroupHttpRequest
   field_entity_map:
-    instanceGroup: instanceGroup
+    instanceGroup: projectZoneInstanceGroup
 - message_name: SetNamedPortsInstanceGroupHttpRequest
   field_entity_map:
-    instanceGroup: instanceGroup
+    instanceGroup: projectZoneInstanceGroup
 - message_name: DeleteInstanceTemplateHttpRequest
   field_entity_map:
-    instanceTemplate: instanceTemplate
+    instanceTemplate: projectGlobalInstanceTemplate
 - message_name: GetInstanceTemplateHttpRequest
   field_entity_map:
-    instanceTemplate: instanceTemplate
+    instanceTemplate: projectGlobalInstanceTemplate
 - message_name: GetIamPolicyInstanceTemplateHttpRequest
   field_entity_map:
-    resource: instanceTemplatesResource
+    resource: projectGlobalInstanceTemplateResource
 - message_name: InsertInstanceTemplateHttpRequest
   field_entity_map:
     project: project
@@ -15894,148 +13927,148 @@ resource_name_generation:
     project: project
 - message_name: SetIamPolicyInstanceTemplateHttpRequest
   field_entity_map:
-    resource: instanceTemplatesResource
+    resource: projectGlobalInstanceTemplateResource
 - message_name: TestIamPermissionsInstanceTemplateHttpRequest
   field_entity_map:
-    resource: instanceTemplatesResource
+    resource: projectGlobalInstanceTemplateResource
 - message_name: AddAccessConfigInstanceHttpRequest
   field_entity_map:
-    instance: instance
+    instance: projectZoneInstance
 - message_name: AggregatedListInstancesHttpRequest
   field_entity_map:
     project: project
 - message_name: AttachDiskInstanceHttpRequest
   field_entity_map:
-    instance: instance
+    instance: projectZoneInstance
 - message_name: DeleteInstanceHttpRequest
   field_entity_map:
-    instance: instance
+    instance: projectZoneInstance
 - message_name: DeleteAccessConfigInstanceHttpRequest
   field_entity_map:
-    instance: instance
+    instance: projectZoneInstance
 - message_name: DetachDiskInstanceHttpRequest
   field_entity_map:
-    instance: instance
+    instance: projectZoneInstance
 - message_name: GetInstanceHttpRequest
   field_entity_map:
-    instance: instance
+    instance: projectZoneInstance
 - message_name: GetGuestAttributesInstanceHttpRequest
   field_entity_map:
-    instance: instance
+    instance: projectZoneInstance
 - message_name: GetIamPolicyInstanceHttpRequest
   field_entity_map:
-    resource: instancesResource
+    resource: projectZoneInstanceResource
 - message_name: GetSerialPortOutputInstanceHttpRequest
   field_entity_map:
-    instance: instance
+    instance: projectZoneInstance
 - message_name: GetShieldedInstanceIdentityInstanceHttpRequest
   field_entity_map:
-    instance: instance
+    instance: projectZoneInstance
 - message_name: InsertInstanceHttpRequest
   field_entity_map:
-    zone: zone
+    zone: projectZone
 - message_name: ListInstancesHttpRequest
   field_entity_map:
-    zone: zone
+    zone: projectZone
 - message_name: ListReferrersInstancesHttpRequest
   field_entity_map:
-    instance: instance
+    instance: projectZoneInstance
 - message_name: ResetInstanceHttpRequest
   field_entity_map:
-    instance: instance
+    instance: projectZoneInstance
 - message_name: SetDeletionProtectionInstanceHttpRequest
   field_entity_map:
-    resource: instancesResource
+    resource: projectZoneInstanceResource
 - message_name: SetDiskAutoDeleteInstanceHttpRequest
   field_entity_map:
-    instance: instance
+    instance: projectZoneInstance
 - message_name: SetIamPolicyInstanceHttpRequest
   field_entity_map:
-    resource: instancesResource
+    resource: projectZoneInstanceResource
 - message_name: SetLabelsInstanceHttpRequest
   field_entity_map:
-    instance: instance
+    instance: projectZoneInstance
 - message_name: SetMachineResourcesInstanceHttpRequest
   field_entity_map:
-    instance: instance
+    instance: projectZoneInstance
 - message_name: SetMachineTypeInstanceHttpRequest
   field_entity_map:
-    instance: instance
+    instance: projectZoneInstance
 - message_name: SetMetadataInstanceHttpRequest
   field_entity_map:
-    instance: instance
+    instance: projectZoneInstance
 - message_name: SetMinCpuPlatformInstanceHttpRequest
   field_entity_map:
-    instance: instance
+    instance: projectZoneInstance
 - message_name: SetSchedulingInstanceHttpRequest
   field_entity_map:
-    instance: instance
+    instance: projectZoneInstance
 - message_name: SetServiceAccountInstanceHttpRequest
   field_entity_map:
-    instance: instance
+    instance: projectZoneInstance
 - message_name: SetShieldedInstanceIntegrityPolicyInstanceHttpRequest
   field_entity_map:
-    instance: instance
+    instance: projectZoneInstance
 - message_name: SetTagsInstanceHttpRequest
   field_entity_map:
-    instance: instance
+    instance: projectZoneInstance
 - message_name: SimulateMaintenanceEventInstanceHttpRequest
   field_entity_map:
-    instance: instance
+    instance: projectZoneInstance
 - message_name: StartInstanceHttpRequest
   field_entity_map:
-    instance: instance
+    instance: projectZoneInstance
 - message_name: StartWithEncryptionKeyInstanceHttpRequest
   field_entity_map:
-    instance: instance
+    instance: projectZoneInstance
 - message_name: StopInstanceHttpRequest
   field_entity_map:
-    instance: instance
+    instance: projectZoneInstance
 - message_name: TestIamPermissionsInstanceHttpRequest
   field_entity_map:
-    resource: instancesResource
+    resource: projectZoneInstanceResource
 - message_name: UpdateAccessConfigInstanceHttpRequest
   field_entity_map:
-    instance: instance
+    instance: projectZoneInstance
 - message_name: UpdateNetworkInterfaceInstanceHttpRequest
   field_entity_map:
-    instance: instance
+    instance: projectZoneInstance
 - message_name: UpdateShieldedInstanceConfigInstanceHttpRequest
   field_entity_map:
-    instance: instance
+    instance: projectZoneInstance
 - message_name: AggregatedListInterconnectAttachmentsHttpRequest
   field_entity_map:
     project: project
 - message_name: DeleteInterconnectAttachmentHttpRequest
   field_entity_map:
-    interconnectAttachment: interconnectAttachment
+    interconnectAttachment: projectRegionInterconnectAttachment
 - message_name: GetInterconnectAttachmentHttpRequest
   field_entity_map:
-    interconnectAttachment: interconnectAttachment
+    interconnectAttachment: projectRegionInterconnectAttachment
 - message_name: InsertInterconnectAttachmentHttpRequest
   field_entity_map:
-    region: region
+    region: projectRegion
 - message_name: ListInterconnectAttachmentsHttpRequest
   field_entity_map:
-    region: region
+    region: projectRegion
 - message_name: PatchInterconnectAttachmentHttpRequest
   field_entity_map:
-    interconnectAttachment: interconnectAttachment
+    interconnectAttachment: projectRegionInterconnectAttachment
 - message_name: GetInterconnectLocationHttpRequest
   field_entity_map:
-    interconnectLocation: interconnectLocation
+    interconnectLocation: projectGlobalInterconnectLocation
 - message_name: ListInterconnectLocationsHttpRequest
   field_entity_map:
     project: project
 - message_name: DeleteInterconnectHttpRequest
   field_entity_map:
-    interconnect: interconnect
+    interconnect: projectGlobalInterconnect
 - message_name: GetInterconnectHttpRequest
   field_entity_map:
-    interconnect: interconnect
+    interconnect: projectGlobalInterconnect
 - message_name: GetDiagnosticsInterconnectHttpRequest
   field_entity_map:
-    interconnect: interconnect
+    interconnect: projectGlobalInterconnect
 - message_name: InsertInterconnectHttpRequest
   field_entity_map:
     project: project
@@ -16044,79 +14077,79 @@ resource_name_generation:
     project: project
 - message_name: PatchInterconnectHttpRequest
   field_entity_map:
-    interconnect: interconnect
+    interconnect: projectGlobalInterconnect
 - message_name: GetLicenseCodeHttpRequest
   field_entity_map:
-    licenseCode: licenseCode
+    licenseCode: projectGlobalLicenseCode
 - message_name: TestIamPermissionsLicenseCodeHttpRequest
   field_entity_map:
-    resource: licenseCodesResource
-- message_name: DeleteLicensHttpRequest
+    resource: projectGlobalLicenseCodeResource
+- message_name: DeleteLicenseHttpRequest
   field_entity_map:
-    license: license
-- message_name: GetLicensHttpRequest
+    license: projectGlobalLicense
+- message_name: GetLicenseHttpRequest
   field_entity_map:
-    license: license
-- message_name: GetIamPolicyLicensHttpRequest
+    license: projectGlobalLicense
+- message_name: GetIamPolicyLicenseHttpRequest
   field_entity_map:
-    resource: licensesResource
-- message_name: InsertLicensHttpRequest
+    resource: projectGlobalLicenseResource
+- message_name: InsertLicenseHttpRequest
   field_entity_map:
     project: project
 - message_name: ListLicensesHttpRequest
   field_entity_map:
     project: project
-- message_name: SetIamPolicyLicensHttpRequest
+- message_name: SetIamPolicyLicenseHttpRequest
   field_entity_map:
-    resource: licensesResource
-- message_name: TestIamPermissionsLicensHttpRequest
+    resource: projectGlobalLicenseResource
+- message_name: TestIamPermissionsLicenseHttpRequest
   field_entity_map:
-    resource: licensesResource
+    resource: projectGlobalLicenseResource
 - message_name: AggregatedListMachineTypesHttpRequest
   field_entity_map:
     project: project
 - message_name: GetMachineTypeHttpRequest
   field_entity_map:
-    machineType: machineType
+    machineType: projectZoneMachineType
 - message_name: ListMachineTypesHttpRequest
   field_entity_map:
-    zone: zone
+    zone: projectZone
 - message_name: AggregatedListNetworkEndpointGroupsHttpRequest
   field_entity_map:
     project: project
 - message_name: AttachNetworkEndpointsNetworkEndpointGroupHttpRequest
   field_entity_map:
-    networkEndpointGroup: networkEndpointGroup
+    networkEndpointGroup: projectZoneNetworkEndpointGroup
 - message_name: DeleteNetworkEndpointGroupHttpRequest
   field_entity_map:
-    networkEndpointGroup: networkEndpointGroup
+    networkEndpointGroup: projectZoneNetworkEndpointGroup
 - message_name: DetachNetworkEndpointsNetworkEndpointGroupHttpRequest
   field_entity_map:
-    networkEndpointGroup: networkEndpointGroup
+    networkEndpointGroup: projectZoneNetworkEndpointGroup
 - message_name: GetNetworkEndpointGroupHttpRequest
   field_entity_map:
-    networkEndpointGroup: networkEndpointGroup
+    networkEndpointGroup: projectZoneNetworkEndpointGroup
 - message_name: InsertNetworkEndpointGroupHttpRequest
   field_entity_map:
-    zone: zone
+    zone: projectZone
 - message_name: ListNetworkEndpointGroupsHttpRequest
   field_entity_map:
-    zone: zone
+    zone: projectZone
 - message_name: ListNetworkEndpointsNetworkEndpointGroupsHttpRequest
   field_entity_map:
-    networkEndpointGroup: networkEndpointGroup
+    networkEndpointGroup: projectZoneNetworkEndpointGroup
 - message_name: TestIamPermissionsNetworkEndpointGroupHttpRequest
   field_entity_map:
-    resource: networkEndpointGroupsResource
+    resource: projectZoneNetworkEndpointGroupResource
 - message_name: AddPeeringNetworkHttpRequest
   field_entity_map:
-    network: network
+    network: projectGlobalNetwork
 - message_name: DeleteNetworkHttpRequest
   field_entity_map:
-    network: network
+    network: projectGlobalNetwork
 - message_name: GetNetworkHttpRequest
   field_entity_map:
-    network: network
+    network: projectGlobalNetwork
 - message_name: InsertNetworkHttpRequest
   field_entity_map:
     project: project
@@ -16125,82 +14158,82 @@ resource_name_generation:
     project: project
 - message_name: PatchNetworkHttpRequest
   field_entity_map:
-    network: network
+    network: projectGlobalNetwork
 - message_name: RemovePeeringNetworkHttpRequest
   field_entity_map:
-    network: network
+    network: projectGlobalNetwork
 - message_name: SwitchToCustomModeNetworkHttpRequest
   field_entity_map:
-    network: network
+    network: projectGlobalNetwork
 - message_name: AddNodesNodeGroupHttpRequest
   field_entity_map:
-    nodeGroup: nodeGroup
+    nodeGroup: projectZoneNodeGroup
 - message_name: AggregatedListNodeGroupsHttpRequest
   field_entity_map:
     project: project
 - message_name: DeleteNodeGroupHttpRequest
   field_entity_map:
-    nodeGroup: nodeGroup
+    nodeGroup: projectZoneNodeGroup
 - message_name: DeleteNodesNodeGroupHttpRequest
   field_entity_map:
-    nodeGroup: nodeGroup
+    nodeGroup: projectZoneNodeGroup
 - message_name: GetNodeGroupHttpRequest
   field_entity_map:
-    nodeGroup: nodeGroup
+    nodeGroup: projectZoneNodeGroup
 - message_name: GetIamPolicyNodeGroupHttpRequest
   field_entity_map:
-    resource: nodeGroupsResource
+    resource: projectZoneNodeGroupResource
 - message_name: InsertNodeGroupHttpRequest
   field_entity_map:
-    zone: zone
+    zone: projectZone
 - message_name: ListNodeGroupsHttpRequest
   field_entity_map:
-    zone: zone
+    zone: projectZone
 - message_name: ListNodesNodeGroupsHttpRequest
   field_entity_map:
-    nodeGroup: nodeGroup
+    nodeGroup: projectZoneNodeGroup
 - message_name: SetIamPolicyNodeGroupHttpRequest
   field_entity_map:
-    resource: nodeGroupsResource
+    resource: projectZoneNodeGroupResource
 - message_name: SetNodeTemplateNodeGroupHttpRequest
   field_entity_map:
-    nodeGroup: nodeGroup
+    nodeGroup: projectZoneNodeGroup
 - message_name: TestIamPermissionsNodeGroupHttpRequest
   field_entity_map:
-    resource: nodeGroupsResource
+    resource: projectZoneNodeGroupResource
 - message_name: AggregatedListNodeTemplatesHttpRequest
   field_entity_map:
     project: project
 - message_name: DeleteNodeTemplateHttpRequest
   field_entity_map:
-    nodeTemplate: nodeTemplate
+    nodeTemplate: projectRegionNodeTemplate
 - message_name: GetNodeTemplateHttpRequest
   field_entity_map:
-    nodeTemplate: nodeTemplate
+    nodeTemplate: projectRegionNodeTemplate
 - message_name: GetIamPolicyNodeTemplateHttpRequest
   field_entity_map:
-    resource: nodeTemplatesResource
+    resource: projectRegionNodeTemplateResource
 - message_name: InsertNodeTemplateHttpRequest
   field_entity_map:
-    region: region
+    region: projectRegion
 - message_name: ListNodeTemplatesHttpRequest
   field_entity_map:
-    region: region
+    region: projectRegion
 - message_name: SetIamPolicyNodeTemplateHttpRequest
   field_entity_map:
-    resource: nodeTemplatesResource
+    resource: projectRegionNodeTemplateResource
 - message_name: TestIamPermissionsNodeTemplateHttpRequest
   field_entity_map:
-    resource: nodeTemplatesResource
+    resource: projectRegionNodeTemplateResource
 - message_name: AggregatedListNodeTypesHttpRequest
   field_entity_map:
     project: project
 - message_name: GetNodeTypeHttpRequest
   field_entity_map:
-    nodeType: nodeType
+    nodeType: projectZoneNodeType
 - message_name: ListNodeTypesHttpRequest
   field_entity_map:
-    zone: zone
+    zone: projectZone
 - message_name: DisableXpnHostProjectHttpRequest
   field_entity_map:
     project: project
@@ -16242,151 +14275,151 @@ resource_name_generation:
     project: project
 - message_name: DeleteRegionAutoscalerHttpRequest
   field_entity_map:
-    autoscaler: regionAutoscalersAutoscaler
+    autoscaler: projectRegionAutoscaler
 - message_name: GetRegionAutoscalerHttpRequest
   field_entity_map:
-    autoscaler: regionAutoscalersAutoscaler
+    autoscaler: projectRegionAutoscaler
 - message_name: InsertRegionAutoscalerHttpRequest
   field_entity_map:
-    region: region
+    region: projectRegion
 - message_name: ListRegionAutoscalersHttpRequest
   field_entity_map:
-    region: region
+    region: projectRegion
 - message_name: PatchRegionAutoscalerHttpRequest
   field_entity_map:
-    region: region
+    region: projectRegion
 - message_name: UpdateRegionAutoscalerHttpRequest
   field_entity_map:
-    region: region
+    region: projectRegion
 - message_name: DeleteRegionBackendServiceHttpRequest
   field_entity_map:
-    backendService: regionBackendServicesBackendService
+    backendService: projectRegionBackendService
 - message_name: GetRegionBackendServiceHttpRequest
   field_entity_map:
-    backendService: regionBackendServicesBackendService
+    backendService: projectRegionBackendService
 - message_name: GetHealthRegionBackendServiceHttpRequest
   field_entity_map:
-    backendService: regionBackendServicesBackendService
+    backendService: projectRegionBackendService
 - message_name: InsertRegionBackendServiceHttpRequest
   field_entity_map:
-    region: region
+    region: projectRegion
 - message_name: ListRegionBackendServicesHttpRequest
   field_entity_map:
-    region: region
+    region: projectRegion
 - message_name: PatchRegionBackendServiceHttpRequest
   field_entity_map:
-    backendService: regionBackendServicesBackendService
+    backendService: projectRegionBackendService
 - message_name: UpdateRegionBackendServiceHttpRequest
   field_entity_map:
-    backendService: regionBackendServicesBackendService
+    backendService: projectRegionBackendService
 - message_name: AggregatedListRegionCommitmentsHttpRequest
   field_entity_map:
     project: project
 - message_name: GetRegionCommitmentHttpRequest
   field_entity_map:
-    commitment: commitment
+    commitment: projectRegionCommitment
 - message_name: InsertRegionCommitmentHttpRequest
   field_entity_map:
-    region: region
+    region: projectRegion
 - message_name: ListRegionCommitmentsHttpRequest
   field_entity_map:
-    region: region
+    region: projectRegion
 - message_name: GetRegionDiskTypeHttpRequest
   field_entity_map:
-    diskType: regionDiskTypesDiskType
+    diskType: projectRegionDiskType
 - message_name: ListRegionDiskTypesHttpRequest
   field_entity_map:
-    region: region
+    region: projectRegion
 - message_name: AddResourcePoliciesRegionDiskHttpRequest
   field_entity_map:
-    disk: regionDisksDisk
+    disk: projectRegionDisk
 - message_name: CreateSnapshotRegionDiskHttpRequest
   field_entity_map:
-    disk: regionDisksDisk
+    disk: projectRegionDisk
 - message_name: DeleteRegionDiskHttpRequest
   field_entity_map:
-    disk: regionDisksDisk
+    disk: projectRegionDisk
 - message_name: GetRegionDiskHttpRequest
   field_entity_map:
-    disk: regionDisksDisk
+    disk: projectRegionDisk
 - message_name: InsertRegionDiskHttpRequest
   field_entity_map:
-    region: region
+    region: projectRegion
 - message_name: ListRegionDisksHttpRequest
   field_entity_map:
-    region: region
+    region: projectRegion
 - message_name: RemoveResourcePoliciesRegionDiskHttpRequest
   field_entity_map:
-    disk: regionDisksDisk
+    disk: projectRegionDisk
 - message_name: ResizeRegionDiskHttpRequest
   field_entity_map:
-    disk: regionDisksDisk
+    disk: projectRegionDisk
 - message_name: SetLabelsRegionDiskHttpRequest
   field_entity_map:
-    resource: regionDisksResource
+    resource: projectRegionDiskResource
 - message_name: TestIamPermissionsRegionDiskHttpRequest
   field_entity_map:
-    resource: regionDisksResource
+    resource: projectRegionDiskResource
 - message_name: AbandonInstancesRegionInstanceGroupManagerHttpRequest
   field_entity_map:
-    instanceGroupManager: regionInstanceGroupManagersInstanceGroupManager
+    instanceGroupManager: projectRegionInstanceGroupManager
 - message_name: DeleteRegionInstanceGroupManagerHttpRequest
   field_entity_map:
-    instanceGroupManager: regionInstanceGroupManagersInstanceGroupManager
+    instanceGroupManager: projectRegionInstanceGroupManager
 - message_name: DeleteInstancesRegionInstanceGroupManagerHttpRequest
   field_entity_map:
-    instanceGroupManager: regionInstanceGroupManagersInstanceGroupManager
+    instanceGroupManager: projectRegionInstanceGroupManager
 - message_name: GetRegionInstanceGroupManagerHttpRequest
   field_entity_map:
-    instanceGroupManager: regionInstanceGroupManagersInstanceGroupManager
+    instanceGroupManager: projectRegionInstanceGroupManager
 - message_name: InsertRegionInstanceGroupManagerHttpRequest
   field_entity_map:
-    region: region
+    region: projectRegion
 - message_name: ListRegionInstanceGroupManagersHttpRequest
   field_entity_map:
-    region: region
+    region: projectRegion
 - message_name: ListManagedInstancesRegionInstanceGroupManagersHttpRequest
   field_entity_map:
-    instanceGroupManager: regionInstanceGroupManagersInstanceGroupManager
+    instanceGroupManager: projectRegionInstanceGroupManager
 - message_name: PatchRegionInstanceGroupManagerHttpRequest
   field_entity_map:
-    instanceGroupManager: regionInstanceGroupManagersInstanceGroupManager
+    instanceGroupManager: projectRegionInstanceGroupManager
 - message_name: RecreateInstancesRegionInstanceGroupManagerHttpRequest
   field_entity_map:
-    instanceGroupManager: regionInstanceGroupManagersInstanceGroupManager
+    instanceGroupManager: projectRegionInstanceGroupManager
 - message_name: ResizeRegionInstanceGroupManagerHttpRequest
   field_entity_map:
-    instanceGroupManager: regionInstanceGroupManagersInstanceGroupManager
+    instanceGroupManager: projectRegionInstanceGroupManager
 - message_name: SetInstanceTemplateRegionInstanceGroupManagerHttpRequest
   field_entity_map:
-    instanceGroupManager: regionInstanceGroupManagersInstanceGroupManager
+    instanceGroupManager: projectRegionInstanceGroupManager
 - message_name: SetTargetPoolsRegionInstanceGroupManagerHttpRequest
   field_entity_map:
-    instanceGroupManager: regionInstanceGroupManagersInstanceGroupManager
+    instanceGroupManager: projectRegionInstanceGroupManager
 - message_name: GetRegionInstanceGroupHttpRequest
   field_entity_map:
-    instanceGroup: regionInstanceGroupsInstanceGroup
+    instanceGroup: projectRegionInstanceGroup
 - message_name: ListRegionInstanceGroupsHttpRequest
   field_entity_map:
-    region: region
+    region: projectRegion
 - message_name: ListInstancesRegionInstanceGroupsHttpRequest
   field_entity_map:
-    instanceGroup: regionInstanceGroupsInstanceGroup
+    instanceGroup: projectRegionInstanceGroup
 - message_name: SetNamedPortsRegionInstanceGroupHttpRequest
   field_entity_map:
-    instanceGroup: regionInstanceGroupsInstanceGroup
+    instanceGroup: projectRegionInstanceGroup
 - message_name: DeleteRegionOperationHttpRequest
   field_entity_map:
-    operation: regionOperationsOperation
+    operation: projectRegionOperation
 - message_name: GetRegionOperationHttpRequest
   field_entity_map:
-    operation: regionOperationsOperation
+    operation: projectRegionOperation
 - message_name: ListRegionOperationsHttpRequest
   field_entity_map:
-    region: region
+    region: projectRegion
 - message_name: GetRegionHttpRequest
   field_entity_map:
-    region: region
+    region: projectRegion
 - message_name: ListRegionsHttpRequest
   field_entity_map:
     project: project
@@ -16395,88 +14428,88 @@ resource_name_generation:
     project: project
 - message_name: DeleteReservationHttpRequest
   field_entity_map:
-    reservation: reservation
+    reservation: projectZoneReservation
 - message_name: GetReservationHttpRequest
   field_entity_map:
-    reservation: reservation
+    reservation: projectZoneReservation
 - message_name: GetIamPolicyReservationHttpRequest
   field_entity_map:
-    resource: reservationsResource
+    resource: projectZoneReservationResource
 - message_name: InsertReservationHttpRequest
   field_entity_map:
-    zone: zone
+    zone: projectZone
 - message_name: ListReservationsHttpRequest
   field_entity_map:
-    zone: zone
+    zone: projectZone
 - message_name: ResizeReservationHttpRequest
   field_entity_map:
-    reservation: reservation
+    reservation: projectZoneReservation
 - message_name: SetIamPolicyReservationHttpRequest
   field_entity_map:
-    resource: reservationsResource
+    resource: projectZoneReservationResource
 - message_name: TestIamPermissionsReservationHttpRequest
   field_entity_map:
-    resource: reservationsResource
+    resource: projectZoneReservationResource
 - message_name: AggregatedListResourcePoliciesHttpRequest
   field_entity_map:
     project: project
 - message_name: DeleteResourcePolicyHttpRequest
   field_entity_map:
-    resourcePolicy: resourcePolicy
+    resourcePolicy: projectRegionResourcePolicy
 - message_name: GetResourcePolicyHttpRequest
   field_entity_map:
-    resourcePolicy: resourcePolicy
+    resourcePolicy: projectRegionResourcePolicy
 - message_name: GetIamPolicyResourcePolicyHttpRequest
   field_entity_map:
-    resource: resourcePoliciesResource
+    resource: projectRegionResourcePolicyResource
 - message_name: InsertResourcePolicyHttpRequest
   field_entity_map:
-    region: region
+    region: projectRegion
 - message_name: ListResourcePoliciesHttpRequest
   field_entity_map:
-    region: region
+    region: projectRegion
 - message_name: SetIamPolicyResourcePolicyHttpRequest
   field_entity_map:
-    resource: resourcePoliciesResource
+    resource: projectRegionResourcePolicyResource
 - message_name: TestIamPermissionsResourcePolicyHttpRequest
   field_entity_map:
-    resource: resourcePoliciesResource
+    resource: projectRegionResourcePolicyResource
 - message_name: AggregatedListRoutersHttpRequest
   field_entity_map:
     project: project
 - message_name: DeleteRouterHttpRequest
   field_entity_map:
-    router: router
+    router: projectRegionRouter
 - message_name: GetRouterHttpRequest
   field_entity_map:
-    router: router
+    router: projectRegionRouter
 - message_name: GetNatMappingInfoRoutersHttpRequest
   field_entity_map:
-    router: router
+    router: projectRegionRouter
 - message_name: GetRouterStatusRouterHttpRequest
   field_entity_map:
-    router: router
+    router: projectRegionRouter
 - message_name: InsertRouterHttpRequest
   field_entity_map:
-    region: region
+    region: projectRegion
 - message_name: ListRoutersHttpRequest
   field_entity_map:
-    region: region
+    region: projectRegion
 - message_name: PatchRouterHttpRequest
   field_entity_map:
-    router: router
+    router: projectRegionRouter
 - message_name: PreviewRouterHttpRequest
   field_entity_map:
-    router: router
+    router: projectRegionRouter
 - message_name: UpdateRouterHttpRequest
   field_entity_map:
-    router: router
+    router: projectRegionRouter
 - message_name: DeleteRouteHttpRequest
   field_entity_map:
-    route: route
+    route: projectGlobalRoute
 - message_name: GetRouteHttpRequest
   field_entity_map:
-    route: route
+    route: projectGlobalRoute
 - message_name: InsertRouteHttpRequest
   field_entity_map:
     project: project
@@ -16485,16 +14518,16 @@ resource_name_generation:
     project: project
 - message_name: AddRuleSecurityPolicyHttpRequest
   field_entity_map:
-    securityPolicy: securityPolicy
+    securityPolicy: projectGlobalSecurityPolicy
 - message_name: DeleteSecurityPolicyHttpRequest
   field_entity_map:
-    securityPolicy: securityPolicy
+    securityPolicy: projectGlobalSecurityPolicy
 - message_name: GetSecurityPolicyHttpRequest
   field_entity_map:
-    securityPolicy: securityPolicy
+    securityPolicy: projectGlobalSecurityPolicy
 - message_name: GetRuleSecurityPolicyHttpRequest
   field_entity_map:
-    securityPolicy: securityPolicy
+    securityPolicy: projectGlobalSecurityPolicy
 - message_name: InsertSecurityPolicyHttpRequest
   field_entity_map:
     project: project
@@ -16503,40 +14536,40 @@ resource_name_generation:
     project: project
 - message_name: PatchSecurityPolicyHttpRequest
   field_entity_map:
-    securityPolicy: securityPolicy
+    securityPolicy: projectGlobalSecurityPolicy
 - message_name: PatchRuleSecurityPolicyHttpRequest
   field_entity_map:
-    securityPolicy: securityPolicy
+    securityPolicy: projectGlobalSecurityPolicy
 - message_name: RemoveRuleSecurityPolicyHttpRequest
   field_entity_map:
-    securityPolicy: securityPolicy
+    securityPolicy: projectGlobalSecurityPolicy
 - message_name: DeleteSnapshotHttpRequest
   field_entity_map:
-    snapshot: snapshot
+    snapshot: projectGlobalSnapshot
 - message_name: GetSnapshotHttpRequest
   field_entity_map:
-    snapshot: snapshot
+    snapshot: projectGlobalSnapshot
 - message_name: GetIamPolicySnapshotHttpRequest
   field_entity_map:
-    resource: snapshotsResource
+    resource: projectGlobalSnapshotResource
 - message_name: ListSnapshotsHttpRequest
   field_entity_map:
     project: project
 - message_name: SetIamPolicySnapshotHttpRequest
   field_entity_map:
-    resource: snapshotsResource
+    resource: projectGlobalSnapshotResource
 - message_name: SetLabelsSnapshotHttpRequest
   field_entity_map:
-    resource: snapshotsResource
+    resource: projectGlobalSnapshotResource
 - message_name: TestIamPermissionsSnapshotHttpRequest
   field_entity_map:
-    resource: snapshotsResource
+    resource: projectGlobalSnapshotResource
 - message_name: DeleteSslCertificateHttpRequest
   field_entity_map:
-    sslCertificate: sslCertificate
+    sslCertificate: projectGlobalSslCertificate
 - message_name: GetSslCertificateHttpRequest
   field_entity_map:
-    sslCertificate: sslCertificate
+    sslCertificate: projectGlobalSslCertificate
 - message_name: InsertSslCertificateHttpRequest
   field_entity_map:
     project: project
@@ -16545,10 +14578,10 @@ resource_name_generation:
     project: project
 - message_name: DeleteSslPolicyHttpRequest
   field_entity_map:
-    sslPolicy: sslPolicy
+    sslPolicy: projectGlobalSslPolicy
 - message_name: GetSslPolicyHttpRequest
   field_entity_map:
-    sslPolicy: sslPolicy
+    sslPolicy: projectGlobalSslPolicy
 - message_name: InsertSslPolicyHttpRequest
   field_entity_map:
     project: project
@@ -16560,49 +14593,49 @@ resource_name_generation:
     project: project
 - message_name: PatchSslPolicyHttpRequest
   field_entity_map:
-    sslPolicy: sslPolicy
+    sslPolicy: projectGlobalSslPolicy
 - message_name: AggregatedListSubnetworksHttpRequest
   field_entity_map:
     project: project
 - message_name: DeleteSubnetworkHttpRequest
   field_entity_map:
-    subnetwork: subnetwork
+    subnetwork: projectRegionSubnetwork
 - message_name: ExpandIpCidrRangeSubnetworkHttpRequest
   field_entity_map:
-    subnetwork: subnetwork
+    subnetwork: projectRegionSubnetwork
 - message_name: GetSubnetworkHttpRequest
   field_entity_map:
-    subnetwork: subnetwork
+    subnetwork: projectRegionSubnetwork
 - message_name: GetIamPolicySubnetworkHttpRequest
   field_entity_map:
-    resource: subnetworksResource
+    resource: projectRegionSubnetworkResource
 - message_name: InsertSubnetworkHttpRequest
   field_entity_map:
-    region: region
+    region: projectRegion
 - message_name: ListSubnetworksHttpRequest
   field_entity_map:
-    region: region
+    region: projectRegion
 - message_name: ListUsableSubnetworksHttpRequest
   field_entity_map:
     project: project
 - message_name: PatchSubnetworkHttpRequest
   field_entity_map:
-    subnetwork: subnetwork
+    subnetwork: projectRegionSubnetwork
 - message_name: SetIamPolicySubnetworkHttpRequest
   field_entity_map:
-    resource: subnetworksResource
+    resource: projectRegionSubnetworkResource
 - message_name: SetPrivateIpGoogleAccessSubnetworkHttpRequest
   field_entity_map:
-    subnetwork: subnetwork
+    subnetwork: projectRegionSubnetwork
 - message_name: TestIamPermissionsSubnetworkHttpRequest
   field_entity_map:
-    resource: subnetworksResource
+    resource: projectRegionSubnetworkResource
 - message_name: DeleteTargetHttpProxyHttpRequest
   field_entity_map:
-    targetHttpProxy: targetHttpProxy
+    targetHttpProxy: projectGlobalTargetHttpProxy
 - message_name: GetTargetHttpProxyHttpRequest
   field_entity_map:
-    targetHttpProxy: targetHttpProxy
+    targetHttpProxy: projectGlobalTargetHttpProxy
 - message_name: InsertTargetHttpProxyHttpRequest
   field_entity_map:
     project: project
@@ -16611,13 +14644,13 @@ resource_name_generation:
     project: project
 - message_name: SetUrlMapTargetHttpProxyHttpRequest
   field_entity_map:
-    targetHttpProxy: targetHttpProxy
+    targetHttpProxy: projectTargetHttpProxy
 - message_name: DeleteTargetHttpsProxyHttpRequest
   field_entity_map:
-    targetHttpsProxy: targetHttpsProxy
+    targetHttpsProxy: projectGlobalTargetHttpsProxy
 - message_name: GetTargetHttpsProxyHttpRequest
   field_entity_map:
-    targetHttpsProxy: targetHttpsProxy
+    targetHttpsProxy: projectGlobalTargetHttpsProxy
 - message_name: InsertTargetHttpsProxyHttpRequest
   field_entity_map:
     project: project
@@ -16626,70 +14659,70 @@ resource_name_generation:
     project: project
 - message_name: SetQuicOverrideTargetHttpsProxyHttpRequest
   field_entity_map:
-    targetHttpsProxy: targetHttpsProxy
+    targetHttpsProxy: projectGlobalTargetHttpsProxy
 - message_name: SetSslCertificatesTargetHttpsProxyHttpRequest
   field_entity_map:
-    targetHttpsProxy: targetHttpsProxy
+    targetHttpsProxy: projectTargetHttpsProxy
 - message_name: SetSslPolicyTargetHttpsProxyHttpRequest
   field_entity_map:
-    targetHttpsProxy: targetHttpsProxy
+    targetHttpsProxy: projectGlobalTargetHttpsProxy
 - message_name: SetUrlMapTargetHttpsProxyHttpRequest
   field_entity_map:
-    targetHttpsProxy: targetHttpsProxy
+    targetHttpsProxy: projectTargetHttpsProxy
 - message_name: AggregatedListTargetInstancesHttpRequest
   field_entity_map:
     project: project
 - message_name: DeleteTargetInstanceHttpRequest
   field_entity_map:
-    targetInstance: targetInstance
+    targetInstance: projectZoneTargetInstance
 - message_name: GetTargetInstanceHttpRequest
   field_entity_map:
-    targetInstance: targetInstance
+    targetInstance: projectZoneTargetInstance
 - message_name: InsertTargetInstanceHttpRequest
   field_entity_map:
-    zone: zone
+    zone: projectZone
 - message_name: ListTargetInstancesHttpRequest
   field_entity_map:
-    zone: zone
+    zone: projectZone
 - message_name: AddHealthCheckTargetPoolHttpRequest
   field_entity_map:
-    targetPool: targetPool
+    targetPool: projectRegionTargetPool
 - message_name: AddInstanceTargetPoolHttpRequest
   field_entity_map:
-    targetPool: targetPool
+    targetPool: projectRegionTargetPool
 - message_name: AggregatedListTargetPoolsHttpRequest
   field_entity_map:
     project: project
 - message_name: DeleteTargetPoolHttpRequest
   field_entity_map:
-    targetPool: targetPool
+    targetPool: projectRegionTargetPool
 - message_name: GetTargetPoolHttpRequest
   field_entity_map:
-    targetPool: targetPool
+    targetPool: projectRegionTargetPool
 - message_name: GetHealthTargetPoolHttpRequest
   field_entity_map:
-    targetPool: targetPool
+    targetPool: projectRegionTargetPool
 - message_name: InsertTargetPoolHttpRequest
   field_entity_map:
-    region: region
+    region: projectRegion
 - message_name: ListTargetPoolsHttpRequest
   field_entity_map:
-    region: region
+    region: projectRegion
 - message_name: RemoveHealthCheckTargetPoolHttpRequest
   field_entity_map:
-    targetPool: targetPool
+    targetPool: projectRegionTargetPool
 - message_name: RemoveInstanceTargetPoolHttpRequest
   field_entity_map:
-    targetPool: targetPool
+    targetPool: projectRegionTargetPool
 - message_name: SetBackupTargetPoolHttpRequest
   field_entity_map:
-    targetPool: targetPool
+    targetPool: projectRegionTargetPool
 - message_name: DeleteTargetSslProxyHttpRequest
   field_entity_map:
-    targetSslProxy: targetSslProxy
+    targetSslProxy: projectGlobalTargetSslProxy
 - message_name: GetTargetSslProxyHttpRequest
   field_entity_map:
-    targetSslProxy: targetSslProxy
+    targetSslProxy: projectGlobalTargetSslProxy
 - message_name: InsertTargetSslProxyHttpRequest
   field_entity_map:
     project: project
@@ -16698,22 +14731,22 @@ resource_name_generation:
     project: project
 - message_name: SetBackendServiceTargetSslProxyHttpRequest
   field_entity_map:
-    targetSslProxy: targetSslProxy
+    targetSslProxy: projectGlobalTargetSslProxy
 - message_name: SetProxyHeaderTargetSslProxyHttpRequest
   field_entity_map:
-    targetSslProxy: targetSslProxy
+    targetSslProxy: projectGlobalTargetSslProxy
 - message_name: SetSslCertificatesTargetSslProxyHttpRequest
   field_entity_map:
-    targetSslProxy: targetSslProxy
+    targetSslProxy: projectGlobalTargetSslProxy
 - message_name: SetSslPolicyTargetSslProxyHttpRequest
   field_entity_map:
-    targetSslProxy: targetSslProxy
+    targetSslProxy: projectGlobalTargetSslProxy
 - message_name: DeleteTargetTcpProxyHttpRequest
   field_entity_map:
-    targetTcpProxy: targetTcpProxy
+    targetTcpProxy: projectGlobalTargetTcpProxy
 - message_name: GetTargetTcpProxyHttpRequest
   field_entity_map:
-    targetTcpProxy: targetTcpProxy
+    targetTcpProxy: projectGlobalTargetTcpProxy
 - message_name: InsertTargetTcpProxyHttpRequest
   field_entity_map:
     project: project
@@ -16722,76 +14755,76 @@ resource_name_generation:
     project: project
 - message_name: SetBackendServiceTargetTcpProxyHttpRequest
   field_entity_map:
-    targetTcpProxy: targetTcpProxy
+    targetTcpProxy: projectGlobalTargetTcpProxy
 - message_name: SetProxyHeaderTargetTcpProxyHttpRequest
   field_entity_map:
-    targetTcpProxy: targetTcpProxy
+    targetTcpProxy: projectGlobalTargetTcpProxy
 - message_name: AggregatedListTargetVpnGatewaysHttpRequest
   field_entity_map:
     project: project
 - message_name: DeleteTargetVpnGatewayHttpRequest
   field_entity_map:
-    targetVpnGateway: targetVpnGateway
+    targetVpnGateway: projectRegionTargetVpnGateway
 - message_name: GetTargetVpnGatewayHttpRequest
   field_entity_map:
-    targetVpnGateway: targetVpnGateway
+    targetVpnGateway: projectRegionTargetVpnGateway
 - message_name: InsertTargetVpnGatewayHttpRequest
   field_entity_map:
-    region: region
+    region: projectRegion
 - message_name: ListTargetVpnGatewaysHttpRequest
   field_entity_map:
-    region: region
+    region: projectRegion
 - message_name: DeleteUrlMapHttpRequest
   field_entity_map:
-    urlMap: urlMap
+    urlMap: projectGlobalUrlMap
 - message_name: GetUrlMapHttpRequest
   field_entity_map:
-    urlMap: urlMap
+    urlMap: projectGlobalUrlMap
 - message_name: InsertUrlMapHttpRequest
   field_entity_map:
     project: project
 - message_name: InvalidateCacheUrlMapHttpRequest
   field_entity_map:
-    urlMap: urlMap
+    urlMap: projectGlobalUrlMap
 - message_name: ListUrlMapsHttpRequest
   field_entity_map:
     project: project
 - message_name: PatchUrlMapHttpRequest
   field_entity_map:
-    urlMap: urlMap
+    urlMap: projectGlobalUrlMap
 - message_name: UpdateUrlMapHttpRequest
   field_entity_map:
-    urlMap: urlMap
+    urlMap: projectGlobalUrlMap
 - message_name: ValidateUrlMapHttpRequest
   field_entity_map:
-    urlMap: urlMap
+    urlMap: projectGlobalUrlMap
 - message_name: AggregatedListVpnTunnelsHttpRequest
   field_entity_map:
     project: project
 - message_name: DeleteVpnTunnelHttpRequest
   field_entity_map:
-    vpnTunnel: vpnTunnel
+    vpnTunnel: projectRegionVpnTunnel
 - message_name: GetVpnTunnelHttpRequest
   field_entity_map:
-    vpnTunnel: vpnTunnel
+    vpnTunnel: projectRegionVpnTunnel
 - message_name: InsertVpnTunnelHttpRequest
   field_entity_map:
-    region: region
+    region: projectRegion
 - message_name: ListVpnTunnelsHttpRequest
   field_entity_map:
-    region: region
+    region: projectRegion
 - message_name: DeleteZoneOperationHttpRequest
   field_entity_map:
-    operation: zoneOperationsOperation
+    operation: projectZoneOperation
 - message_name: GetZoneOperationHttpRequest
   field_entity_map:
-    operation: zoneOperationsOperation
+    operation: projectZoneOperation
 - message_name: ListZoneOperationsHttpRequest
   field_entity_map:
-    zone: zone
+    zone: projectZone
 - message_name: GetZoneHttpRequest
   field_entity_map:
-    zone: zone
+    zone: projectZone
 - message_name: ListZonesHttpRequest
   field_entity_map:
     project: project


### PR DESCRIPTION
Previously generated gapic config for compute was generated by toolkit in this repo, which has been out of date. Regenerate it with the latest gapic-generator.

Was able to successfully generate the client with a local artman.