### PR TITLE
refactor Go generation

### DIFF
--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -17,6 +17,7 @@ RUN wget https://storage.googleapis.com/golang/go1.12.linux-amd64.tar.gz
 RUN tar -xvf go1.12.linux-amd64.tar.gz
 RUN mv go /usr/local
 ENV PATH /usr/local/go/bin:$PATH
+ENV GO111MODULE on
 
 # Install Node.js 8.x.
 # We need to use 8.x because generate.ts in google-cloud-nodejs-client

--- a/server/tasks/google_api_go_client.py
+++ b/server/tasks/google_api_go_client.py
@@ -35,12 +35,8 @@ def update(filepath, github_account):
         github_account (GitHubAccount): the GitHub account to commit with.
     """
     env = os.environ.copy()
-    env['GOPATH'] = filepath
-    check_output(['go', 'get', '-d', '-t', 'google.golang.org/api/...'],
-                 env=env)
-    repo = _git.Repository(join(filepath, 'src/google.golang.org/api'))
+    repo = _git.clone('https://code.googlesource.com/google-api-go-client', join(filepath, 'google-api-go-client'))
     generator_filepath = join(repo.filepath, 'google-api-go-generator')
-    env['GO111MODULE'] = 'on'
     check_output(['make', 'all'], cwd=generator_filepath, env=env)
     repo.add(['.'])
     added, deleted, updated = set(), set(), set()


### PR DESCRIPTION
There seems to be something strange where GO111MODULE=on is not
being honored by the `make all` command. I believe this is because
the code was in GOPATH.

Removed the need for GOPATH by making use of git to download the
src code.