### PR TITLE
fix: Fix bazel generation for discogapic clients.

### DIFF
--- a/gapic/google/compute/v1/BUILD.bazel
+++ b/gapic/google/compute/v1/BUILD.bazel
@@ -1,92 +1,92 @@
-load("@com_google_api_codegen//rules_gapic/java:java_gapic.bzl", "java_discogapic_library")
-load("@com_google_api_codegen//rules_gapic/java:java_gapic_pkg.bzl", "java_gapic_assembly_gradle_pkg")
-
 # This is an API workspace, having public visibility by default makes perfect sense.
 package(default_visibility = ["//visibility:public"])
 
 ##############################################################################
 # Java
 ##############################################################################
+load("@com_google_api_codegen//rules_gapic:gapic.bzl", "discogapic_config")
+load("@com_google_api_codegen//rules_gapic/java:java_gapic.bzl", "java_discogapic_library", "java_gapic_test")
+load("@com_google_api_codegen//rules_gapic/java:java_gapic_pkg.bzl", "java_discogapic_assembly_gradle_pkg")
+
+discogapic_config(
+    name = "compute_gapic_config",
+    src = "//discoveries:compute.v1.json",
+)
+
 java_discogapic_library(
     name = "compute_java_gapic",
     src = "//discoveries:compute.v1.json",
-    gapic_yaml = "compute_gapic.yaml",
+    gapic_yaml = ":compute_gapic_config",
 )
 
-[java_test(
-    name = test_name,
-    test_class = test_name,
-    runtime_deps = [
-        ":compute_java_gapic_test",
+java_gapic_test(
+    name = "compute_java_gapic_test_suite",
+    test_classes = [
+        "com.google.cloud.compute.v1.AcceleratorTypeClientTest",
+        "com.google.cloud.compute.v1.AddressClientTest",
+        "com.google.cloud.compute.v1.AutoscalerClientTest",
+        "com.google.cloud.compute.v1.BackendBucketClientTest",
+        "com.google.cloud.compute.v1.BackendServiceClientTest",
+        "com.google.cloud.compute.v1.DiskClientTest",
+        "com.google.cloud.compute.v1.DiskTypeClientTest",
+        "com.google.cloud.compute.v1.FirewallClientTest",
+        "com.google.cloud.compute.v1.ForwardingRuleClientTest",
+        "com.google.cloud.compute.v1.GlobalAddressClientTest",
+        "com.google.cloud.compute.v1.GlobalForwardingRuleClientTest",
+        "com.google.cloud.compute.v1.GlobalOperationClientTest",
+        "com.google.cloud.compute.v1.HealthCheckClientTest",
+        "com.google.cloud.compute.v1.HttpHealthCheckClientTest",
+        "com.google.cloud.compute.v1.HttpsHealthCheckClientTest",
+        "com.google.cloud.compute.v1.ImageClientTest",
+        "com.google.cloud.compute.v1.InstanceClientTest",
+        "com.google.cloud.compute.v1.InstanceGroupClientTest",
+        "com.google.cloud.compute.v1.InstanceGroupManagerClientTest",
+        "com.google.cloud.compute.v1.InstanceTemplateClientTest",
+        "com.google.cloud.compute.v1.InterconnectAttachmentClientTest",
+        "com.google.cloud.compute.v1.InterconnectClientTest",
+        "com.google.cloud.compute.v1.InterconnectLocationClientTest",
+        "com.google.cloud.compute.v1.LicenseClientTest",
+        "com.google.cloud.compute.v1.LicenseCodeClientTest",
+        "com.google.cloud.compute.v1.MachineTypeClientTest",
+        "com.google.cloud.compute.v1.NetworkClientTest",
+        "com.google.cloud.compute.v1.NodeGroupClientTest",
+        "com.google.cloud.compute.v1.NodeTemplateClientTest",
+        "com.google.cloud.compute.v1.NodeTypeClientTest",
+        "com.google.cloud.compute.v1.ProjectClientTest",
+        "com.google.cloud.compute.v1.RegionAutoscalerClientTest",
+        "com.google.cloud.compute.v1.RegionBackendServiceClientTest",
+        "com.google.cloud.compute.v1.RegionClientTest",
+        "com.google.cloud.compute.v1.RegionCommitmentClientTest",
+        "com.google.cloud.compute.v1.RegionDiskClientTest",
+        "com.google.cloud.compute.v1.RegionDiskTypeClientTest",
+        "com.google.cloud.compute.v1.RegionInstanceGroupClientTest",
+        "com.google.cloud.compute.v1.RegionInstanceGroupManagerClientTest",
+        "com.google.cloud.compute.v1.RegionOperationClientTest",
+        "com.google.cloud.compute.v1.RouteClientTest",
+        "com.google.cloud.compute.v1.RouterClientTest",
+        "com.google.cloud.compute.v1.SnapshotClientTest",
+        "com.google.cloud.compute.v1.SslCertificateClientTest",
+        "com.google.cloud.compute.v1.SslPolicyClientTest",
+        "com.google.cloud.compute.v1.SubnetworkClientTest",
+        "com.google.cloud.compute.v1.TargetHttpProxyClientTest",
+        "com.google.cloud.compute.v1.TargetHttpsProxyClientTest",
+        "com.google.cloud.compute.v1.TargetInstanceClientTest",
+        "com.google.cloud.compute.v1.TargetPoolClientTest",
+        "com.google.cloud.compute.v1.TargetSslProxyClientTest",
+        "com.google.cloud.compute.v1.TargetTcpProxyClientTest",
+        "com.google.cloud.compute.v1.TargetVpnGatewayClientTest",
+        "com.google.cloud.compute.v1.UrlMapClientTest",
+        "com.google.cloud.compute.v1.VpnTunnelClientTest",
+        "com.google.cloud.compute.v1.ZoneClientTest",
+        "com.google.cloud.compute.v1.ZoneOperationClientTest"
     ],
-) for test_name in [
-    "com.google.cloud.compute.v1.AcceleratorTypeClientTest",
-    "com.google.cloud.compute.v1.AddressClientTest",
-    "com.google.cloud.compute.v1.AutoscalerClientTest",
-    "com.google.cloud.compute.v1.BackendBucketClientTest",
-    "com.google.cloud.compute.v1.BackendServiceClientTest",
-    "com.google.cloud.compute.v1.DiskClientTest",
-    "com.google.cloud.compute.v1.DiskTypeClientTest",
-    "com.google.cloud.compute.v1.FirewallClientTest",
-    "com.google.cloud.compute.v1.ForwardingRuleClientTest",
-    "com.google.cloud.compute.v1.GlobalAddressClientTest",
-    "com.google.cloud.compute.v1.GlobalForwardingRuleClientTest",
-    "com.google.cloud.compute.v1.GlobalOperationClientTest",
-    "com.google.cloud.compute.v1.HealthCheckClientTest",
-    "com.google.cloud.compute.v1.HttpHealthCheckClientTest",
-    "com.google.cloud.compute.v1.HttpsHealthCheckClientTest",
-    "com.google.cloud.compute.v1.ImageClientTest",
-    "com.google.cloud.compute.v1.InstanceClientTest",
-    "com.google.cloud.compute.v1.InstanceGroupClientTest",
-    "com.google.cloud.compute.v1.InstanceGroupManagerClientTest",
-    "com.google.cloud.compute.v1.InstanceTemplateClientTest",
-    "com.google.cloud.compute.v1.InterconnectAttachmentClientTest",
-    "com.google.cloud.compute.v1.InterconnectClientTest",
-    "com.google.cloud.compute.v1.InterconnectLocationClientTest",
-    "com.google.cloud.compute.v1.LicenseClientTest",
-    "com.google.cloud.compute.v1.LicenseCodeClientTest",
-    "com.google.cloud.compute.v1.MachineTypeClientTest",
-    "com.google.cloud.compute.v1.NetworkClientTest",
-    "com.google.cloud.compute.v1.NodeGroupClientTest",
-    "com.google.cloud.compute.v1.NodeTemplateClientTest",
-    "com.google.cloud.compute.v1.NodeTypeClientTest",
-    "com.google.cloud.compute.v1.ProjectClientTest",
-    "com.google.cloud.compute.v1.RegionAutoscalerClientTest",
-    "com.google.cloud.compute.v1.RegionBackendServiceClientTest",
-    "com.google.cloud.compute.v1.RegionClientTest",
-    "com.google.cloud.compute.v1.RegionCommitmentClientTest",
-    "com.google.cloud.compute.v1.RegionDiskClientTest",
-    "com.google.cloud.compute.v1.RegionDiskTypeClientTest",
-    "com.google.cloud.compute.v1.RegionInstanceGroupClientTest",
-    "com.google.cloud.compute.v1.RegionInstanceGroupManagerClientTest",
-    "com.google.cloud.compute.v1.RegionOperationClientTest",
-    "com.google.cloud.compute.v1.RouteClientTest",
-    "com.google.cloud.compute.v1.RouterClientTest",
-    "com.google.cloud.compute.v1.SnapshotClientTest",
-    "com.google.cloud.compute.v1.SslCertificateClientTest",
-    "com.google.cloud.compute.v1.SslPolicyClientTest",
-    "com.google.cloud.compute.v1.SubnetworkClientTest",
-    "com.google.cloud.compute.v1.TargetHttpProxyClientTest",
-    "com.google.cloud.compute.v1.TargetHttpsProxyClientTest",
-    "com.google.cloud.compute.v1.TargetInstanceClientTest",
-    "com.google.cloud.compute.v1.TargetPoolClientTest",
-    "com.google.cloud.compute.v1.TargetSslProxyClientTest",
-    "com.google.cloud.compute.v1.TargetTcpProxyClientTest",
-    "com.google.cloud.compute.v1.TargetVpnGatewayClientTest",
-    "com.google.cloud.compute.v1.UrlMapClientTest",
-    "com.google.cloud.compute.v1.VpnTunnelClientTest",
-    "com.google.cloud.compute.v1.ZoneClientTest",
-    "com.google.cloud.compute.v1.ZoneOperationClientTest",
-]]
+    runtime_deps = [":compute_java_gapic_test"],
+)
 
-
-##############################################################################
-# Java Opensource Gradle Packages
-##############################################################################
-java_gapic_assembly_gradle_pkg(
+# Open Source Packages
+java_discogapic_assembly_gradle_pkg(
     name = "google-cloud-compute-v1-java",
-    client_group = 'com.google.cloud',
-    version = '0.0.0-SNAPSHOT',
-    client_deps = [":compute_java_gapic"],
-    client_test_deps = [":compute_java_gapic_test"],
+    deps = [
+        ":compute_java_gapic",
+    ],
 )

--- a/gapic/google/compute/v1/compute_gapic.yaml
+++ b/gapic/google/compute/v1/compute_gapic.yaml
@@ -106,9 +106,11 @@ interfaces:
     flattening:
       groups:
       - parameters:
+        - includeAllScopes
         - project
     # TODO: Configure which fields are required.
     required_fields:
+    - includeAllScopes
     - project
     page_streaming:
       request:
@@ -251,9 +253,11 @@ interfaces:
     flattening:
       groups:
       - parameters:
+        - includeAllScopes
         - project
     # TODO: Configure which fields are required.
     required_fields:
+    - includeAllScopes
     - project
     page_streaming:
       request:
@@ -434,9 +438,11 @@ interfaces:
     flattening:
       groups:
       - parameters:
+        - includeAllScopes
         - project
     # TODO: Configure which fields are required.
     required_fields:
+    - includeAllScopes
     - project
     page_streaming:
       request:
@@ -915,9 +921,11 @@ interfaces:
     flattening:
       groups:
       - parameters:
+        - includeAllScopes
         - project
     # TODO: Configure which fields are required.
     required_fields:
+    - includeAllScopes
     - project
     page_streaming:
       request:
@@ -1198,9 +1206,11 @@ interfaces:
     flattening:
       groups:
       - parameters:
+        - includeAllScopes
         - project
     # TODO: Configure which fields are required.
     required_fields:
+    - includeAllScopes
     - project
     page_streaming:
       request:
@@ -1365,9 +1375,11 @@ interfaces:
     flattening:
       groups:
       - parameters:
+        - includeAllScopes
         - project
     # TODO: Configure which fields are required.
     required_fields:
+    - includeAllScopes
     - project
     page_streaming:
       request:
@@ -2082,9 +2094,11 @@ interfaces:
     flattening:
       groups:
       - parameters:
+        - includeAllScopes
         - project
     # TODO: Configure which fields are required.
     required_fields:
+    - includeAllScopes
     - project
     page_streaming:
       request:
@@ -2575,6 +2589,227 @@ interfaces:
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
 # The fully qualified name of the API interface.
+- name: google.compute.v1.GlobalNetworkEndpointGroups
+  # A list of resource collection configurations.
+  # Consists of a name_pattern and an entity_name.
+  # The name_pattern is a pattern to describe the names of the resources of this
+  # collection, using the platform's conventions for URI patterns. A generator
+  # may use this to generate methods to compose and decompose such names. The
+  # pattern should use named placeholders as in `shelves/{shelf}/books/{book}`;
+  # those will be taken as hints for the parameter names of the generated
+  # methods. If empty, no name methods are generated.
+  # The entity_name is the name to be used as a basis for generated methods and
+  # classes.
+  collections:
+  - name_pattern: '{project}'
+    entity_name: project
+  - name_pattern: '{project}/global/networkEndpointGroups/{networkEndpointGroup}'
+    entity_name: projectGlobalNetworkEndpointGroup
+  # Definition for retryable codes.
+  retry_codes_def:
+  - name: idempotent
+    retry_codes:
+    - UNAVAILABLE
+    - DEADLINE_EXCEEDED
+  - name: non_idempotent
+    retry_codes: []
+  # Definition for retry/backoff parameters.
+  retry_params_def:
+  - name: default
+    initial_retry_delay_millis: 100
+    retry_delay_multiplier: 1.3
+    max_retry_delay_millis: 60000
+    initial_rpc_timeout_millis: 20000
+    rpc_timeout_multiplier: 1
+    max_rpc_timeout_millis: 20000
+    total_timeout_millis: 600000
+  # A list of method configurations.
+  # Common properties:
+  #   name - The simple name of the method.
+  #   flattening - Specifies the configuration for parameter flattening.
+  #       Describes the parameter groups for which a generator should produce
+  #       method overloads which allow a client to directly pass request message
+  #       fields as method parameters. This information may or may not be used,
+  #       depending on the target language.
+  #       Consists of groups, which each represent a list of parameters to be
+  #       flattened. Each parameter listed must be a field of the request
+  #       message.
+  #   required_fields - Fields that are always required for a request to be
+  #       valid.
+  #   page_streaming - Specifies the configuration for paging.
+  #       Describes information for generating a method which transforms a
+  #       paging list RPC into a stream of resources.
+  #       Consists of a request and a response.
+  #       The request specifies request information of the list method. It
+  #       defines which fields match the paging pattern in the request. The
+  #       request consists of a page_size_field and a token_field. The
+  #       page_size_field is the name of the optional field specifying the
+  #       maximum number of elements to be returned in the response. The
+  #       token_field is the name of the field in the request containing the
+  #       page token.
+  #       The response specifies response information of the list method. It
+  #       defines which fields match the paging pattern in the response. The
+  #       response consists of a token_field and a resources_field. The
+  #       token_field is the name of the field in the response containing the
+  #       next page token. The resources_field is the name of the field in the
+  #       response containing the list of resources belonging to the page.
+  #   retry_codes_name - Specifies the configuration for retryable codes. The
+  #       name must be defined in interfaces.retry_codes_def.
+  #   retry_params_name - Specifies the configuration for retry/backoff
+  #       parameters. The name must be defined in interfaces.retry_params_def.
+  #   field_name_patterns - Maps the field name of the request type to
+  #       entity_name of interfaces.collections.
+  #       Specifies the string pattern that the field must follow.
+  #   timeout_millis - Specifies the default timeout for a non-retrying call. If
+  #       the call is retrying, refer to retry_params_name instead.
+  methods:
+  - name: compute.globalNetworkEndpointGroups.attachNetworkEndpoints
+    # TODO: Configure which groups of fields should be flattened into method
+    # params.
+    flattening:
+      groups:
+      - parameters:
+        - networkEndpointGroup
+        - globalNetworkEndpointGroupsAttachEndpointsRequestResource
+    # TODO: Configure which fields are required.
+    required_fields:
+    - networkEndpointGroup
+    - globalNetworkEndpointGroupsAttachEndpointsRequestResource
+    # TODO: Configure the retryable codes for this method.
+    retry_codes_name: non_idempotent
+    # TODO: Configure the retryable params for this method.
+    retry_params_name: default
+    field_name_patterns:
+      networkEndpointGroup: projectGlobalNetworkEndpointGroup
+    # TODO: Configure the default timeout for a non-retrying call.
+    timeout_millis: 60000
+  - name: compute.globalNetworkEndpointGroups.delete
+    # TODO: Configure which groups of fields should be flattened into method
+    # params.
+    flattening:
+      groups:
+      - parameters:
+        - networkEndpointGroup
+    # TODO: Configure which fields are required.
+    required_fields:
+    - networkEndpointGroup
+    # TODO: Configure the retryable codes for this method.
+    retry_codes_name: idempotent
+    # TODO: Configure the retryable params for this method.
+    retry_params_name: default
+    field_name_patterns:
+      networkEndpointGroup: projectGlobalNetworkEndpointGroup
+    # TODO: Configure the default timeout for a non-retrying call.
+    timeout_millis: 60000
+  - name: compute.globalNetworkEndpointGroups.detachNetworkEndpoints
+    # TODO: Configure which groups of fields should be flattened into method
+    # params.
+    flattening:
+      groups:
+      - parameters:
+        - networkEndpointGroup
+        - globalNetworkEndpointGroupsDetachEndpointsRequestResource
+    # TODO: Configure which fields are required.
+    required_fields:
+    - networkEndpointGroup
+    - globalNetworkEndpointGroupsDetachEndpointsRequestResource
+    # TODO: Configure the retryable codes for this method.
+    retry_codes_name: non_idempotent
+    # TODO: Configure the retryable params for this method.
+    retry_params_name: default
+    field_name_patterns:
+      networkEndpointGroup: projectGlobalNetworkEndpointGroup
+    # TODO: Configure the default timeout for a non-retrying call.
+    timeout_millis: 60000
+  - name: compute.globalNetworkEndpointGroups.get
+    # TODO: Configure which groups of fields should be flattened into method
+    # params.
+    flattening:
+      groups:
+      - parameters:
+        - networkEndpointGroup
+    # TODO: Configure which fields are required.
+    required_fields:
+    - networkEndpointGroup
+    # TODO: Configure the retryable codes for this method.
+    retry_codes_name: idempotent
+    # TODO: Configure the retryable params for this method.
+    retry_params_name: default
+    field_name_patterns:
+      networkEndpointGroup: projectGlobalNetworkEndpointGroup
+    # TODO: Configure the default timeout for a non-retrying call.
+    timeout_millis: 60000
+  - name: compute.globalNetworkEndpointGroups.insert
+    # TODO: Configure which groups of fields should be flattened into method
+    # params.
+    flattening:
+      groups:
+      - parameters:
+        - project
+        - networkEndpointGroupResource
+    # TODO: Configure which fields are required.
+    required_fields:
+    - project
+    - networkEndpointGroupResource
+    # TODO: Configure the retryable codes for this method.
+    retry_codes_name: non_idempotent
+    # TODO: Configure the retryable params for this method.
+    retry_params_name: default
+    field_name_patterns:
+      project: project
+    # TODO: Configure the default timeout for a non-retrying call.
+    timeout_millis: 60000
+  - name: compute.globalNetworkEndpointGroups.list
+    # TODO: Configure which groups of fields should be flattened into method
+    # params.
+    flattening:
+      groups:
+      - parameters:
+        - project
+    # TODO: Configure which fields are required.
+    required_fields:
+    - project
+    page_streaming:
+      request:
+        page_size_field: maxResults
+        token_field: pageToken
+      response:
+        token_field: nextPageToken
+        resources_field: items
+    # TODO: Configure the retryable codes for this method.
+    retry_codes_name: idempotent
+    # TODO: Configure the retryable params for this method.
+    retry_params_name: default
+    field_name_patterns:
+      project: project
+    # TODO: Configure the default timeout for a non-retrying call.
+    timeout_millis: 60000
+  - name: compute.globalNetworkEndpointGroups.listNetworkEndpoints
+    # TODO: Configure which groups of fields should be flattened into method
+    # params.
+    flattening:
+      groups:
+      - parameters:
+        - networkEndpointGroup
+    # TODO: Configure which fields are required.
+    required_fields:
+    - networkEndpointGroup
+    page_streaming:
+      request:
+        page_size_field: maxResults
+        token_field: pageToken
+      response:
+        token_field: nextPageToken
+        resources_field: items
+    # TODO: Configure the retryable codes for this method.
+    retry_codes_name: non_idempotent
+    # TODO: Configure the retryable params for this method.
+    retry_params_name: default
+    field_name_patterns:
+      networkEndpointGroup: projectGlobalNetworkEndpointGroup
+    # TODO: Configure the default timeout for a non-retrying call.
+    timeout_millis: 60000
+# The fully qualified name of the API interface.
 - name: google.compute.v1.GlobalOperations
   # A list of resource collection configurations.
   # Consists of a name_pattern and an entity_name.
@@ -2655,9 +2890,11 @@ interfaces:
     flattening:
       groups:
       - parameters:
+        - includeAllScopes
         - project
     # TODO: Configure which fields are required.
     required_fields:
+    - includeAllScopes
     - project
     page_streaming:
       request:
@@ -2834,9 +3071,11 @@ interfaces:
     flattening:
       groups:
       - parameters:
+        - includeAllScopes
         - project
     # TODO: Configure which fields are required.
     required_fields:
+    - includeAllScopes
     - project
     page_streaming:
       request:
@@ -3747,9 +3986,11 @@ interfaces:
     flattening:
       groups:
       - parameters:
+        - includeAllScopes
         - project
     # TODO: Configure which fields are required.
     required_fields:
+    - includeAllScopes
     - project
     page_streaming:
       request:
@@ -3764,6 +4005,26 @@ interfaces:
     retry_params_name: default
     field_name_patterns:
       project: project
+    # TODO: Configure the default timeout for a non-retrying call.
+    timeout_millis: 60000
+  - name: compute.instanceGroupManagers.applyUpdatesToInstances
+    # TODO: Configure which groups of fields should be flattened into method
+    # params.
+    flattening:
+      groups:
+      - parameters:
+        - instanceGroupManager
+        - instanceGroupManagersApplyUpdatesRequestResource
+    # TODO: Configure which fields are required.
+    required_fields:
+    - instanceGroupManager
+    - instanceGroupManagersApplyUpdatesRequestResource
+    # TODO: Configure the retryable codes for this method.
+    retry_codes_name: non_idempotent
+    # TODO: Configure the retryable params for this method.
+    retry_params_name: default
+    field_name_patterns:
+      instanceGroupManager: projectZoneInstanceGroupManager
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
   - name: compute.instanceGroupManagers.createInstances
@@ -3885,6 +4146,31 @@ interfaces:
     retry_params_name: default
     field_name_patterns:
       zone: projectZone
+    # TODO: Configure the default timeout for a non-retrying call.
+    timeout_millis: 60000
+  - name: compute.instanceGroupManagers.listErrors
+    # TODO: Configure which groups of fields should be flattened into method
+    # params.
+    flattening:
+      groups:
+      - parameters:
+        - instanceGroupManager
+    # TODO: Configure which fields are required.
+    required_fields:
+    - instanceGroupManager
+    page_streaming:
+      request:
+        page_size_field: maxResults
+        token_field: pageToken
+      response:
+        token_field: nextPageToken
+        resources_field: items
+    # TODO: Configure the retryable codes for this method.
+    retry_codes_name: idempotent
+    # TODO: Configure the retryable params for this method.
+    retry_params_name: default
+    field_name_patterns:
+      instanceGroupManager: projectZoneInstanceGroupManager
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
   - name: compute.instanceGroupManagers.listManagedInstances
@@ -4108,9 +4394,11 @@ interfaces:
     flattening:
       groups:
       - parameters:
+        - includeAllScopes
         - project
     # TODO: Configure which fields are required.
     required_fields:
+    - includeAllScopes
     - project
     page_streaming:
       request:
@@ -4592,15 +4880,37 @@ interfaces:
       instance: projectZoneInstance
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
+  - name: compute.instances.addResourcePolicies
+    # TODO: Configure which groups of fields should be flattened into method
+    # params.
+    flattening:
+      groups:
+      - parameters:
+        - instance
+        - instancesAddResourcePoliciesRequestResource
+    # TODO: Configure which fields are required.
+    required_fields:
+    - instance
+    - instancesAddResourcePoliciesRequestResource
+    # TODO: Configure the retryable codes for this method.
+    retry_codes_name: non_idempotent
+    # TODO: Configure the retryable params for this method.
+    retry_params_name: default
+    field_name_patterns:
+      instance: projectZoneInstance
+    # TODO: Configure the default timeout for a non-retrying call.
+    timeout_millis: 60000
   - name: compute.instances.aggregatedList
     # TODO: Configure which groups of fields should be flattened into method
     # params.
     flattening:
       groups:
       - parameters:
+        - includeAllScopes
         - project
     # TODO: Configure which fields are required.
     required_fields:
+    - includeAllScopes
     - project
     page_streaming:
       request:
@@ -4861,6 +5171,26 @@ interfaces:
         resources_field: items
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: idempotent
+    # TODO: Configure the retryable params for this method.
+    retry_params_name: default
+    field_name_patterns:
+      instance: projectZoneInstance
+    # TODO: Configure the default timeout for a non-retrying call.
+    timeout_millis: 60000
+  - name: compute.instances.removeResourcePolicies
+    # TODO: Configure which groups of fields should be flattened into method
+    # params.
+    flattening:
+      groups:
+      - parameters:
+        - instance
+        - instancesRemoveResourcePoliciesRequestResource
+    # TODO: Configure which fields are required.
+    required_fields:
+    - instance
+    - instancesRemoveResourcePoliciesRequestResource
+    # TODO: Configure the retryable codes for this method.
+    retry_codes_name: non_idempotent
     # TODO: Configure the retryable params for this method.
     retry_params_name: default
     field_name_patterns:
@@ -5221,6 +5551,28 @@ interfaces:
       resource: projectZoneInstanceResource
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
+  - name: compute.instances.update
+    # TODO: Configure which fields are required.
+    flattening:
+      groups:
+      - parameters:
+        - mostDisruptiveAllowedAction
+        - minimalAction
+        - instance
+        - instanceResource
+    required_fields:
+    - mostDisruptiveAllowedAction
+    - minimalAction
+    - instance
+    - instanceResource
+    # TODO: Configure the retryable codes for this method.
+    retry_codes_name: idempotent
+    # TODO: Configure the retryable params for this method.
+    retry_params_name: default
+    field_name_patterns:
+      instance: projectZoneInstance
+    # TODO: Configure the default timeout for a non-retrying call.
+    timeout_millis: 60000
   - name: compute.instances.updateAccessConfig
     # TODO: Configure which groups of fields should be flattened into method
     # params.
@@ -5388,9 +5740,11 @@ interfaces:
     flattening:
       groups:
       - parameters:
+        - includeAllScopes
         - project
     # TODO: Configure which fields are required.
     required_fields:
+    - includeAllScopes
     - project
     page_streaming:
       request:
@@ -6234,9 +6588,11 @@ interfaces:
     flattening:
       groups:
       - parameters:
+        - includeAllScopes
         - project
     # TODO: Configure which fields are required.
     required_fields:
+    - includeAllScopes
     - project
     page_streaming:
       request:
@@ -6381,9 +6737,11 @@ interfaces:
     flattening:
       groups:
       - parameters:
+        - includeAllScopes
         - project
     # TODO: Configure which fields are required.
     required_fields:
+    - includeAllScopes
     - project
     page_streaming:
       request:
@@ -6958,9 +7316,11 @@ interfaces:
     flattening:
       groups:
       - parameters:
+        - includeAllScopes
         - project
     # TODO: Configure which fields are required.
     required_fields:
+    - includeAllScopes
     - project
     page_streaming:
       request:
@@ -7123,6 +7483,26 @@ interfaces:
       nodeGroup: projectZoneNodeGroup
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
+  - name: compute.nodeGroups.patch
+    # TODO: Configure which groups of fields should be flattened into method
+    # params.
+    flattening:
+      groups:
+      - parameters:
+        - nodeGroup
+        - nodeGroupResource
+    # TODO: Configure which fields are required.
+    required_fields:
+    - nodeGroup
+    - nodeGroupResource
+    # TODO: Configure the retryable codes for this method.
+    retry_codes_name: non_idempotent
+    # TODO: Configure the retryable params for this method.
+    retry_params_name: default
+    field_name_patterns:
+      nodeGroup: projectZoneNodeGroup
+    # TODO: Configure the default timeout for a non-retrying call.
+    timeout_millis: 60000
   - name: compute.nodeGroups.setIamPolicy
     # TODO: Configure which groups of fields should be flattened into method
     # params.
@@ -7268,9 +7648,11 @@ interfaces:
     flattening:
       groups:
       - parameters:
+        - includeAllScopes
         - project
     # TODO: Configure which fields are required.
     required_fields:
+    - includeAllScopes
     - project
     page_streaming:
       request:
@@ -7509,9 +7891,11 @@ interfaces:
     flattening:
       groups:
       - parameters:
+        - includeAllScopes
         - project
     # TODO: Configure which fields are required.
     required_fields:
+    - includeAllScopes
     - project
     page_streaming:
       request:
@@ -7656,9 +8040,11 @@ interfaces:
     flattening:
       groups:
       - parameters:
+        - includeAllScopes
         - project
     # TODO: Configure which fields are required.
     required_fields:
+    - includeAllScopes
     - project
     page_streaming:
       request:
@@ -8632,9 +9018,11 @@ interfaces:
     flattening:
       groups:
       - parameters:
+        - includeAllScopes
         - project
     # TODO: Configure which fields are required.
     required_fields:
+    - includeAllScopes
     - project
     page_streaming:
       request:
@@ -9401,6 +9789,26 @@ interfaces:
       instanceGroupManager: projectRegionInstanceGroupManager
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
+  - name: compute.regionInstanceGroupManagers.applyUpdatesToInstances
+    # TODO: Configure which groups of fields should be flattened into method
+    # params.
+    flattening:
+      groups:
+      - parameters:
+        - instanceGroupManager
+        - regionInstanceGroupManagersApplyUpdatesRequestResource
+    # TODO: Configure which fields are required.
+    required_fields:
+    - instanceGroupManager
+    - regionInstanceGroupManagersApplyUpdatesRequestResource
+    # TODO: Configure the retryable codes for this method.
+    retry_codes_name: non_idempotent
+    # TODO: Configure the retryable params for this method.
+    retry_params_name: default
+    field_name_patterns:
+      instanceGroupManager: projectRegionInstanceGroupManager
+    # TODO: Configure the default timeout for a non-retrying call.
+    timeout_millis: 60000
   - name: compute.regionInstanceGroupManagers.createInstances
     # TODO: Configure which groups of fields should be flattened into method
     # params.
@@ -9520,6 +9928,31 @@ interfaces:
     retry_params_name: default
     field_name_patterns:
       region: projectRegion
+    # TODO: Configure the default timeout for a non-retrying call.
+    timeout_millis: 60000
+  - name: compute.regionInstanceGroupManagers.listErrors
+    # TODO: Configure which groups of fields should be flattened into method
+    # params.
+    flattening:
+      groups:
+      - parameters:
+        - instanceGroupManager
+    # TODO: Configure which fields are required.
+    required_fields:
+    - instanceGroupManager
+    page_streaming:
+      request:
+        page_size_field: maxResults
+        token_field: pageToken
+      response:
+        token_field: nextPageToken
+        resources_field: items
+    # TODO: Configure the retryable codes for this method.
+    retry_codes_name: idempotent
+    # TODO: Configure the retryable params for this method.
+    retry_params_name: default
+    field_name_patterns:
+      instanceGroupManager: projectRegionInstanceGroupManager
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
   - name: compute.regionInstanceGroupManagers.listManagedInstances
@@ -10077,11 +10510,9 @@ interfaces:
       groups:
       - parameters:
         - region
-        - sslCertificateResource
     # TODO: Configure which fields are required.
     required_fields:
     - region
-    - sslCertificateResource
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: non_idempotent
     # TODO: Configure the retryable params for this method.
@@ -10914,9 +11345,11 @@ interfaces:
     flattening:
       groups:
       - parameters:
+        - includeAllScopes
         - project
     # TODO: Configure which fields are required.
     required_fields:
+    - includeAllScopes
     - project
     page_streaming:
       request:
@@ -11177,9 +11610,11 @@ interfaces:
     flattening:
       groups:
       - parameters:
+        - includeAllScopes
         - project
     # TODO: Configure which fields are required.
     required_fields:
+    - includeAllScopes
     - project
     page_streaming:
       request:
@@ -11418,9 +11853,11 @@ interfaces:
     flattening:
       groups:
       - parameters:
+        - includeAllScopes
         - project
     # TODO: Configure which fields are required.
     required_fields:
+    - includeAllScopes
     - project
     page_streaming:
       request:
@@ -12332,9 +12769,11 @@ interfaces:
     flattening:
       groups:
       - parameters:
+        - includeAllScopes
         - project
     # TODO: Configure which fields are required.
     required_fields:
+    - includeAllScopes
     - project
     page_streaming:
       request:
@@ -12394,11 +12833,9 @@ interfaces:
       groups:
       - parameters:
         - project
-        - sslCertificateResource
     # TODO: Configure which fields are required.
     required_fields:
     - project
-    - sslCertificateResource
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: non_idempotent
     # TODO: Configure the retryable params for this method.
@@ -12711,9 +13148,11 @@ interfaces:
     flattening:
       groups:
       - parameters:
+        - includeAllScopes
         - project
     # TODO: Configure which fields are required.
     required_fields:
+    - includeAllScopes
     - project
     page_streaming:
       request:
@@ -13039,9 +13478,11 @@ interfaces:
     flattening:
       groups:
       - parameters:
+        - includeAllScopes
         - project
     # TODO: Configure which fields are required.
     required_fields:
+    - includeAllScopes
     - project
     page_streaming:
       request:
@@ -13242,9 +13683,11 @@ interfaces:
     flattening:
       groups:
       - parameters:
+        - includeAllScopes
         - project
     # TODO: Configure which fields are required.
     required_fields:
+    - includeAllScopes
     - project
     page_streaming:
       request:
@@ -13505,9 +13948,11 @@ interfaces:
     flattening:
       groups:
       - parameters:
+        - includeAllScopes
         - project
     # TODO: Configure which fields are required.
     required_fields:
+    - includeAllScopes
     - project
     page_streaming:
       request:
@@ -13728,9 +14173,11 @@ interfaces:
     flattening:
       groups:
       - parameters:
+        - includeAllScopes
         - project
     # TODO: Configure which fields are required.
     required_fields:
+    - includeAllScopes
     - project
     page_streaming:
       request:
@@ -14423,9 +14870,11 @@ interfaces:
     flattening:
       groups:
       - parameters:
+        - includeAllScopes
         - project
     # TODO: Configure which fields are required.
     required_fields:
+    - includeAllScopes
     - project
     page_streaming:
       request:
@@ -14604,9 +15053,11 @@ interfaces:
     flattening:
       groups:
       - parameters:
+        - includeAllScopes
         - project
     # TODO: Configure which fields are required.
     required_fields:
+    - includeAllScopes
     - project
     page_streaming:
       request:
@@ -14869,9 +15320,11 @@ interfaces:
     flattening:
       groups:
       - parameters:
+        - includeAllScopes
         - project
     # TODO: Configure which fields are required.
     required_fields:
+    - includeAllScopes
     - project
     page_streaming:
       request:
@@ -15110,9 +15563,11 @@ interfaces:
     flattening:
       groups:
       - parameters:
+        - includeAllScopes
         - project
     # TODO: Configure which fields are required.
     required_fields:
+    - includeAllScopes
     - project
     page_streaming:
       request:
@@ -15720,6 +16175,27 @@ resource_name_generation:
 - message_name: SetTargetGlobalForwardingRuleHttpRequest
   field_entity_map:
     forwardingRule: projectGlobalForwardingRule
+- message_name: AttachNetworkEndpointsGlobalNetworkEndpointGroupHttpRequest
+  field_entity_map:
+    networkEndpointGroup: projectGlobalNetworkEndpointGroup
+- message_name: DeleteGlobalNetworkEndpointGroupHttpRequest
+  field_entity_map:
+    networkEndpointGroup: projectGlobalNetworkEndpointGroup
+- message_name: DetachNetworkEndpointsGlobalNetworkEndpointGroupHttpRequest
+  field_entity_map:
+    networkEndpointGroup: projectGlobalNetworkEndpointGroup
+- message_name: GetGlobalNetworkEndpointGroupHttpRequest
+  field_entity_map:
+    networkEndpointGroup: projectGlobalNetworkEndpointGroup
+- message_name: InsertGlobalNetworkEndpointGroupHttpRequest
+  field_entity_map:
+    project: project
+- message_name: ListGlobalNetworkEndpointGroupsHttpRequest
+  field_entity_map:
+    project: project
+- message_name: ListNetworkEndpointsGlobalNetworkEndpointGroupsHttpRequest
+  field_entity_map:
+    networkEndpointGroup: projectGlobalNetworkEndpointGroup
 - message_name: AggregatedListGlobalOperationsHttpRequest
   field_entity_map:
     project: project
@@ -15828,6 +16304,9 @@ resource_name_generation:
 - message_name: AggregatedListInstanceGroupManagersHttpRequest
   field_entity_map:
     project: project
+- message_name: ApplyUpdatesToInstancesInstanceGroupManagerHttpRequest
+  field_entity_map:
+    instanceGroupManager: projectZoneInstanceGroupManager
 - message_name: CreateInstancesInstanceGroupManagerHttpRequest
   field_entity_map:
     instanceGroupManager: projectZoneInstanceGroupManager
@@ -15846,6 +16325,9 @@ resource_name_generation:
 - message_name: ListInstanceGroupManagersHttpRequest
   field_entity_map:
     zone: projectZone
+- message_name: ListErrorsInstanceGroupManagersHttpRequest
+  field_entity_map:
+    instanceGroupManager: projectZoneInstanceGroupManager
 - message_name: ListManagedInstancesInstanceGroupManagersHttpRequest
   field_entity_map:
     instanceGroupManager: projectZoneInstanceGroupManager
@@ -15915,6 +16397,9 @@ resource_name_generation:
 - message_name: AddAccessConfigInstanceHttpRequest
   field_entity_map:
     instance: projectZoneInstance
+- message_name: AddResourcePoliciesInstanceHttpRequest
+  field_entity_map:
+    instance: projectZoneInstance
 - message_name: AggregatedListInstancesHttpRequest
   field_entity_map:
     project: project
@@ -15952,6 +16437,9 @@ resource_name_generation:
   field_entity_map:
     zone: projectZone
 - message_name: ListReferrersInstancesHttpRequest
+  field_entity_map:
+    instance: projectZoneInstance
+- message_name: RemoveResourcePoliciesInstanceHttpRequest
   field_entity_map:
     instance: projectZoneInstance
 - message_name: ResetInstanceHttpRequest
@@ -16008,6 +16496,9 @@ resource_name_generation:
 - message_name: TestIamPermissionsInstanceHttpRequest
   field_entity_map:
     resource: projectZoneInstanceResource
+- message_name: UpdateInstanceHttpRequest
+  field_entity_map:
+    instance: projectZoneInstance
 - message_name: UpdateAccessConfigInstanceHttpRequest
   field_entity_map:
     instance: projectZoneInstance
@@ -16180,6 +16671,9 @@ resource_name_generation:
   field_entity_map:
     zone: projectZone
 - message_name: ListNodesNodeGroupsHttpRequest
+  field_entity_map:
+    nodeGroup: projectZoneNodeGroup
+- message_name: PatchNodeGroupHttpRequest
   field_entity_map:
     nodeGroup: projectZoneNodeGroup
 - message_name: SetIamPolicyNodeGroupHttpRequest
@@ -16392,6 +16886,9 @@ resource_name_generation:
 - message_name: AbandonInstancesRegionInstanceGroupManagerHttpRequest
   field_entity_map:
     instanceGroupManager: projectRegionInstanceGroupManager
+- message_name: ApplyUpdatesToInstancesRegionInstanceGroupManagerHttpRequest
+  field_entity_map:
+    instanceGroupManager: projectRegionInstanceGroupManager
 - message_name: CreateInstancesRegionInstanceGroupManagerHttpRequest
   field_entity_map:
     instanceGroupManager: projectRegionInstanceGroupManager
@@ -16410,6 +16907,9 @@ resource_name_generation:
 - message_name: ListRegionInstanceGroupManagersHttpRequest
   field_entity_map:
     region: projectRegion
+- message_name: ListErrorsRegionInstanceGroupManagersHttpRequest
+  field_entity_map:
+    instanceGroupManager: projectRegionInstanceGroupManager
 - message_name: ListManagedInstancesRegionInstanceGroupManagersHttpRequest
   field_entity_map:
     instanceGroupManager: projectRegionInstanceGroupManager


### PR DESCRIPTION
Also update `compute_gapic.yaml`.

Note, the checked in `cumpute_gapic.yaml` is not used for bazel generation and is kept here only for backward compatibility with artman generation. Bazel generates the gapic file on the fly.