### PR TITLE
Discovery samples: Ensure the last element of the Java import path is capitalized

### DIFF
--- a/toolkit/src/main/java/com/google/api/codegen/discovery/transformer/java/JavaSampleTypeNameConverter.java
+++ b/toolkit/src/main/java/com/google/api/codegen/discovery/transformer/java/JavaSampleTypeNameConverter.java
@@ -73,7 +73,15 @@ class JavaSampleTypeNameConverter implements SampleTypeNameConverter {
 
   @Override
   public TypeName getServiceTypeName(String apiTypeName) {
-    return typeNameConverter.getTypeName(Joiner.on('.').join(packagePrefix, apiTypeName));
+    return typeNameConverter.getTypeName(
+        Joiner.on('.').join(packagePrefix, capitalize(apiTypeName)));
+  }
+
+  public static String capitalize(String str) {
+    if (str == null || str.isEmpty()) {
+      return str;
+    }
+    return str.substring(0, 1).toUpperCase() + str.substring(1);
   }
 
   @Override


### PR DESCRIPTION
This was causing problems for IAM, since the Discovery file said `"canonicalName" : "iam"` and thus the import in the sample read `import ....v1.iam;` instead of `import ....v1.Iam;`