### PR TITLE
Prevent generation of websecurityscanner:v1 for PHP

### DIFF
--- a/server/main.py
+++ b/server/main.py
@@ -58,7 +58,8 @@ def nodejs_release(filepath, github_account, force):
 def php_update(filepath, github_account):
     """Wrapper over the PHP release function to standardize parameters."""
     ddocs = discovery_artifact_manager.discovery_documents(
-        filepath, preferred=True, skip=['discovery:v1'])
+        filepath, preferred=True, skip=['discovery:v1',
+                                        'websecurityscanner:v1'])
     google_api_php_client_services.update(filepath, github_account, ddocs)
 
 


### PR DESCRIPTION
websecurityscanner:v1 shouldn't be in the list returned from https://www.googleapis.com/discovery/v1/apis, we need to prevent generation until this is resolved upstream.