### PR TITLE
fix go generation

### DIFF
--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -12,9 +12,9 @@ RUN apt-get install -y git
 
 RUN apt-get install -y curl openssh-client wget
 
-# Install Go 1.11.
-RUN wget https://storage.googleapis.com/golang/go1.11.linux-amd64.tar.gz
-RUN tar -xvf go1.11.linux-amd64.tar.gz
+# Install Go 1.12.
+RUN wget https://storage.googleapis.com/golang/go1.12.linux-amd64.tar.gz
+RUN tar -xvf go1.12.linux-amd64.tar.gz
 RUN mv go /usr/local
 ENV PATH /usr/local/go/bin:$PATH
 

--- a/server/tasks/google_api_go_client.py
+++ b/server/tasks/google_api_go_client.py
@@ -40,6 +40,7 @@ def update(filepath, github_account):
                  env=env)
     repo = _git.Repository(join(filepath, 'src/google.golang.org/api'))
     generator_filepath = join(repo.filepath, 'google-api-go-generator')
+    env['GO111MODULE'] = 'on'
     check_output(['make', 'all'], cwd=generator_filepath, env=env)
     repo.add(['.'])
     added, deleted, updated = set(), set(), set()


### PR DESCRIPTION
The way this was managing the dependencies used for Go was not
honoring modules. This caused the apiaries to be built with HEAD
of deps. There was a recent change in one of our deps that broke on
us when using head. We should now use modules for building the code.
Note, the ennvar is explicitly not set for the `go get` command.