### PR TITLE
Replacing deprecated oauth2client with google-auth

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,8 @@
 *~
 git-subrepo
 *.pyc
+mockgen/build
+mockgen/dist
+mockgen/mockgen.egg-info
+test
+.vscode

--- a/run_tests.py
+++ b/run_tests.py
@@ -690,7 +690,7 @@ def _load_python(test_dir, ctxs):
         src_dir = _make_src_dir(test_dir, ctx.name, ctx.version, _PYTHON)
         # Create a virtualenv.
         _call('virtualenv venv', cwd=src_dir)
-        _call('venv/bin/pip install google-api-python-client', cwd=src_dir)
+        _call('venv/bin/pip install google-api-python-client google-auth', cwd=src_dir)
 
         for filename in sample_filenames:
             method_id = _parse_method_id_from_sample_filename(filename)
@@ -701,6 +701,7 @@ def _load_python(test_dir, ctxs):
             cmd = 'venv/bin/python {}'.format(new_filename)
             sample_cmds[ctx.id_].append(SampleCommand(method_id, cmd, src_dir))
 
+        print('Generated {} samples in {}'.format(len(sample_filenames), src_dir))
     return sample_cmds
 
 

--- a/toolkit/src/main/java/com/google/api/codegen/discovery/transformer/py/PythonSampleMethodToViewTransformer.java
+++ b/toolkit/src/main/java/com/google/api/codegen/discovery/transformer/py/PythonSampleMethodToViewTransformer.java
@@ -122,8 +122,10 @@ public class PythonSampleMethodToViewTransformer implements SampleMethodToViewTr
       case API_KEY:
         discoveryBuildParams.add("developerKey=" + credentialsVarName);
         break;
-      default:
+      case OAUTH_3L:
         discoveryBuildParams.add("credentials=" + credentialsVarName);
+        break;
+      default:
         break;
     }
     String discoveryDocUrl = config.discoveryDocUrl();

--- a/toolkit/src/main/resources/com/google/api/codegen/py/discovery_fragment.snip
+++ b/toolkit/src/main/resources/com/google/api/codegen/py/discovery_fragment.snip
@@ -19,9 +19,9 @@
             2. This sample uses Application Default Credentials for authentication.
                If not already done, install the gcloud CLI from
                https://cloud.google.com/sdk/ and run
-               `gcloud beta auth application-default login`
-            3. Install the Python client library for Google APIs by running
-               `pip install --upgrade google-api-python-client`
+               `gcloud auth application-default login`
+            3. Install the Python client library for Google APIs and Google Auth Python Library by running
+               `pip install --upgrade google-api-python-client google-auth`
         @else
             2. Install the Python client library for Google APIs by running
                `pip install --upgrade google-api-python-client`
@@ -47,7 +47,7 @@
             @# Use Application Default Credentials for authentication when running locally.
             @# For more information, see:
             @# https://developers.google.com/identity/protocols/application-default-credentials
-            {@importGoogleCredential()}credentials = GoogleCredentials.get_application_default()
+            @# Google API Client will automatically use them as long as googl-auth is installed.
             {@BREAK}
         @case "OAUTH_3L"
             @# {@TODO()} Change placeholder below to get authentication credentials.
@@ -73,8 +73,10 @@
         @if authType == "API_KEY"
             @# {@TODO()} Change placeholder below to desired API key:
             {@serviceName()} = discovery.build('{@apiName}', '{@apiVersion}', developerKey='{MY-API-KEY}')
-        @else
+        @else if authType == "OAUTH_3L"
             {@serviceName()} = discovery.build('{@apiName}', '{@apiVersion}', credentials=credentials)
+        @else
+            {@serviceName()} = discovery.build('{@apiName}', '{@apiVersion}')
         @end
     @end
 
@@ -260,10 +262,6 @@
     @let pprint = importHandler.addImportStandard("pprint", "pprint")
         {@pprint}(({@key}, {@value}))
     @end
-@end
-
-@private importGoogleCredential() fill
-    {@context.silent(importHandler.addImportLocal("oauth2client.client", "GoogleCredentials"))}
 @end
 
 @private alwaysImport() fill

--- a/toolkit/src/main/resources/com/google/api/codegen/py/sample.snip
+++ b/toolkit/src/main/resources/com/google/api/codegen/py/sample.snip
@@ -10,11 +10,12 @@
         2. This sample uses Application Default Credentials for authentication.
            If not already done, install the gcloud CLI from
            https://cloud.google.com/sdk and run
-           `gcloud beta auth application-default login`.
+           `gcloud auth application-default login`.
+           Google API Client will automatically use them as long as googl-auth is installed.
            For more information, see
            https://developers.google.com/identity/protocols/application-default-credentials
-        3. Install the Python client library for Google APIs by running
-           `pip install --upgrade google-api-python-client`
+        3. Install the Python client library for Google APIs and Google Auth Python Library by running
+           `pip install --upgrade google-api-python-client google-auth`
     @default
         2. Install the Python client library for Google APIs by running
            `pip install --upgrade google-api-python-client`
@@ -28,15 +29,10 @@
         import httplib2
     @end
     from googleapiclient import discovery
-    @if class.auth.type == "APPLICATION_DEFAULT_CREDENTIALS"
-        from oauth2client.client import GoogleCredentials
-    @end
 
     @switch class.auth.type
     @case "NONE"
     @case "APPLICATION_DEFAULT_CREDENTIALS"
-        {@class.credentialsVarName} = GoogleCredentials.get_application_default()
-
     @case "OAUTH_3L"
         @# TODO: Change placeholder below to generate authentication credentials. See
         @# {@class.auth.instructionsUrl}

--- a/toolkit/src/test/java/com/google/api/codegen/testdata/discoveries/py/py_appengine.v1beta5.json.baseline
+++ b/toolkit/src/test/java/com/google/api/codegen/testdata/discoveries/py/py_appengine.v1beta5.json.baseline
@@ -8,20 +8,18 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 from pprint import pprint
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('appengine', 'v1beta5', credentials=credentials)
+service = discovery.build('appengine', 'v1beta5')
 
 application_body = {
     # TODO: Add desired entries to the request body.
@@ -41,20 +39,18 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 from pprint import pprint
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('appengine', 'v1beta5', credentials=credentials)
+service = discovery.build('appengine', 'v1beta5')
 
 # Part of `name`. Name of the application to get. Example: apps/myapp.
 apps_id = 'my-apps-id'  # TODO: Update placeholder value.
@@ -73,20 +69,18 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 from pprint import pprint
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('appengine', 'v1beta5', credentials=credentials)
+service = discovery.build('appengine', 'v1beta5')
 
 # Part of `name`. Resource name for the location.
 apps_id = 'my-apps-id'  # TODO: Update placeholder value.
@@ -108,20 +102,18 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 from pprint import pprint
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('appengine', 'v1beta5', credentials=credentials)
+service = discovery.build('appengine', 'v1beta5')
 
 # Part of `name`. The resource that owns the locations collection, if applicable.
 apps_id = 'my-apps-id'  # TODO: Update placeholder value.
@@ -146,20 +138,18 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 from pprint import pprint
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('appengine', 'v1beta5', credentials=credentials)
+service = discovery.build('appengine', 'v1beta5')
 
 # Part of `name`. The name of the operation resource.
 apps_id = 'my-apps-id'  # TODO: Update placeholder value.
@@ -181,20 +171,18 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 from pprint import pprint
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('appengine', 'v1beta5', credentials=credentials)
+service = discovery.build('appengine', 'v1beta5')
 
 # Part of `name`. The name of the operation collection.
 apps_id = 'my-apps-id'  # TODO: Update placeholder value.
@@ -219,20 +207,18 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 from pprint import pprint
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('appengine', 'v1beta5', credentials=credentials)
+service = discovery.build('appengine', 'v1beta5')
 
 # Part of `name`. Name of the Application resource to update. Example: apps/myapp.
 apps_id = 'my-apps-id'  # TODO: Update placeholder value.
@@ -256,20 +242,18 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 from pprint import pprint
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('appengine', 'v1beta5', credentials=credentials)
+service = discovery.build('appengine', 'v1beta5')
 
 # Part of `name`. Name of the resource requested. Example: apps/myapp/services/default.
 apps_id = 'my-apps-id'  # TODO: Update placeholder value.
@@ -291,20 +275,18 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 from pprint import pprint
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('appengine', 'v1beta5', credentials=credentials)
+service = discovery.build('appengine', 'v1beta5')
 
 # Part of `name`. Name of the resource requested. Example: apps/myapp/services/default.
 apps_id = 'my-apps-id'  # TODO: Update placeholder value.
@@ -326,20 +308,18 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 from pprint import pprint
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('appengine', 'v1beta5', credentials=credentials)
+service = discovery.build('appengine', 'v1beta5')
 
 # Part of `name`. Name of the resource requested. Example: apps/myapp.
 apps_id = 'my-apps-id'  # TODO: Update placeholder value.
@@ -364,20 +344,18 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 from pprint import pprint
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('appengine', 'v1beta5', credentials=credentials)
+service = discovery.build('appengine', 'v1beta5')
 
 # Part of `name`. Name of the resource to update. Example: apps/myapp/services/default.
 apps_id = 'my-apps-id'  # TODO: Update placeholder value.
@@ -404,20 +382,18 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 from pprint import pprint
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('appengine', 'v1beta5', credentials=credentials)
+service = discovery.build('appengine', 'v1beta5')
 
 # Part of `name`. Name of the resource to update. For example: "apps/myapp/services/default".
 apps_id = 'my-apps-id'  # TODO: Update placeholder value.
@@ -443,20 +419,18 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 from pprint import pprint
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('appengine', 'v1beta5', credentials=credentials)
+service = discovery.build('appengine', 'v1beta5')
 
 # Part of `name`. Name of the resource requested. Example: apps/myapp/services/default/versions/v1.
 apps_id = 'my-apps-id'  # TODO: Update placeholder value.
@@ -481,20 +455,18 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 from pprint import pprint
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('appengine', 'v1beta5', credentials=credentials)
+service = discovery.build('appengine', 'v1beta5')
 
 # Part of `name`. Name of the resource requested. Example: apps/myapp/services/default/versions/v1.
 apps_id = 'my-apps-id'  # TODO: Update placeholder value.
@@ -519,20 +491,18 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 from pprint import pprint
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('appengine', 'v1beta5', credentials=credentials)
+service = discovery.build('appengine', 'v1beta5')
 
 # Part of `name`. Name of the resource requested. Example:
 # apps/myapp/services/default/versions/v1/instances/instance-1.
@@ -565,20 +535,18 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 from pprint import pprint
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('appengine', 'v1beta5', credentials=credentials)
+service = discovery.build('appengine', 'v1beta5')
 
 # Part of `name`. Name of the resource requested. For example:
 # "apps/myapp/services/default/versions/v1/instances/instance-1".
@@ -607,20 +575,18 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 from pprint import pprint
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('appengine', 'v1beta5', credentials=credentials)
+service = discovery.build('appengine', 'v1beta5')
 
 # Part of `name`. Name of the resource requested. Example:
 # apps/myapp/services/default/versions/v1/instances/instance-1.
@@ -649,20 +615,18 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 from pprint import pprint
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('appengine', 'v1beta5', credentials=credentials)
+service = discovery.build('appengine', 'v1beta5')
 
 # Part of `name`. Name of the resource requested. Example: apps/myapp/services/default/versions/v1.
 apps_id = 'my-apps-id'  # TODO: Update placeholder value.
@@ -693,20 +657,18 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 from pprint import pprint
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('appengine', 'v1beta5', credentials=credentials)
+service = discovery.build('appengine', 'v1beta5')
 
 # Part of `name`. Name of the resource requested. Example: apps/myapp/services/default.
 apps_id = 'my-apps-id'  # TODO: Update placeholder value.
@@ -734,20 +696,18 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 from pprint import pprint
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('appengine', 'v1beta5', credentials=credentials)
+service = discovery.build('appengine', 'v1beta5')
 
 # Part of `name`. Name of the resource to update. Example: apps/myapp/services/default/versions/1.
 apps_id = 'my-apps-id'  # TODO: Update placeholder value.

--- a/toolkit/src/test/java/com/google/api/codegen/testdata/discoveries/py/py_bigquery.v2.json.baseline
+++ b/toolkit/src/test/java/com/google/api/codegen/testdata/discoveries/py/py_bigquery.v2.json.baseline
@@ -8,19 +8,17 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('bigquery', 'v2', credentials=credentials)
+service = discovery.build('bigquery', 'v2')
 
 # Project ID of the dataset being deleted
 project_id = 'my-project-id'  # TODO: Update placeholder value.
@@ -39,20 +37,18 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 from pprint import pprint
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('bigquery', 'v2', credentials=credentials)
+service = discovery.build('bigquery', 'v2')
 
 # Project ID of the requested dataset
 project_id = 'my-project-id'  # TODO: Update placeholder value.
@@ -74,20 +70,18 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 from pprint import pprint
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('bigquery', 'v2', credentials=credentials)
+service = discovery.build('bigquery', 'v2')
 
 # Project ID of the new dataset
 project_id = 'my-project-id'  # TODO: Update placeholder value.
@@ -110,20 +104,18 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 from pprint import pprint
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('bigquery', 'v2', credentials=credentials)
+service = discovery.build('bigquery', 'v2')
 
 # Project ID of the datasets to be listed
 project_id = 'my-project-id'  # TODO: Update placeholder value.
@@ -148,20 +140,18 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 from pprint import pprint
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('bigquery', 'v2', credentials=credentials)
+service = discovery.build('bigquery', 'v2')
 
 # Project ID of the dataset being updated
 project_id = 'my-project-id'  # TODO: Update placeholder value.
@@ -188,20 +178,18 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 from pprint import pprint
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('bigquery', 'v2', credentials=credentials)
+service = discovery.build('bigquery', 'v2')
 
 # Project ID of the dataset being updated
 project_id = 'my-project-id'  # TODO: Update placeholder value.
@@ -228,20 +216,18 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 from pprint import pprint
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('bigquery', 'v2', credentials=credentials)
+service = discovery.build('bigquery', 'v2')
 
 # [Required] Project ID of the job to cancel
 project_id = 'my-project-id'  # TODO: Update placeholder value.
@@ -263,20 +249,18 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 from pprint import pprint
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('bigquery', 'v2', credentials=credentials)
+service = discovery.build('bigquery', 'v2')
 
 # [Required] Project ID of the requested job
 project_id = 'my-project-id'  # TODO: Update placeholder value.
@@ -298,20 +282,18 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 from pprint import pprint
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('bigquery', 'v2', credentials=credentials)
+service = discovery.build('bigquery', 'v2')
 
 # [Required] Project ID of the query job
 project_id = 'my-project-id'  # TODO: Update placeholder value.
@@ -339,20 +321,18 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 from pprint import pprint
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('bigquery', 'v2', credentials=credentials)
+service = discovery.build('bigquery', 'v2')
 
 # Project ID of the project that will be billed for the job
 project_id = 'my-project-id'  # TODO: Update placeholder value.
@@ -378,20 +358,18 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 from pprint import pprint
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('bigquery', 'v2', credentials=credentials)
+service = discovery.build('bigquery', 'v2')
 
 # Project ID of the jobs to list
 project_id = 'my-project-id'  # TODO: Update placeholder value.
@@ -416,20 +394,18 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 from pprint import pprint
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('bigquery', 'v2', credentials=credentials)
+service = discovery.build('bigquery', 'v2')
 
 # Project ID of the project billed for the query
 project_id = 'my-project-id'  # TODO: Update placeholder value.
@@ -452,20 +428,18 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 from pprint import pprint
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('bigquery', 'v2', credentials=credentials)
+service = discovery.build('bigquery', 'v2')
 
 request = service.projects().list()
 while True:
@@ -487,20 +461,18 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 from pprint import pprint
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('bigquery', 'v2', credentials=credentials)
+service = discovery.build('bigquery', 'v2')
 
 # Project ID of the destination table.
 project_id = 'my-project-id'  # TODO: Update placeholder value.
@@ -529,20 +501,18 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 from pprint import pprint
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('bigquery', 'v2', credentials=credentials)
+service = discovery.build('bigquery', 'v2')
 
 # Project ID of the table to read
 project_id = 'my-project-id'  # TODO: Update placeholder value.
@@ -573,19 +543,17 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('bigquery', 'v2', credentials=credentials)
+service = discovery.build('bigquery', 'v2')
 
 # Project ID of the table to delete
 project_id = 'my-project-id'  # TODO: Update placeholder value.
@@ -607,20 +575,18 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 from pprint import pprint
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('bigquery', 'v2', credentials=credentials)
+service = discovery.build('bigquery', 'v2')
 
 # Project ID of the requested table
 project_id = 'my-project-id'  # TODO: Update placeholder value.
@@ -645,20 +611,18 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 from pprint import pprint
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('bigquery', 'v2', credentials=credentials)
+service = discovery.build('bigquery', 'v2')
 
 # Project ID of the new table
 project_id = 'my-project-id'  # TODO: Update placeholder value.
@@ -684,20 +648,18 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 from pprint import pprint
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('bigquery', 'v2', credentials=credentials)
+service = discovery.build('bigquery', 'v2')
 
 # Project ID of the tables to list
 project_id = 'my-project-id'  # TODO: Update placeholder value.
@@ -725,20 +687,18 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 from pprint import pprint
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('bigquery', 'v2', credentials=credentials)
+service = discovery.build('bigquery', 'v2')
 
 # Project ID of the table to update
 project_id = 'my-project-id'  # TODO: Update placeholder value.
@@ -768,20 +728,18 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 from pprint import pprint
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('bigquery', 'v2', credentials=credentials)
+service = discovery.build('bigquery', 'v2')
 
 # Project ID of the table to update
 project_id = 'my-project-id'  # TODO: Update placeholder value.

--- a/toolkit/src/test/java/com/google/api/codegen/testdata/discoveries/py/py_cloudbilling.v1.json.baseline
+++ b/toolkit/src/test/java/com/google/api/codegen/testdata/discoveries/py/py_cloudbilling.v1.json.baseline
@@ -8,20 +8,18 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 from pprint import pprint
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('cloudbilling', 'v1', credentials=credentials)
+service = discovery.build('cloudbilling', 'v1')
 
 # The resource name of the billing account to retrieve. For example,
 # `billingAccounts/012345-567890-ABCDEF`.
@@ -41,20 +39,18 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 from pprint import pprint
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('cloudbilling', 'v1', credentials=credentials)
+service = discovery.build('cloudbilling', 'v1')
 
 request = service.billingAccounts().list()
 while True:
@@ -76,20 +72,18 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 from pprint import pprint
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('cloudbilling', 'v1', credentials=credentials)
+service = discovery.build('cloudbilling', 'v1')
 
 # The resource name of the billing account associated with the projects that
 # you want to list. For example, `billingAccounts/012345-567890-ABCDEF`.
@@ -115,20 +109,18 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 from pprint import pprint
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('cloudbilling', 'v1', credentials=credentials)
+service = discovery.build('cloudbilling', 'v1')
 
 # The resource name of the project for which billing information is
 # retrieved. For example, `projects/tokyo-rain-123`.
@@ -148,20 +140,18 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 from pprint import pprint
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('cloudbilling', 'v1', credentials=credentials)
+service = discovery.build('cloudbilling', 'v1')
 
 # The resource name of the project associated with the billing information
 # that you want to update. For example, `projects/tokyo-rain-123`.

--- a/toolkit/src/test/java/com/google/api/codegen/testdata/discoveries/py/py_clouddebugger.v2.json.baseline
+++ b/toolkit/src/test/java/com/google/api/codegen/testdata/discoveries/py/py_clouddebugger.v2.json.baseline
@@ -8,20 +8,18 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 from pprint import pprint
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('clouddebugger', 'v2', credentials=credentials)
+service = discovery.build('clouddebugger', 'v2')
 
 # Identifies the debuggee.
 debuggee_id = 'my-debuggee-id'  # TODO: Update placeholder value.
@@ -40,20 +38,18 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 from pprint import pprint
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('clouddebugger', 'v2', credentials=credentials)
+service = discovery.build('clouddebugger', 'v2')
 
 # Identifies the debuggee being debugged.
 debuggee_id = 'my-debuggee-id'  # TODO: Update placeholder value.
@@ -80,20 +76,18 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 from pprint import pprint
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('clouddebugger', 'v2', credentials=credentials)
+service = discovery.build('clouddebugger', 'v2')
 
 register_debuggee_request_body = {
     # TODO: Add desired entries to the request body.
@@ -113,19 +107,17 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('clouddebugger', 'v2', credentials=credentials)
+service = discovery.build('clouddebugger', 'v2')
 
 # ID of the debuggee whose breakpoint to delete.
 debuggee_id = 'my-debuggee-id'  # TODO: Update placeholder value.
@@ -144,20 +136,18 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 from pprint import pprint
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('clouddebugger', 'v2', credentials=credentials)
+service = discovery.build('clouddebugger', 'v2')
 
 # ID of the debuggee whose breakpoint to get.
 debuggee_id = 'my-debuggee-id'  # TODO: Update placeholder value.
@@ -179,20 +169,18 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 from pprint import pprint
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('clouddebugger', 'v2', credentials=credentials)
+service = discovery.build('clouddebugger', 'v2')
 
 # ID of the debuggee whose breakpoints to list.
 debuggee_id = 'my-debuggee-id'  # TODO: Update placeholder value.
@@ -211,20 +199,18 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 from pprint import pprint
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('clouddebugger', 'v2', credentials=credentials)
+service = discovery.build('clouddebugger', 'v2')
 
 # ID of the debuggee where the breakpoint is to be set.
 debuggee_id = 'my-debuggee-id'  # TODO: Update placeholder value.
@@ -247,20 +233,18 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 from pprint import pprint
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('clouddebugger', 'v2', credentials=credentials)
+service = discovery.build('clouddebugger', 'v2')
 
 request = service.debugger().debuggees().list()
 response = request.execute()

--- a/toolkit/src/test/java/com/google/api/codegen/testdata/discoveries/py/py_cloudmonitoring.v2beta2.json.baseline
+++ b/toolkit/src/test/java/com/google/api/codegen/testdata/discoveries/py/py_cloudmonitoring.v2beta2.json.baseline
@@ -8,20 +8,18 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 from pprint import pprint
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('cloudmonitoring', 'v2beta2', credentials=credentials)
+service = discovery.build('cloudmonitoring', 'v2beta2')
 
 # The project id. The value can be the numeric project ID or string-based project name.
 project = 'my-project'  # TODO: Update placeholder value.
@@ -44,20 +42,18 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 from pprint import pprint
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('cloudmonitoring', 'v2beta2', credentials=credentials)
+service = discovery.build('cloudmonitoring', 'v2beta2')
 
 # The project ID to which the metric belongs.
 project = 'my-project'  # TODO: Update placeholder value.
@@ -79,20 +75,18 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 from pprint import pprint
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('cloudmonitoring', 'v2beta2', credentials=credentials)
+service = discovery.build('cloudmonitoring', 'v2beta2')
 
 # The project id. The value can be the numeric project ID or string-based project name.
 project = 'my-project'  # TODO: Update placeholder value.
@@ -121,20 +115,18 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 from pprint import pprint
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('cloudmonitoring', 'v2beta2', credentials=credentials)
+service = discovery.build('cloudmonitoring', 'v2beta2')
 
 # The project ID to which this time series belongs. The value can be the numeric project ID or
 # string-based project name.
@@ -171,20 +163,18 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 from pprint import pprint
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('cloudmonitoring', 'v2beta2', credentials=credentials)
+service = discovery.build('cloudmonitoring', 'v2beta2')
 
 # The project ID. The value can be the numeric project ID or string-based project name.
 project = 'my-project'  # TODO: Update placeholder value.
@@ -207,20 +197,18 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 from pprint import pprint
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('cloudmonitoring', 'v2beta2', credentials=credentials)
+service = discovery.build('cloudmonitoring', 'v2beta2')
 
 # The project ID to which this time series belongs. The value can be the numeric project ID or
 # string-based project name.

--- a/toolkit/src/test/java/com/google/api/codegen/testdata/discoveries/py/py_cloudresourcemanager.v1.json.baseline
+++ b/toolkit/src/test/java/com/google/api/codegen/testdata/discoveries/py/py_cloudresourcemanager.v1.json.baseline
@@ -8,20 +8,18 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 from pprint import pprint
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('cloudresourcemanager', 'v1', credentials=credentials)
+service = discovery.build('cloudresourcemanager', 'v1')
 
 # The name of the operation resource.
 name = 'operations/my-operation'  # TODO: Update placeholder value.
@@ -40,20 +38,18 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 from pprint import pprint
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('cloudresourcemanager', 'v1', credentials=credentials)
+service = discovery.build('cloudresourcemanager', 'v1')
 
 # The resource name of the Organization to fetch, e.g. "organizations/1234".
 name = 'organizations/my-organization'  # TODO: Update placeholder value.
@@ -72,20 +68,18 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 from pprint import pprint
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('cloudresourcemanager', 'v1', credentials=credentials)
+service = discovery.build('cloudresourcemanager', 'v1')
 
 # REQUIRED: The resource for which the policy is being requested.
 # `resource` is usually specified as a path. For example, a Project
@@ -110,20 +104,18 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 from pprint import pprint
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('cloudresourcemanager', 'v1', credentials=credentials)
+service = discovery.build('cloudresourcemanager', 'v1')
 
 search_organizations_request_body = {
     # TODO: Add desired entries to the request body.
@@ -149,20 +141,18 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 from pprint import pprint
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('cloudresourcemanager', 'v1', credentials=credentials)
+service = discovery.build('cloudresourcemanager', 'v1')
 
 # REQUIRED: The resource for which the policy is being specified.
 # `resource` is usually specified as a path. For example, a Project
@@ -187,20 +177,18 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 from pprint import pprint
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('cloudresourcemanager', 'v1', credentials=credentials)
+service = discovery.build('cloudresourcemanager', 'v1')
 
 # REQUIRED: The resource for which the policy detail is being requested.
 # `resource` is usually specified as a path. For example, a Project
@@ -225,20 +213,18 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 from pprint import pprint
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('cloudresourcemanager', 'v1', credentials=credentials)
+service = discovery.build('cloudresourcemanager', 'v1')
 
 project_body = {
     # TODO: Add desired entries to the request body.
@@ -258,19 +244,17 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('cloudresourcemanager', 'v1', credentials=credentials)
+service = discovery.build('cloudresourcemanager', 'v1')
 
 # The Project ID (for example, `foo-bar-123`).
 # Required.
@@ -287,20 +271,18 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 from pprint import pprint
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('cloudresourcemanager', 'v1', credentials=credentials)
+service = discovery.build('cloudresourcemanager', 'v1')
 
 # The Project ID (for example, `my-project-123`).
 # Required.
@@ -320,20 +302,18 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 from pprint import pprint
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('cloudresourcemanager', 'v1', credentials=credentials)
+service = discovery.build('cloudresourcemanager', 'v1')
 
 # The Project ID (for example, `my-project-123`).
 # Required.
@@ -357,20 +337,18 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 from pprint import pprint
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('cloudresourcemanager', 'v1', credentials=credentials)
+service = discovery.build('cloudresourcemanager', 'v1')
 
 # REQUIRED: The resource for which the policy is being requested.
 # `resource` is usually specified as a path. For example, a Project
@@ -395,20 +373,18 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 from pprint import pprint
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('cloudresourcemanager', 'v1', credentials=credentials)
+service = discovery.build('cloudresourcemanager', 'v1')
 
 request = service.projects().list()
 while True:
@@ -430,20 +406,18 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 from pprint import pprint
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('cloudresourcemanager', 'v1', credentials=credentials)
+service = discovery.build('cloudresourcemanager', 'v1')
 
 # REQUIRED: The resource for which the policy is being specified.
 # `resource` is usually specified as a path. For example, a Project
@@ -468,20 +442,18 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 from pprint import pprint
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('cloudresourcemanager', 'v1', credentials=credentials)
+service = discovery.build('cloudresourcemanager', 'v1')
 
 # REQUIRED: The resource for which the policy detail is being requested.
 # `resource` is usually specified as a path. For example, a Project
@@ -506,19 +478,17 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('cloudresourcemanager', 'v1', credentials=credentials)
+service = discovery.build('cloudresourcemanager', 'v1')
 
 # The project ID (for example, `foo-bar-123`).
 # Required.
@@ -539,20 +509,18 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 from pprint import pprint
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('cloudresourcemanager', 'v1', credentials=credentials)
+service = discovery.build('cloudresourcemanager', 'v1')
 
 # The project ID (for example, `my-project-123`).
 # Required.

--- a/toolkit/src/test/java/com/google/api/codegen/testdata/discoveries/py/py_cloudtrace.v1.json.baseline
+++ b/toolkit/src/test/java/com/google/api/codegen/testdata/discoveries/py/py_cloudtrace.v1.json.baseline
@@ -8,19 +8,17 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('cloudtrace', 'v1', credentials=credentials)
+service = discovery.build('cloudtrace', 'v1')
 
 # ID of the Cloud project where the trace data is stored.
 project_id = 'my-project-id'  # TODO: Update placeholder value.
@@ -41,20 +39,18 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 from pprint import pprint
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('cloudtrace', 'v1', credentials=credentials)
+service = discovery.build('cloudtrace', 'v1')
 
 # ID of the Cloud project where the trace data is stored.
 project_id = 'my-project-id'  # TODO: Update placeholder value.
@@ -76,20 +72,18 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 from pprint import pprint
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('cloudtrace', 'v1', credentials=credentials)
+service = discovery.build('cloudtrace', 'v1')
 
 # ID of the Cloud project where the trace data is stored.
 project_id = 'my-project-id'  # TODO: Update placeholder value.

--- a/toolkit/src/test/java/com/google/api/codegen/testdata/discoveries/py/py_clouduseraccounts.beta.json.baseline
+++ b/toolkit/src/test/java/com/google/api/codegen/testdata/discoveries/py/py_clouduseraccounts.beta.json.baseline
@@ -8,19 +8,17 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('clouduseraccounts', 'beta', credentials=credentials)
+service = discovery.build('clouduseraccounts', 'beta')
 
 # Project ID for this request.
 project = 'my-project'  # TODO: Update placeholder value.
@@ -39,20 +37,18 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 from pprint import pprint
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('clouduseraccounts', 'beta', credentials=credentials)
+service = discovery.build('clouduseraccounts', 'beta')
 
 # Project ID for this request.
 project = 'my-project'  # TODO: Update placeholder value.
@@ -74,20 +70,18 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 from pprint import pprint
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('clouduseraccounts', 'beta', credentials=credentials)
+service = discovery.build('clouduseraccounts', 'beta')
 
 # Project ID for this request.
 project = 'my-project'  # TODO: Update placeholder value.
@@ -112,20 +106,18 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 from pprint import pprint
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('clouduseraccounts', 'beta', credentials=credentials)
+service = discovery.build('clouduseraccounts', 'beta')
 
 # Project ID for this request.
 project = 'my-project'  # TODO: Update placeholder value.
@@ -151,20 +143,18 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 from pprint import pprint
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('clouduseraccounts', 'beta', credentials=credentials)
+service = discovery.build('clouduseraccounts', 'beta')
 
 # Project ID for this request.
 project = 'my-project'  # TODO: Update placeholder value.
@@ -186,20 +176,18 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 from pprint import pprint
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('clouduseraccounts', 'beta', credentials=credentials)
+service = discovery.build('clouduseraccounts', 'beta')
 
 # Project ID for this request.
 project = 'my-project'  # TODO: Update placeholder value.
@@ -221,20 +209,18 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 from pprint import pprint
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('clouduseraccounts', 'beta', credentials=credentials)
+service = discovery.build('clouduseraccounts', 'beta')
 
 # Project ID for this request.
 project = 'my-project'  # TODO: Update placeholder value.
@@ -257,20 +243,18 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 from pprint import pprint
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('clouduseraccounts', 'beta', credentials=credentials)
+service = discovery.build('clouduseraccounts', 'beta')
 
 # Project ID for this request.
 project = 'my-project'  # TODO: Update placeholder value.
@@ -295,20 +279,18 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 from pprint import pprint
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('clouduseraccounts', 'beta', credentials=credentials)
+service = discovery.build('clouduseraccounts', 'beta')
 
 # Project ID for this request.
 project = 'my-project'  # TODO: Update placeholder value.
@@ -334,20 +316,18 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 from pprint import pprint
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('clouduseraccounts', 'beta', credentials=credentials)
+service = discovery.build('clouduseraccounts', 'beta')
 
 # Project ID for this request.
 project = 'my-project'  # TODO: Update placeholder value.
@@ -375,20 +355,18 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 from pprint import pprint
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('clouduseraccounts', 'beta', credentials=credentials)
+service = discovery.build('clouduseraccounts', 'beta')
 
 # Project ID for this request.
 project = 'my-project'  # TODO: Update placeholder value.
@@ -413,20 +391,18 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 from pprint import pprint
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('clouduseraccounts', 'beta', credentials=credentials)
+service = discovery.build('clouduseraccounts', 'beta')
 
 # Project ID for this request.
 project = 'my-project'  # TODO: Update placeholder value.
@@ -452,20 +428,18 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 from pprint import pprint
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('clouduseraccounts', 'beta', credentials=credentials)
+service = discovery.build('clouduseraccounts', 'beta')
 
 # Project ID for this request.
 project = 'my-project'  # TODO: Update placeholder value.
@@ -487,20 +461,18 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 from pprint import pprint
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('clouduseraccounts', 'beta', credentials=credentials)
+service = discovery.build('clouduseraccounts', 'beta')
 
 # Project ID for this request.
 project = 'my-project'  # TODO: Update placeholder value.
@@ -522,20 +494,18 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 from pprint import pprint
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('clouduseraccounts', 'beta', credentials=credentials)
+service = discovery.build('clouduseraccounts', 'beta')
 
 # Project ID for this request.
 project = 'my-project'  # TODO: Update placeholder value.
@@ -558,20 +528,18 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 from pprint import pprint
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('clouduseraccounts', 'beta', credentials=credentials)
+service = discovery.build('clouduseraccounts', 'beta')
 
 # Project ID for this request.
 project = 'my-project'  # TODO: Update placeholder value.
@@ -596,20 +564,18 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 from pprint import pprint
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('clouduseraccounts', 'beta', credentials=credentials)
+service = discovery.build('clouduseraccounts', 'beta')
 
 # Project ID for this request.
 project = 'my-project'  # TODO: Update placeholder value.

--- a/toolkit/src/test/java/com/google/api/codegen/testdata/discoveries/py/py_compute.v1.json.baseline
+++ b/toolkit/src/test/java/com/google/api/codegen/testdata/discoveries/py/py_compute.v1.json.baseline
@@ -8,20 +8,18 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 from pprint import pprint
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('compute', 'v1', credentials=credentials)
+service = discovery.build('compute', 'v1')
 
 # Project ID for this request.
 project = 'my-project'  # TODO: Update placeholder value.
@@ -46,20 +44,18 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 from pprint import pprint
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('compute', 'v1', credentials=credentials)
+service = discovery.build('compute', 'v1')
 
 # Project ID for this request.
 project = 'my-project'  # TODO: Update placeholder value.
@@ -84,20 +80,18 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 from pprint import pprint
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('compute', 'v1', credentials=credentials)
+service = discovery.build('compute', 'v1')
 
 # Project ID for this request.
 project = 'my-project'  # TODO: Update placeholder value.
@@ -122,20 +116,18 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 from pprint import pprint
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('compute', 'v1', credentials=credentials)
+service = discovery.build('compute', 'v1')
 
 # Project ID for this request.
 project = 'my-project'  # TODO: Update placeholder value.
@@ -161,20 +153,18 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 from pprint import pprint
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('compute', 'v1', credentials=credentials)
+service = discovery.build('compute', 'v1')
 
 # Project ID for this request.
 project = 'my-project'  # TODO: Update placeholder value.
@@ -202,20 +192,18 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 from pprint import pprint
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('compute', 'v1', credentials=credentials)
+service = discovery.build('compute', 'v1')
 
 # Project ID for this request.
 project = 'my-project'  # TODO: Update placeholder value.
@@ -240,20 +228,18 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 from pprint import pprint
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('compute', 'v1', credentials=credentials)
+service = discovery.build('compute', 'v1')
 
 # Project ID for this request.
 project = 'my-project'  # TODO: Update placeholder value.
@@ -278,20 +264,18 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 from pprint import pprint
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('compute', 'v1', credentials=credentials)
+service = discovery.build('compute', 'v1')
 
 # Project ID for this request.
 project = 'my-project'  # TODO: Update placeholder value.
@@ -316,20 +300,18 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 from pprint import pprint
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('compute', 'v1', credentials=credentials)
+service = discovery.build('compute', 'v1')
 
 # Project ID for this request.
 project = 'my-project'  # TODO: Update placeholder value.
@@ -355,20 +337,18 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 from pprint import pprint
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('compute', 'v1', credentials=credentials)
+service = discovery.build('compute', 'v1')
 
 # Project ID for this request.
 project = 'my-project'  # TODO: Update placeholder value.
@@ -396,20 +376,18 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 from pprint import pprint
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('compute', 'v1', credentials=credentials)
+service = discovery.build('compute', 'v1')
 
 # Project ID for this request.
 project = 'my-project'  # TODO: Update placeholder value.
@@ -439,20 +417,18 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 from pprint import pprint
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('compute', 'v1', credentials=credentials)
+service = discovery.build('compute', 'v1')
 
 # Project ID for this request.
 project = 'my-project'  # TODO: Update placeholder value.
@@ -479,20 +455,18 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 from pprint import pprint
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('compute', 'v1', credentials=credentials)
+service = discovery.build('compute', 'v1')
 
 # Name of the project scoping this request.
 project = 'my-project'  # TODO: Update placeholder value.
@@ -517,20 +491,18 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 from pprint import pprint
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('compute', 'v1', credentials=credentials)
+service = discovery.build('compute', 'v1')
 
 # Project ID for this request.
 project = 'my-project'  # TODO: Update placeholder value.
@@ -552,20 +524,18 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 from pprint import pprint
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('compute', 'v1', credentials=credentials)
+service = discovery.build('compute', 'v1')
 
 # Project ID for this request.
 project = 'my-project'  # TODO: Update placeholder value.
@@ -587,20 +557,18 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 from pprint import pprint
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('compute', 'v1', credentials=credentials)
+service = discovery.build('compute', 'v1')
 
 project = 'my-project'  # TODO: Update placeholder value.
 
@@ -625,20 +593,18 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 from pprint import pprint
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('compute', 'v1', credentials=credentials)
+service = discovery.build('compute', 'v1')
 
 # Project ID for this request.
 project = 'my-project'  # TODO: Update placeholder value.
@@ -661,20 +627,18 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 from pprint import pprint
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('compute', 'v1', credentials=credentials)
+service = discovery.build('compute', 'v1')
 
 # Project ID for this request.
 project = 'my-project'  # TODO: Update placeholder value.
@@ -699,20 +663,18 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 from pprint import pprint
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('compute', 'v1', credentials=credentials)
+service = discovery.build('compute', 'v1')
 
 # Project ID for this request.
 project = 'my-project'  # TODO: Update placeholder value.
@@ -739,20 +701,18 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 from pprint import pprint
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('compute', 'v1', credentials=credentials)
+service = discovery.build('compute', 'v1')
 
 # Project ID for this request.
 project = 'my-project'  # TODO: Update placeholder value.
@@ -779,20 +739,18 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 from pprint import pprint
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('compute', 'v1', credentials=credentials)
+service = discovery.build('compute', 'v1')
 
 # Project ID for this request.
 project = 'my-project'  # TODO: Update placeholder value.
@@ -817,20 +775,18 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 from pprint import pprint
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('compute', 'v1', credentials=credentials)
+service = discovery.build('compute', 'v1')
 
 # Project ID for this request.
 project = 'my-project'  # TODO: Update placeholder value.
@@ -855,20 +811,18 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 from pprint import pprint
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('compute', 'v1', credentials=credentials)
+service = discovery.build('compute', 'v1')
 
 # Project ID for this request.
 project = 'my-project'  # TODO: Update placeholder value.
@@ -896,20 +850,18 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 from pprint import pprint
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('compute', 'v1', credentials=credentials)
+service = discovery.build('compute', 'v1')
 
 # Project ID for this request.
 project = 'my-project'  # TODO: Update placeholder value.
@@ -934,20 +886,18 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 from pprint import pprint
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('compute', 'v1', credentials=credentials)
+service = discovery.build('compute', 'v1')
 
 # Project ID for this request.
 project = 'my-project'  # TODO: Update placeholder value.
@@ -976,20 +926,18 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 from pprint import pprint
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('compute', 'v1', credentials=credentials)
+service = discovery.build('compute', 'v1')
 
 # Project ID for this request.
 project = 'my-project'  # TODO: Update placeholder value.
@@ -1014,20 +962,18 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 from pprint import pprint
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('compute', 'v1', credentials=credentials)
+service = discovery.build('compute', 'v1')
 
 # Project ID for this request.
 project = 'my-project'  # TODO: Update placeholder value.
@@ -1052,20 +998,18 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 from pprint import pprint
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('compute', 'v1', credentials=credentials)
+service = discovery.build('compute', 'v1')
 
 # Project ID for this request.
 project = 'my-project'  # TODO: Update placeholder value.
@@ -1091,20 +1035,18 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 from pprint import pprint
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('compute', 'v1', credentials=credentials)
+service = discovery.build('compute', 'v1')
 
 # Project ID for this request.
 project = 'my-project'  # TODO: Update placeholder value.
@@ -1132,20 +1074,18 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 from pprint import pprint
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('compute', 'v1', credentials=credentials)
+service = discovery.build('compute', 'v1')
 
 # Project ID for this request.
 project = 'my-project'  # TODO: Update placeholder value.
@@ -1174,20 +1114,18 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 from pprint import pprint
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('compute', 'v1', credentials=credentials)
+service = discovery.build('compute', 'v1')
 
 # Project ID for this request.
 project = 'my-project'  # TODO: Update placeholder value.
@@ -1209,20 +1147,18 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 from pprint import pprint
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('compute', 'v1', credentials=credentials)
+service = discovery.build('compute', 'v1')
 
 # Project ID for this request.
 project = 'my-project'  # TODO: Update placeholder value.
@@ -1244,20 +1180,18 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 from pprint import pprint
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('compute', 'v1', credentials=credentials)
+service = discovery.build('compute', 'v1')
 
 # Project ID for this request.
 project = 'my-project'  # TODO: Update placeholder value.
@@ -1280,20 +1214,18 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 from pprint import pprint
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('compute', 'v1', credentials=credentials)
+service = discovery.build('compute', 'v1')
 
 # Project ID for this request.
 project = 'my-project'  # TODO: Update placeholder value.
@@ -1318,20 +1250,18 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 from pprint import pprint
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('compute', 'v1', credentials=credentials)
+service = discovery.build('compute', 'v1')
 
 # Project ID for this request.
 project = 'my-project'  # TODO: Update placeholder value.
@@ -1358,20 +1288,18 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 from pprint import pprint
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('compute', 'v1', credentials=credentials)
+service = discovery.build('compute', 'v1')
 
 # Project ID for this request.
 project = 'my-project'  # TODO: Update placeholder value.
@@ -1398,20 +1326,18 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 from pprint import pprint
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('compute', 'v1', credentials=credentials)
+service = discovery.build('compute', 'v1')
 
 # Project ID for this request.
 project = 'my-project'  # TODO: Update placeholder value.
@@ -1436,20 +1362,18 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 from pprint import pprint
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('compute', 'v1', credentials=credentials)
+service = discovery.build('compute', 'v1')
 
 # Project ID for this request.
 project = 'my-project'  # TODO: Update placeholder value.
@@ -1474,20 +1398,18 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 from pprint import pprint
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('compute', 'v1', credentials=credentials)
+service = discovery.build('compute', 'v1')
 
 # Project ID for this request.
 project = 'my-project'  # TODO: Update placeholder value.
@@ -1512,20 +1434,18 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 from pprint import pprint
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('compute', 'v1', credentials=credentials)
+service = discovery.build('compute', 'v1')
 
 # Project ID for this request.
 project = 'my-project'  # TODO: Update placeholder value.
@@ -1551,20 +1471,18 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 from pprint import pprint
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('compute', 'v1', credentials=credentials)
+service = discovery.build('compute', 'v1')
 
 # Project ID for this request.
 project = 'my-project'  # TODO: Update placeholder value.
@@ -1592,20 +1510,18 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 from pprint import pprint
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('compute', 'v1', credentials=credentials)
+service = discovery.build('compute', 'v1')
 
 # Project ID for this request.
 project = 'my-project'  # TODO: Update placeholder value.
@@ -1634,20 +1550,18 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 from pprint import pprint
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('compute', 'v1', credentials=credentials)
+service = discovery.build('compute', 'v1')
 
 # Project ID for this request.
 project = 'my-project'  # TODO: Update placeholder value.
@@ -1669,20 +1583,18 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 from pprint import pprint
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('compute', 'v1', credentials=credentials)
+service = discovery.build('compute', 'v1')
 
 # Project ID for this request.
 project = 'my-project'  # TODO: Update placeholder value.
@@ -1704,20 +1616,18 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 from pprint import pprint
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('compute', 'v1', credentials=credentials)
+service = discovery.build('compute', 'v1')
 
 # Project ID for this request.
 project = 'my-project'  # TODO: Update placeholder value.
@@ -1740,20 +1650,18 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 from pprint import pprint
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('compute', 'v1', credentials=credentials)
+service = discovery.build('compute', 'v1')
 
 # Project ID for this request.
 project = 'my-project'  # TODO: Update placeholder value.
@@ -1778,20 +1686,18 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 from pprint import pprint
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('compute', 'v1', credentials=credentials)
+service = discovery.build('compute', 'v1')
 
 # Project ID for this request.
 project = 'my-project'  # TODO: Update placeholder value.
@@ -1813,20 +1719,18 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 from pprint import pprint
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('compute', 'v1', credentials=credentials)
+service = discovery.build('compute', 'v1')
 
 # Project ID for this request.
 project = 'my-project'  # TODO: Update placeholder value.
@@ -1848,20 +1752,18 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 from pprint import pprint
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('compute', 'v1', credentials=credentials)
+service = discovery.build('compute', 'v1')
 
 # Project ID for this request.
 project = 'my-project'  # TODO: Update placeholder value.
@@ -1884,20 +1786,18 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 from pprint import pprint
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('compute', 'v1', credentials=credentials)
+service = discovery.build('compute', 'v1')
 
 # Project ID for this request.
 project = 'my-project'  # TODO: Update placeholder value.
@@ -1922,20 +1822,18 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 from pprint import pprint
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('compute', 'v1', credentials=credentials)
+service = discovery.build('compute', 'v1')
 
 # Project ID for this request.
 project = 'my-project'  # TODO: Update placeholder value.
@@ -1961,20 +1859,18 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 from pprint import pprint
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('compute', 'v1', credentials=credentials)
+service = discovery.build('compute', 'v1')
 
 # Project ID for this request.
 project = 'my-project'  # TODO: Update placeholder value.
@@ -1999,19 +1895,17 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('compute', 'v1', credentials=credentials)
+service = discovery.build('compute', 'v1')
 
 # Project ID for this request.
 project = 'my-project'  # TODO: Update placeholder value.
@@ -2030,20 +1924,18 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 from pprint import pprint
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('compute', 'v1', credentials=credentials)
+service = discovery.build('compute', 'v1')
 
 # Project ID for this request.
 project = 'my-project'  # TODO: Update placeholder value.
@@ -2065,20 +1957,18 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 from pprint import pprint
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('compute', 'v1', credentials=credentials)
+service = discovery.build('compute', 'v1')
 
 # Project ID for this request.
 project = 'my-project'  # TODO: Update placeholder value.
@@ -2103,20 +1993,18 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 from pprint import pprint
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('compute', 'v1', credentials=credentials)
+service = discovery.build('compute', 'v1')
 
 # Project ID for this request.
 project = 'my-project'  # TODO: Update placeholder value.
@@ -2138,20 +2026,18 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 from pprint import pprint
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('compute', 'v1', credentials=credentials)
+service = discovery.build('compute', 'v1')
 
 # Project ID for this request.
 project = 'my-project'  # TODO: Update placeholder value.
@@ -2173,20 +2059,18 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 from pprint import pprint
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('compute', 'v1', credentials=credentials)
+service = discovery.build('compute', 'v1')
 
 # Project ID for this request.
 project = 'my-project'  # TODO: Update placeholder value.
@@ -2209,20 +2093,18 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 from pprint import pprint
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('compute', 'v1', credentials=credentials)
+service = discovery.build('compute', 'v1')
 
 # Project ID for this request.
 project = 'my-project'  # TODO: Update placeholder value.
@@ -2247,20 +2129,18 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 from pprint import pprint
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('compute', 'v1', credentials=credentials)
+service = discovery.build('compute', 'v1')
 
 # Project ID for this request.
 project = 'my-project'  # TODO: Update placeholder value.
@@ -2287,20 +2167,18 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 from pprint import pprint
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('compute', 'v1', credentials=credentials)
+service = discovery.build('compute', 'v1')
 
 # Project ID for this request.
 project = 'my-project'  # TODO: Update placeholder value.
@@ -2327,20 +2205,18 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 from pprint import pprint
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('compute', 'v1', credentials=credentials)
+service = discovery.build('compute', 'v1')
 
 # Project ID for this request.
 project = 'my-project'  # TODO: Update placeholder value.
@@ -2362,20 +2238,18 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 from pprint import pprint
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('compute', 'v1', credentials=credentials)
+service = discovery.build('compute', 'v1')
 
 # Project ID for this request.
 project = 'my-project'  # TODO: Update placeholder value.
@@ -2397,20 +2271,18 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 from pprint import pprint
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('compute', 'v1', credentials=credentials)
+service = discovery.build('compute', 'v1')
 
 # Project ID for this request.
 project = 'my-project'  # TODO: Update placeholder value.
@@ -2433,20 +2305,18 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 from pprint import pprint
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('compute', 'v1', credentials=credentials)
+service = discovery.build('compute', 'v1')
 
 # Project ID for this request.
 project = 'my-project'  # TODO: Update placeholder value.
@@ -2471,20 +2341,18 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 from pprint import pprint
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('compute', 'v1', credentials=credentials)
+service = discovery.build('compute', 'v1')
 
 # Project ID for this request.
 project = 'my-project'  # TODO: Update placeholder value.
@@ -2511,20 +2379,18 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 from pprint import pprint
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('compute', 'v1', credentials=credentials)
+service = discovery.build('compute', 'v1')
 
 # Project ID for this request.
 project = 'my-project'  # TODO: Update placeholder value.
@@ -2551,20 +2417,18 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 from pprint import pprint
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('compute', 'v1', credentials=credentials)
+service = discovery.build('compute', 'v1')
 
 # Project ID for this request.
 project = 'my-project'  # TODO: Update placeholder value.
@@ -2586,20 +2450,18 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 from pprint import pprint
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('compute', 'v1', credentials=credentials)
+service = discovery.build('compute', 'v1')
 
 # Project ID for this request.
 project = 'my-project'  # TODO: Update placeholder value.
@@ -2621,20 +2483,18 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 from pprint import pprint
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('compute', 'v1', credentials=credentials)
+service = discovery.build('compute', 'v1')
 
 # Project ID for this request.
 project = 'my-project'  # TODO: Update placeholder value.
@@ -2657,20 +2517,18 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 from pprint import pprint
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('compute', 'v1', credentials=credentials)
+service = discovery.build('compute', 'v1')
 
 # Project ID for this request.
 project = 'my-project'  # TODO: Update placeholder value.
@@ -2695,20 +2553,18 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 from pprint import pprint
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('compute', 'v1', credentials=credentials)
+service = discovery.build('compute', 'v1')
 
 # Project ID for this request.
 project = 'my-project'  # TODO: Update placeholder value.
@@ -2735,20 +2591,18 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 from pprint import pprint
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('compute', 'v1', credentials=credentials)
+service = discovery.build('compute', 'v1')
 
 # Project ID for this request.
 project = 'my-project'  # TODO: Update placeholder value.
@@ -2775,20 +2629,18 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 from pprint import pprint
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('compute', 'v1', credentials=credentials)
+service = discovery.build('compute', 'v1')
 
 # Project ID for this request.
 project = 'my-project'  # TODO: Update placeholder value.
@@ -2810,20 +2662,18 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 from pprint import pprint
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('compute', 'v1', credentials=credentials)
+service = discovery.build('compute', 'v1')
 
 # Project ID for this request.
 project = 'my-project'  # TODO: Update placeholder value.
@@ -2849,20 +2699,18 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 from pprint import pprint
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('compute', 'v1', credentials=credentials)
+service = discovery.build('compute', 'v1')
 
 # Project ID for this request.
 project = 'my-project'  # TODO: Update placeholder value.
@@ -2884,20 +2732,18 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 from pprint import pprint
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('compute', 'v1', credentials=credentials)
+service = discovery.build('compute', 'v1')
 
 # Project ID for this request.
 project = 'my-project'  # TODO: Update placeholder value.
@@ -2919,20 +2765,18 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 from pprint import pprint
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('compute', 'v1', credentials=credentials)
+service = discovery.build('compute', 'v1')
 
 # Project ID for this request.
 project = 'my-project'  # TODO: Update placeholder value.
@@ -2955,20 +2799,18 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 from pprint import pprint
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('compute', 'v1', credentials=credentials)
+service = discovery.build('compute', 'v1')
 
 # Project ID for this request.
 project = 'my-project'  # TODO: Update placeholder value.
@@ -2993,20 +2835,18 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 from pprint import pprint
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('compute', 'v1', credentials=credentials)
+service = discovery.build('compute', 'v1')
 
 # Project ID for this request.
 project = 'my-project'  # TODO: Update placeholder value.
@@ -3035,20 +2875,18 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 from pprint import pprint
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('compute', 'v1', credentials=credentials)
+service = discovery.build('compute', 'v1')
 
 # Project ID for this request.
 project = 'my-project'  # TODO: Update placeholder value.
@@ -3073,20 +2911,18 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 from pprint import pprint
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('compute', 'v1', credentials=credentials)
+service = discovery.build('compute', 'v1')
 
 # Project ID for this request.
 project = 'my-project'  # TODO: Update placeholder value.
@@ -3111,20 +2947,18 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 from pprint import pprint
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('compute', 'v1', credentials=credentials)
+service = discovery.build('compute', 'v1')
 
 # Project ID for this request.
 project = 'my-project'  # TODO: Update placeholder value.
@@ -3153,20 +2987,18 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 from pprint import pprint
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('compute', 'v1', credentials=credentials)
+service = discovery.build('compute', 'v1')
 
 # Project ID for this request.
 project = 'my-project'  # TODO: Update placeholder value.
@@ -3191,20 +3023,18 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 from pprint import pprint
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('compute', 'v1', credentials=credentials)
+service = discovery.build('compute', 'v1')
 
 # Project ID for this request.
 project = 'my-project'  # TODO: Update placeholder value.
@@ -3230,20 +3060,18 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 from pprint import pprint
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('compute', 'v1', credentials=credentials)
+service = discovery.build('compute', 'v1')
 
 # Project ID for this request.
 project = 'my-project'  # TODO: Update placeholder value.
@@ -3271,20 +3099,18 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 from pprint import pprint
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('compute', 'v1', credentials=credentials)
+service = discovery.build('compute', 'v1')
 
 # Project ID for this request.
 project = 'my-project'  # TODO: Update placeholder value.
@@ -3309,20 +3135,18 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 from pprint import pprint
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('compute', 'v1', credentials=credentials)
+service = discovery.build('compute', 'v1')
 
 # Project ID for this request.
 project = 'my-project'  # TODO: Update placeholder value.
@@ -3351,20 +3175,18 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 from pprint import pprint
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('compute', 'v1', credentials=credentials)
+service = discovery.build('compute', 'v1')
 
 # Project ID for this request.
 project = 'my-project'  # TODO: Update placeholder value.
@@ -3394,20 +3216,18 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 from pprint import pprint
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('compute', 'v1', credentials=credentials)
+service = discovery.build('compute', 'v1')
 
 # Project ID for this request.
 project = 'my-project'  # TODO: Update placeholder value.
@@ -3436,20 +3256,18 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 from pprint import pprint
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('compute', 'v1', credentials=credentials)
+service = discovery.build('compute', 'v1')
 
 # Project ID for this request.
 project = 'my-project'  # TODO: Update placeholder value.
@@ -3478,20 +3296,18 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 from pprint import pprint
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('compute', 'v1', credentials=credentials)
+service = discovery.build('compute', 'v1')
 
 # Project ID for this request.
 project = 'my-project'  # TODO: Update placeholder value.
@@ -3520,20 +3336,18 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 from pprint import pprint
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('compute', 'v1', credentials=credentials)
+service = discovery.build('compute', 'v1')
 
 # Project ID for this request.
 project = 'my-project'  # TODO: Update placeholder value.
@@ -3558,20 +3372,18 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 from pprint import pprint
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('compute', 'v1', credentials=credentials)
+service = discovery.build('compute', 'v1')
 
 # Project ID for this request.
 project = 'my-project'  # TODO: Update placeholder value.
@@ -3596,20 +3408,18 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 from pprint import pprint
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('compute', 'v1', credentials=credentials)
+service = discovery.build('compute', 'v1')
 
 # Project ID for this request.
 project = 'my-project'  # TODO: Update placeholder value.
@@ -3634,20 +3444,18 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 from pprint import pprint
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('compute', 'v1', credentials=credentials)
+service = discovery.build('compute', 'v1')
 
 # Project ID for this request.
 project = 'my-project'  # TODO: Update placeholder value.
@@ -3673,20 +3481,18 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 from pprint import pprint
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('compute', 'v1', credentials=credentials)
+service = discovery.build('compute', 'v1')
 
 # Project ID for this request.
 project = 'my-project'  # TODO: Update placeholder value.
@@ -3714,20 +3520,18 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 from pprint import pprint
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('compute', 'v1', credentials=credentials)
+service = discovery.build('compute', 'v1')
 
 # Project ID for this request.
 project = 'my-project'  # TODO: Update placeholder value.
@@ -3762,20 +3566,18 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 from pprint import pprint
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('compute', 'v1', credentials=credentials)
+service = discovery.build('compute', 'v1')
 
 # Project ID for this request.
 project = 'my-project'  # TODO: Update placeholder value.
@@ -3804,20 +3606,18 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 from pprint import pprint
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('compute', 'v1', credentials=credentials)
+service = discovery.build('compute', 'v1')
 
 # Project ID for this request.
 project = 'my-project'  # TODO: Update placeholder value.
@@ -3846,20 +3646,18 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 from pprint import pprint
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('compute', 'v1', credentials=credentials)
+service = discovery.build('compute', 'v1')
 
 # Project ID for this request.
 project = 'my-project'  # TODO: Update placeholder value.
@@ -3881,20 +3679,18 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 from pprint import pprint
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('compute', 'v1', credentials=credentials)
+service = discovery.build('compute', 'v1')
 
 # Project ID for this request.
 project = 'my-project'  # TODO: Update placeholder value.
@@ -3916,20 +3712,18 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 from pprint import pprint
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('compute', 'v1', credentials=credentials)
+service = discovery.build('compute', 'v1')
 
 # Project ID for this request.
 project = 'my-project'  # TODO: Update placeholder value.
@@ -3952,20 +3746,18 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 from pprint import pprint
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('compute', 'v1', credentials=credentials)
+service = discovery.build('compute', 'v1')
 
 # Project ID for this request.
 project = 'my-project'  # TODO: Update placeholder value.
@@ -3990,20 +3782,18 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 from pprint import pprint
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('compute', 'v1', credentials=credentials)
+service = discovery.build('compute', 'v1')
 
 # Project ID for this request.
 project = 'my-project'  # TODO: Update placeholder value.
@@ -4035,20 +3825,18 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 from pprint import pprint
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('compute', 'v1', credentials=credentials)
+service = discovery.build('compute', 'v1')
 
 # Project ID for this request.
 project = 'my-project'  # TODO: Update placeholder value.
@@ -4073,20 +3861,18 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 from pprint import pprint
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('compute', 'v1', credentials=credentials)
+service = discovery.build('compute', 'v1')
 
 # Project ID for this request.
 project = 'my-project'  # TODO: Update placeholder value.
@@ -4115,20 +3901,18 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 from pprint import pprint
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('compute', 'v1', credentials=credentials)
+service = discovery.build('compute', 'v1')
 
 # Project ID for this request.
 project = 'my-project'  # TODO: Update placeholder value.
@@ -4153,20 +3937,18 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 from pprint import pprint
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('compute', 'v1', credentials=credentials)
+service = discovery.build('compute', 'v1')
 
 # Project ID for this request.
 project = 'my-project'  # TODO: Update placeholder value.
@@ -4197,20 +3979,18 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 from pprint import pprint
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('compute', 'v1', credentials=credentials)
+service = discovery.build('compute', 'v1')
 
 # Project ID for this request.
 project = 'my-project'  # TODO: Update placeholder value.
@@ -4238,20 +4018,18 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 from pprint import pprint
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('compute', 'v1', credentials=credentials)
+service = discovery.build('compute', 'v1')
 
 # Project ID for this request.
 project = 'my-project'  # TODO: Update placeholder value.
@@ -4276,20 +4054,18 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 from pprint import pprint
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('compute', 'v1', credentials=credentials)
+service = discovery.build('compute', 'v1')
 
 # Project ID for this request.
 project = 'my-project'  # TODO: Update placeholder value.
@@ -4314,20 +4090,18 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 from pprint import pprint
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('compute', 'v1', credentials=credentials)
+service = discovery.build('compute', 'v1')
 
 # Project ID for this request.
 project = 'my-project'  # TODO: Update placeholder value.
@@ -4353,20 +4127,18 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 from pprint import pprint
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('compute', 'v1', credentials=credentials)
+service = discovery.build('compute', 'v1')
 
 # Project ID for this request.
 project = 'my-project'  # TODO: Update placeholder value.
@@ -4394,20 +4166,18 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 from pprint import pprint
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('compute', 'v1', credentials=credentials)
+service = discovery.build('compute', 'v1')
 
 # Project ID for this request.
 project = 'my-project'  # TODO: Update placeholder value.
@@ -4432,20 +4202,18 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 from pprint import pprint
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('compute', 'v1', credentials=credentials)
+service = discovery.build('compute', 'v1')
 
 # Project ID for this request.
 project = 'my-project'  # TODO: Update placeholder value.
@@ -4476,20 +4244,18 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 from pprint import pprint
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('compute', 'v1', credentials=credentials)
+service = discovery.build('compute', 'v1')
 
 # Project ID for this request.
 project = 'my-project'  # TODO: Update placeholder value.
@@ -4518,20 +4284,18 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 from pprint import pprint
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('compute', 'v1', credentials=credentials)
+service = discovery.build('compute', 'v1')
 
 # Project ID for this request.
 project = 'my-project'  # TODO: Update placeholder value.
@@ -4560,20 +4324,18 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 from pprint import pprint
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('compute', 'v1', credentials=credentials)
+service = discovery.build('compute', 'v1')
 
 # Project ID for this request.
 project = 'my-project'  # TODO: Update placeholder value.
@@ -4602,20 +4364,18 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 from pprint import pprint
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('compute', 'v1', credentials=credentials)
+service = discovery.build('compute', 'v1')
 
 # Project ID for this request.
 project = 'my-project'  # TODO: Update placeholder value.
@@ -4644,20 +4404,18 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 from pprint import pprint
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('compute', 'v1', credentials=credentials)
+service = discovery.build('compute', 'v1')
 
 # Project ID for this request.
 project = 'my-project'  # TODO: Update placeholder value.
@@ -4686,20 +4444,18 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 from pprint import pprint
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('compute', 'v1', credentials=credentials)
+service = discovery.build('compute', 'v1')
 
 # Project ID for this request.
 project = 'my-project'  # TODO: Update placeholder value.
@@ -4724,20 +4480,18 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 from pprint import pprint
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('compute', 'v1', credentials=credentials)
+service = discovery.build('compute', 'v1')
 
 # Project ID for this request.
 project = 'my-project'  # TODO: Update placeholder value.
@@ -4766,20 +4520,18 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 from pprint import pprint
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('compute', 'v1', credentials=credentials)
+service = discovery.build('compute', 'v1')
 
 # Project ID for this request.
 project = 'my-project'  # TODO: Update placeholder value.
@@ -4804,20 +4556,18 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 from pprint import pprint
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('compute', 'v1', credentials=credentials)
+service = discovery.build('compute', 'v1')
 
 # Project ID for this request.
 project = 'my-project'  # TODO: Update placeholder value.
@@ -4839,20 +4589,18 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 from pprint import pprint
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('compute', 'v1', credentials=credentials)
+service = discovery.build('compute', 'v1')
 
 # Project ID for this request.
 project = 'my-project'  # TODO: Update placeholder value.
@@ -4877,20 +4625,18 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 from pprint import pprint
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('compute', 'v1', credentials=credentials)
+service = discovery.build('compute', 'v1')
 
 # Project ID for this request.
 project = 'my-project'  # TODO: Update placeholder value.
@@ -4915,20 +4661,18 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 from pprint import pprint
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('compute', 'v1', credentials=credentials)
+service = discovery.build('compute', 'v1')
 
 # Project ID for this request.
 project = 'my-project'  # TODO: Update placeholder value.
@@ -4956,20 +4700,18 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 from pprint import pprint
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('compute', 'v1', credentials=credentials)
+service = discovery.build('compute', 'v1')
 
 # Project ID for this request.
 project = 'my-project'  # TODO: Update placeholder value.
@@ -4991,20 +4733,18 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 from pprint import pprint
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('compute', 'v1', credentials=credentials)
+service = discovery.build('compute', 'v1')
 
 # Project ID for this request.
 project = 'my-project'  # TODO: Update placeholder value.
@@ -5026,20 +4766,18 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 from pprint import pprint
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('compute', 'v1', credentials=credentials)
+service = discovery.build('compute', 'v1')
 
 # Project ID for this request.
 project = 'my-project'  # TODO: Update placeholder value.
@@ -5062,20 +4800,18 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 from pprint import pprint
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('compute', 'v1', credentials=credentials)
+service = discovery.build('compute', 'v1')
 
 # Project ID for this request.
 project = 'my-project'  # TODO: Update placeholder value.
@@ -5100,20 +4836,18 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 from pprint import pprint
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('compute', 'v1', credentials=credentials)
+service = discovery.build('compute', 'v1')
 
 # Project ID for this request.
 project = 'my-project'  # TODO: Update placeholder value.
@@ -5135,20 +4869,18 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 from pprint import pprint
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('compute', 'v1', credentials=credentials)
+service = discovery.build('compute', 'v1')
 
 # Project ID for this request.
 project = 'my-project'  # TODO: Update placeholder value.
@@ -5167,20 +4899,18 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 from pprint import pprint
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('compute', 'v1', credentials=credentials)
+service = discovery.build('compute', 'v1')
 
 # Project ID for this request.
 project = 'my-project'  # TODO: Update placeholder value.
@@ -5203,20 +4933,18 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 from pprint import pprint
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('compute', 'v1', credentials=credentials)
+service = discovery.build('compute', 'v1')
 
 # Project ID for this request.
 project = 'my-project'  # TODO: Update placeholder value.
@@ -5239,20 +4967,18 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 from pprint import pprint
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('compute', 'v1', credentials=credentials)
+service = discovery.build('compute', 'v1')
 
 # Project ID for this request.
 project = 'my-project'  # TODO: Update placeholder value.
@@ -5275,20 +5001,18 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 from pprint import pprint
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('compute', 'v1', credentials=credentials)
+service = discovery.build('compute', 'v1')
 
 # Project ID for this request.
 project = 'my-project'  # TODO: Update placeholder value.
@@ -5311,20 +5035,18 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 from pprint import pprint
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('compute', 'v1', credentials=credentials)
+service = discovery.build('compute', 'v1')
 
 # Project ID for this request.
 project = 'my-project'  # TODO: Update placeholder value.
@@ -5349,20 +5071,18 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 from pprint import pprint
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('compute', 'v1', credentials=credentials)
+service = discovery.build('compute', 'v1')
 
 # Project ID for this request.
 project = 'my-project'  # TODO: Update placeholder value.
@@ -5387,20 +5107,18 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 from pprint import pprint
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('compute', 'v1', credentials=credentials)
+service = discovery.build('compute', 'v1')
 
 # Project ID for this request.
 project = 'my-project'  # TODO: Update placeholder value.
@@ -5426,20 +5144,18 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 from pprint import pprint
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('compute', 'v1', credentials=credentials)
+service = discovery.build('compute', 'v1')
 
 # Project ID for this request.
 project = 'my-project'  # TODO: Update placeholder value.
@@ -5467,20 +5183,18 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 from pprint import pprint
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('compute', 'v1', credentials=credentials)
+service = discovery.build('compute', 'v1')
 
 # Project ID for this request.
 project = 'my-project'  # TODO: Update placeholder value.
@@ -5510,20 +5224,18 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 from pprint import pprint
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('compute', 'v1', credentials=credentials)
+service = discovery.build('compute', 'v1')
 
 # Project ID for this request.
 project = 'my-project'  # TODO: Update placeholder value.
@@ -5550,20 +5262,18 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 from pprint import pprint
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('compute', 'v1', credentials=credentials)
+service = discovery.build('compute', 'v1')
 
 # Project ID for this request.
 project = 'my-project'  # TODO: Update placeholder value.
@@ -5588,20 +5298,18 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 from pprint import pprint
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('compute', 'v1', credentials=credentials)
+service = discovery.build('compute', 'v1')
 
 # Project ID for this request.
 project = 'my-project'  # TODO: Update placeholder value.
@@ -5626,20 +5334,18 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 from pprint import pprint
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('compute', 'v1', credentials=credentials)
+service = discovery.build('compute', 'v1')
 
 project = 'my-project'  # TODO: Update placeholder value.
 
@@ -5667,20 +5373,18 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 from pprint import pprint
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('compute', 'v1', credentials=credentials)
+service = discovery.build('compute', 'v1')
 
 # Project ID for this request.
 project = 'my-project'  # TODO: Update placeholder value.
@@ -5706,20 +5410,18 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 from pprint import pprint
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('compute', 'v1', credentials=credentials)
+service = discovery.build('compute', 'v1')
 
 # Project ID for this request.
 project = 'my-project'  # TODO: Update placeholder value.
@@ -5747,20 +5449,18 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 from pprint import pprint
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('compute', 'v1', credentials=credentials)
+service = discovery.build('compute', 'v1')
 
 # Project ID for this request.
 project = 'my-project'  # TODO: Update placeholder value.
@@ -5790,20 +5490,18 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 from pprint import pprint
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('compute', 'v1', credentials=credentials)
+service = discovery.build('compute', 'v1')
 
 # Project ID for this request.
 project = 'my-project'  # TODO: Update placeholder value.
@@ -5833,20 +5531,18 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 from pprint import pprint
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('compute', 'v1', credentials=credentials)
+service = discovery.build('compute', 'v1')
 
 # Project ID for this request.
 project = 'my-project'  # TODO: Update placeholder value.
@@ -5875,20 +5571,18 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 from pprint import pprint
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('compute', 'v1', credentials=credentials)
+service = discovery.build('compute', 'v1')
 
 # Project ID for this request.
 project = 'my-project'  # TODO: Update placeholder value.
@@ -5913,20 +5607,18 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 from pprint import pprint
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('compute', 'v1', credentials=credentials)
+service = discovery.build('compute', 'v1')
 
 # Project ID for this request.
 project = 'my-project'  # TODO: Update placeholder value.
@@ -5955,20 +5647,18 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 from pprint import pprint
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('compute', 'v1', credentials=credentials)
+service = discovery.build('compute', 'v1')
 
 # Project ID for this request.
 project = 'my-project'  # TODO: Update placeholder value.
@@ -5993,20 +5683,18 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 from pprint import pprint
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('compute', 'v1', credentials=credentials)
+service = discovery.build('compute', 'v1')
 
 # Project ID for this request.
 project = 'my-project'  # TODO: Update placeholder value.
@@ -6032,20 +5720,18 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 from pprint import pprint
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('compute', 'v1', credentials=credentials)
+service = discovery.build('compute', 'v1')
 
 # Project ID for this request.
 project = 'my-project'  # TODO: Update placeholder value.
@@ -6073,20 +5759,18 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 from pprint import pprint
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('compute', 'v1', credentials=credentials)
+service = discovery.build('compute', 'v1')
 
 # Project ID for this request.
 project = 'my-project'  # TODO: Update placeholder value.
@@ -6111,20 +5795,18 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 from pprint import pprint
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('compute', 'v1', credentials=credentials)
+service = discovery.build('compute', 'v1')
 
 # Project ID for this request.
 project = 'my-project'  # TODO: Update placeholder value.
@@ -6153,20 +5835,18 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 from pprint import pprint
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('compute', 'v1', credentials=credentials)
+service = discovery.build('compute', 'v1')
 
 # Project ID for this request.
 project = 'my-project'  # TODO: Update placeholder value.
@@ -6194,20 +5874,18 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 from pprint import pprint
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('compute', 'v1', credentials=credentials)
+service = discovery.build('compute', 'v1')
 
 # Project ID for this request.
 project = 'my-project'  # TODO: Update placeholder value.
@@ -6236,20 +5914,18 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 from pprint import pprint
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('compute', 'v1', credentials=credentials)
+service = discovery.build('compute', 'v1')
 
 # Project ID for this request.
 project = 'my-project'  # TODO: Update placeholder value.
@@ -6278,20 +5954,18 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 from pprint import pprint
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('compute', 'v1', credentials=credentials)
+service = discovery.build('compute', 'v1')
 
 # Project ID for this request.
 project = 'my-project'  # TODO: Update placeholder value.
@@ -6316,20 +5990,18 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 from pprint import pprint
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('compute', 'v1', credentials=credentials)
+service = discovery.build('compute', 'v1')
 
 # Project ID for this request.
 project = 'my-project'  # TODO: Update placeholder value.
@@ -6357,20 +6029,18 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 from pprint import pprint
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('compute', 'v1', credentials=credentials)
+service = discovery.build('compute', 'v1')
 
 # Project ID for this request.
 project = 'my-project'  # TODO: Update placeholder value.
@@ -6405,20 +6075,18 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 from pprint import pprint
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('compute', 'v1', credentials=credentials)
+service = discovery.build('compute', 'v1')
 
 # Project ID for this request.
 project = 'my-project'  # TODO: Update placeholder value.
@@ -6447,19 +6115,17 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('compute', 'v1', credentials=credentials)
+service = discovery.build('compute', 'v1')
 
 # Project ID for this request.
 project = 'my-project'  # TODO: Update placeholder value.
@@ -6481,20 +6147,18 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 from pprint import pprint
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('compute', 'v1', credentials=credentials)
+service = discovery.build('compute', 'v1')
 
 # Project ID for this request.
 project = 'my-project'  # TODO: Update placeholder value.
@@ -6519,20 +6183,18 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 from pprint import pprint
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('compute', 'v1', credentials=credentials)
+service = discovery.build('compute', 'v1')
 
 # Project ID for this request.
 project = 'my-project'  # TODO: Update placeholder value.
@@ -6560,20 +6222,18 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 from pprint import pprint
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('compute', 'v1', credentials=credentials)
+service = discovery.build('compute', 'v1')
 
 # Project ID for this request.
 project = 'my-project'  # TODO: Update placeholder value.
@@ -6595,20 +6255,18 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 from pprint import pprint
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('compute', 'v1', credentials=credentials)
+service = discovery.build('compute', 'v1')
 
 # Project ID for this request.
 project = 'my-project'  # TODO: Update placeholder value.
@@ -6633,20 +6291,18 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 from pprint import pprint
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('compute', 'v1', credentials=credentials)
+service = discovery.build('compute', 'v1')
 
 # Project ID for this request.
 project = 'my-project'  # TODO: Update placeholder value.
@@ -6671,20 +6327,18 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 from pprint import pprint
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('compute', 'v1', credentials=credentials)
+service = discovery.build('compute', 'v1')
 
 # Project ID for this request.
 project = 'my-project'  # TODO: Update placeholder value.
@@ -6709,20 +6363,18 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 from pprint import pprint
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('compute', 'v1', credentials=credentials)
+service = discovery.build('compute', 'v1')
 
 # Project ID for this request.
 project = 'my-project'  # TODO: Update placeholder value.
@@ -6747,20 +6399,18 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 from pprint import pprint
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('compute', 'v1', credentials=credentials)
+service = discovery.build('compute', 'v1')
 
 # Project ID for this request.
 project = 'my-project'  # TODO: Update placeholder value.
@@ -6785,20 +6435,18 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 from pprint import pprint
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('compute', 'v1', credentials=credentials)
+service = discovery.build('compute', 'v1')
 
 # Project ID for this request.
 project = 'my-project'  # TODO: Update placeholder value.
@@ -6824,20 +6472,18 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 from pprint import pprint
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('compute', 'v1', credentials=credentials)
+service = discovery.build('compute', 'v1')
 
 # Project ID for this request.
 project = 'my-project'  # TODO: Update placeholder value.
@@ -6865,20 +6511,18 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 from pprint import pprint
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('compute', 'v1', credentials=credentials)
+service = discovery.build('compute', 'v1')
 
 # Project ID for this request.
 project = 'my-project'  # TODO: Update placeholder value.
@@ -6908,20 +6552,18 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 from pprint import pprint
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('compute', 'v1', credentials=credentials)
+service = discovery.build('compute', 'v1')
 
 # Project ID for this request.
 project = 'my-project'  # TODO: Update placeholder value.
@@ -6950,20 +6592,18 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 from pprint import pprint
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('compute', 'v1', credentials=credentials)
+service = discovery.build('compute', 'v1')
 
 # Project ID for this request.
 project = 'my-project'  # TODO: Update placeholder value.
@@ -6993,20 +6633,18 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 from pprint import pprint
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('compute', 'v1', credentials=credentials)
+service = discovery.build('compute', 'v1')
 
 # Project ID for this request.
 project = 'my-project'  # TODO: Update placeholder value.
@@ -7028,20 +6666,18 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 from pprint import pprint
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('compute', 'v1', credentials=credentials)
+service = discovery.build('compute', 'v1')
 
 # Project ID for this request.
 project = 'my-project'  # TODO: Update placeholder value.
@@ -7063,20 +6699,18 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 from pprint import pprint
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('compute', 'v1', credentials=credentials)
+service = discovery.build('compute', 'v1')
 
 # Project ID for this request.
 project = 'my-project'  # TODO: Update placeholder value.
@@ -7099,20 +6733,18 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 from pprint import pprint
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('compute', 'v1', credentials=credentials)
+service = discovery.build('compute', 'v1')
 
 # Project ID for this request.
 project = 'my-project'  # TODO: Update placeholder value.
@@ -7137,20 +6769,18 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 from pprint import pprint
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('compute', 'v1', credentials=credentials)
+service = discovery.build('compute', 'v1')
 
 # Project ID for this request.
 project = 'my-project'  # TODO: Update placeholder value.
@@ -7172,20 +6802,18 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 from pprint import pprint
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('compute', 'v1', credentials=credentials)
+service = discovery.build('compute', 'v1')
 
 # Project ID for this request.
 project = 'my-project'  # TODO: Update placeholder value.
@@ -7207,20 +6835,18 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 from pprint import pprint
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('compute', 'v1', credentials=credentials)
+service = discovery.build('compute', 'v1')
 
 # Project ID for this request.
 project = 'my-project'  # TODO: Update placeholder value.
@@ -7245,20 +6871,18 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 from pprint import pprint
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('compute', 'v1', credentials=credentials)
+service = discovery.build('compute', 'v1')
 
 # Project ID for this request.
 project = 'my-project'  # TODO: Update placeholder value.
@@ -7280,20 +6904,18 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 from pprint import pprint
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('compute', 'v1', credentials=credentials)
+service = discovery.build('compute', 'v1')
 
 # Project ID for this request.
 project = 'my-project'  # TODO: Update placeholder value.
@@ -7315,20 +6937,18 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 from pprint import pprint
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('compute', 'v1', credentials=credentials)
+service = discovery.build('compute', 'v1')
 
 # Project ID for this request.
 project = 'my-project'  # TODO: Update placeholder value.
@@ -7351,20 +6971,18 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 from pprint import pprint
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('compute', 'v1', credentials=credentials)
+service = discovery.build('compute', 'v1')
 
 # Project ID for this request.
 project = 'my-project'  # TODO: Update placeholder value.
@@ -7389,20 +7007,18 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 from pprint import pprint
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('compute', 'v1', credentials=credentials)
+service = discovery.build('compute', 'v1')
 
 # Project ID for this request.
 project = 'my-project'  # TODO: Update placeholder value.
@@ -7427,20 +7043,18 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 from pprint import pprint
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('compute', 'v1', credentials=credentials)
+service = discovery.build('compute', 'v1')
 
 # Project ID for this request.
 project = 'my-project'  # TODO: Update placeholder value.
@@ -7465,20 +7079,18 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 from pprint import pprint
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('compute', 'v1', credentials=credentials)
+service = discovery.build('compute', 'v1')
 
 # Project ID for this request.
 project = 'my-project'  # TODO: Update placeholder value.
@@ -7507,20 +7119,18 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 from pprint import pprint
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('compute', 'v1', credentials=credentials)
+service = discovery.build('compute', 'v1')
 
 # Project ID for this request.
 project = 'my-project'  # TODO: Update placeholder value.
@@ -7545,20 +7155,18 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 from pprint import pprint
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('compute', 'v1', credentials=credentials)
+service = discovery.build('compute', 'v1')
 
 # Project ID for this request.
 project = 'my-project'  # TODO: Update placeholder value.
@@ -7584,20 +7192,18 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 from pprint import pprint
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('compute', 'v1', credentials=credentials)
+service = discovery.build('compute', 'v1')
 
 # Project ID for this request.
 project = 'my-project'  # TODO: Update placeholder value.
@@ -7625,20 +7231,18 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 from pprint import pprint
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('compute', 'v1', credentials=credentials)
+service = discovery.build('compute', 'v1')
 
 # Project ID for this request.
 project = 'my-project'  # TODO: Update placeholder value.
@@ -7660,20 +7264,18 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 from pprint import pprint
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('compute', 'v1', credentials=credentials)
+service = discovery.build('compute', 'v1')
 
 # Project ID for this request.
 project = 'my-project'  # TODO: Update placeholder value.
@@ -7695,20 +7297,18 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 from pprint import pprint
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('compute', 'v1', credentials=credentials)
+service = discovery.build('compute', 'v1')
 
 # Project ID for this request.
 project = 'my-project'  # TODO: Update placeholder value.
@@ -7731,20 +7331,18 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 from pprint import pprint
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('compute', 'v1', credentials=credentials)
+service = discovery.build('compute', 'v1')
 
 # Project ID for this request.
 project = 'my-project'  # TODO: Update placeholder value.
@@ -7769,20 +7367,18 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 from pprint import pprint
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('compute', 'v1', credentials=credentials)
+service = discovery.build('compute', 'v1')
 
 # Project ID for this request.
 project = 'my-project'  # TODO: Update placeholder value.
@@ -7808,20 +7404,18 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 from pprint import pprint
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('compute', 'v1', credentials=credentials)
+service = discovery.build('compute', 'v1')
 
 # Project ID for this request.
 project = 'my-project'  # TODO: Update placeholder value.
@@ -7843,20 +7437,18 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 from pprint import pprint
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('compute', 'v1', credentials=credentials)
+service = discovery.build('compute', 'v1')
 
 # Project ID for this request.
 project = 'my-project'  # TODO: Update placeholder value.
@@ -7878,20 +7470,18 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 from pprint import pprint
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('compute', 'v1', credentials=credentials)
+service = discovery.build('compute', 'v1')
 
 # Project ID for this request.
 project = 'my-project'  # TODO: Update placeholder value.
@@ -7914,20 +7504,18 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 from pprint import pprint
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('compute', 'v1', credentials=credentials)
+service = discovery.build('compute', 'v1')
 
 # Project ID for this request.
 project = 'my-project'  # TODO: Update placeholder value.
@@ -7952,20 +7540,18 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 from pprint import pprint
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('compute', 'v1', credentials=credentials)
+service = discovery.build('compute', 'v1')
 
 # Project ID for this request.
 project = 'my-project'  # TODO: Update placeholder value.
@@ -7991,20 +7577,18 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 from pprint import pprint
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('compute', 'v1', credentials=credentials)
+service = discovery.build('compute', 'v1')
 
 # Project ID for this request.
 project = 'my-project'  # TODO: Update placeholder value.
@@ -8030,20 +7614,18 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 from pprint import pprint
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('compute', 'v1', credentials=credentials)
+service = discovery.build('compute', 'v1')
 
 # Project ID for this request.
 project = 'my-project'  # TODO: Update placeholder value.
@@ -8068,20 +7650,18 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 from pprint import pprint
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('compute', 'v1', credentials=credentials)
+service = discovery.build('compute', 'v1')
 
 # Project ID for this request.
 project = 'my-project'  # TODO: Update placeholder value.
@@ -8106,20 +7686,18 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 from pprint import pprint
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('compute', 'v1', credentials=credentials)
+service = discovery.build('compute', 'v1')
 
 # Project ID for this request.
 project = 'my-project'  # TODO: Update placeholder value.
@@ -8144,20 +7722,18 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 from pprint import pprint
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('compute', 'v1', credentials=credentials)
+service = discovery.build('compute', 'v1')
 
 # Project ID for this request.
 project = 'my-project'  # TODO: Update placeholder value.
@@ -8183,20 +7759,18 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 from pprint import pprint
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('compute', 'v1', credentials=credentials)
+service = discovery.build('compute', 'v1')
 
 # Project ID for this request.
 project = 'my-project'  # TODO: Update placeholder value.
@@ -8224,20 +7798,18 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 from pprint import pprint
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('compute', 'v1', credentials=credentials)
+service = discovery.build('compute', 'v1')
 
 # Project ID for this request.
 project = 'my-project'  # TODO: Update placeholder value.
@@ -8266,20 +7838,18 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 from pprint import pprint
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('compute', 'v1', credentials=credentials)
+service = discovery.build('compute', 'v1')
 
 # Project ID for this request.
 project = 'my-project'  # TODO: Update placeholder value.
@@ -8308,20 +7878,18 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 from pprint import pprint
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('compute', 'v1', credentials=credentials)
+service = discovery.build('compute', 'v1')
 
 # Project ID for this request.
 project = 'my-project'  # TODO: Update placeholder value.
@@ -8346,20 +7914,18 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 from pprint import pprint
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('compute', 'v1', credentials=credentials)
+service = discovery.build('compute', 'v1')
 
 # Project ID for this request.
 project = 'my-project'  # TODO: Update placeholder value.
@@ -8384,20 +7950,18 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 from pprint import pprint
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('compute', 'v1', credentials=credentials)
+service = discovery.build('compute', 'v1')
 
 # Project ID for this request.
 project = 'my-project'  # TODO: Update placeholder value.
@@ -8422,20 +7986,18 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 from pprint import pprint
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('compute', 'v1', credentials=credentials)
+service = discovery.build('compute', 'v1')
 
 # Project ID for this request.
 project = 'my-project'  # TODO: Update placeholder value.
@@ -8464,20 +8026,18 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 from pprint import pprint
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('compute', 'v1', credentials=credentials)
+service = discovery.build('compute', 'v1')
 
 # Project ID for this request.
 project = 'my-project'  # TODO: Update placeholder value.
@@ -8503,20 +8063,18 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 from pprint import pprint
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('compute', 'v1', credentials=credentials)
+service = discovery.build('compute', 'v1')
 
 # Project ID for this request.
 project = 'my-project'  # TODO: Update placeholder value.
@@ -8544,20 +8102,18 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 from pprint import pprint
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('compute', 'v1', credentials=credentials)
+service = discovery.build('compute', 'v1')
 
 # Project ID for this request.
 project = 'my-project'  # TODO: Update placeholder value.
@@ -8586,20 +8142,18 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 from pprint import pprint
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('compute', 'v1', credentials=credentials)
+service = discovery.build('compute', 'v1')
 
 # Project ID for this request.
 project = 'my-project'  # TODO: Update placeholder value.
@@ -8628,20 +8182,18 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 from pprint import pprint
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('compute', 'v1', credentials=credentials)
+service = discovery.build('compute', 'v1')
 
 # Project ID for this request.
 project = 'my-project'  # TODO: Update placeholder value.
@@ -8670,20 +8222,18 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 from pprint import pprint
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('compute', 'v1', credentials=credentials)
+service = discovery.build('compute', 'v1')
 
 # Project ID for this request.
 project = 'my-project'  # TODO: Update placeholder value.
@@ -8705,20 +8255,18 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 from pprint import pprint
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('compute', 'v1', credentials=credentials)
+service = discovery.build('compute', 'v1')
 
 # Project ID for this request.
 project = 'my-project'  # TODO: Update placeholder value.
@@ -8740,20 +8288,18 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 from pprint import pprint
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('compute', 'v1', credentials=credentials)
+service = discovery.build('compute', 'v1')
 
 # Project ID for this request.
 project = 'my-project'  # TODO: Update placeholder value.
@@ -8776,20 +8322,18 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 from pprint import pprint
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('compute', 'v1', credentials=credentials)
+service = discovery.build('compute', 'v1')
 
 # Project ID for this request.
 project = 'my-project'  # TODO: Update placeholder value.
@@ -8814,20 +8358,18 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 from pprint import pprint
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('compute', 'v1', credentials=credentials)
+service = discovery.build('compute', 'v1')
 
 # Project ID for this request.
 project = 'my-project'  # TODO: Update placeholder value.
@@ -8853,20 +8395,18 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 from pprint import pprint
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('compute', 'v1', credentials=credentials)
+service = discovery.build('compute', 'v1')
 
 # Project ID for this request.
 project = 'my-project'  # TODO: Update placeholder value.
@@ -8892,20 +8432,18 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 from pprint import pprint
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('compute', 'v1', credentials=credentials)
+service = discovery.build('compute', 'v1')
 
 # Project ID for this request.
 project = 'my-project'  # TODO: Update placeholder value.
@@ -8931,20 +8469,18 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 from pprint import pprint
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('compute', 'v1', credentials=credentials)
+service = discovery.build('compute', 'v1')
 
 # Project ID for this request.
 project = 'my-project'  # TODO: Update placeholder value.
@@ -8969,20 +8505,18 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 from pprint import pprint
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('compute', 'v1', credentials=credentials)
+service = discovery.build('compute', 'v1')
 
 # Project ID for this request.
 project = 'my-project'  # TODO: Update placeholder value.
@@ -9007,20 +8541,18 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 from pprint import pprint
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('compute', 'v1', credentials=credentials)
+service = discovery.build('compute', 'v1')
 
 # Project ID for this request.
 project = 'my-project'  # TODO: Update placeholder value.
@@ -9045,20 +8577,18 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 from pprint import pprint
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('compute', 'v1', credentials=credentials)
+service = discovery.build('compute', 'v1')
 
 # Project ID for this request.
 project = 'my-project'  # TODO: Update placeholder value.
@@ -9084,20 +8614,18 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 from pprint import pprint
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('compute', 'v1', credentials=credentials)
+service = discovery.build('compute', 'v1')
 
 # Project ID for this request.
 project = 'my-project'  # TODO: Update placeholder value.
@@ -9125,20 +8653,18 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 from pprint import pprint
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('compute', 'v1', credentials=credentials)
+service = discovery.build('compute', 'v1')
 
 # Project ID for this request.
 project = 'my-project'  # TODO: Update placeholder value.
@@ -9160,20 +8686,18 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 from pprint import pprint
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('compute', 'v1', credentials=credentials)
+service = discovery.build('compute', 'v1')
 
 # Project ID for this request.
 project = 'my-project'  # TODO: Update placeholder value.
@@ -9195,20 +8719,18 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 from pprint import pprint
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('compute', 'v1', credentials=credentials)
+service = discovery.build('compute', 'v1')
 
 # Project ID for this request.
 project = 'my-project'  # TODO: Update placeholder value.
@@ -9231,20 +8753,18 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 from pprint import pprint
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('compute', 'v1', credentials=credentials)
+service = discovery.build('compute', 'v1')
 
 # Project ID for this request.
 project = 'my-project'  # TODO: Update placeholder value.
@@ -9270,20 +8790,18 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 from pprint import pprint
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('compute', 'v1', credentials=credentials)
+service = discovery.build('compute', 'v1')
 
 # Project ID for this request.
 project = 'my-project'  # TODO: Update placeholder value.
@@ -9308,20 +8826,18 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 from pprint import pprint
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('compute', 'v1', credentials=credentials)
+service = discovery.build('compute', 'v1')
 
 # Project ID for this request.
 project = 'my-project'  # TODO: Update placeholder value.
@@ -9348,20 +8864,18 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 from pprint import pprint
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('compute', 'v1', credentials=credentials)
+service = discovery.build('compute', 'v1')
 
 # Project ID for this request.
 project = 'my-project'  # TODO: Update placeholder value.
@@ -9388,20 +8902,18 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 from pprint import pprint
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('compute', 'v1', credentials=credentials)
+service = discovery.build('compute', 'v1')
 
 # Project ID for this request.
 project = 'my-project'  # TODO: Update placeholder value.
@@ -9427,20 +8939,18 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 from pprint import pprint
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('compute', 'v1', credentials=credentials)
+service = discovery.build('compute', 'v1')
 
 # Project ID for this request.
 project = 'my-project'  # TODO: Update placeholder value.
@@ -9465,20 +8975,18 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 from pprint import pprint
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('compute', 'v1', credentials=credentials)
+service = discovery.build('compute', 'v1')
 
 # Project ID for this request.
 project = 'my-project'  # TODO: Update placeholder value.
@@ -9503,20 +9011,18 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 from pprint import pprint
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('compute', 'v1', credentials=credentials)
+service = discovery.build('compute', 'v1')
 
 # Project ID for this request.
 project = 'my-project'  # TODO: Update placeholder value.
@@ -9541,20 +9047,18 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 from pprint import pprint
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('compute', 'v1', credentials=credentials)
+service = discovery.build('compute', 'v1')
 
 # Project ID for this request.
 project = 'my-project'  # TODO: Update placeholder value.
@@ -9580,20 +9084,18 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 from pprint import pprint
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('compute', 'v1', credentials=credentials)
+service = discovery.build('compute', 'v1')
 
 # Project ID for this request.
 project = 'my-project'  # TODO: Update placeholder value.
@@ -9621,19 +9123,17 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('compute', 'v1', credentials=credentials)
+service = discovery.build('compute', 'v1')
 
 # Project ID for this request.
 project = 'my-project'  # TODO: Update placeholder value.
@@ -9655,20 +9155,18 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 from pprint import pprint
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('compute', 'v1', credentials=credentials)
+service = discovery.build('compute', 'v1')
 
 # Project ID for this request.
 project = 'my-project'  # TODO: Update placeholder value.
@@ -9693,20 +9191,18 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 from pprint import pprint
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('compute', 'v1', credentials=credentials)
+service = discovery.build('compute', 'v1')
 
 # Project ID for this request.
 project = 'my-project'  # TODO: Update placeholder value.
@@ -9734,20 +9230,18 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 from pprint import pprint
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('compute', 'v1', credentials=credentials)
+service = discovery.build('compute', 'v1')
 
 # Project ID for this request.
 project = 'my-project'  # TODO: Update placeholder value.
@@ -9769,20 +9263,18 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 from pprint import pprint
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('compute', 'v1', credentials=credentials)
+service = discovery.build('compute', 'v1')
 
 # Project ID for this request.
 project = 'my-project'  # TODO: Update placeholder value.

--- a/toolkit/src/test/java/com/google/api/codegen/testdata/discoveries/py/py_container.v1.json.baseline
+++ b/toolkit/src/test/java/com/google/api/codegen/testdata/discoveries/py/py_container.v1.json.baseline
@@ -8,20 +8,18 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 from pprint import pprint
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('container', 'v1', credentials=credentials)
+service = discovery.build('container', 'v1')
 
 # The Google Developers Console [project ID or project number]
 # (https://support.google.com/cloud/answer/6158840).
@@ -49,20 +47,18 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 from pprint import pprint
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('container', 'v1', credentials=credentials)
+service = discovery.build('container', 'v1')
 
 # The Google Developers Console [project ID or project number]
 # (https://support.google.com/cloud/answer/6158840).
@@ -89,20 +85,18 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 from pprint import pprint
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('container', 'v1', credentials=credentials)
+service = discovery.build('container', 'v1')
 
 # The Google Developers Console [project ID or project number]
 # (https://support.google.com/cloud/answer/6158840).
@@ -129,20 +123,18 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 from pprint import pprint
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('container', 'v1', credentials=credentials)
+service = discovery.build('container', 'v1')
 
 # The Google Developers Console [project ID or project number]
 # (https://support.google.com/cloud/answer/6158840).
@@ -166,20 +158,18 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 from pprint import pprint
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('container', 'v1', credentials=credentials)
+service = discovery.build('container', 'v1')
 
 # The Google Developers Console [project ID or project number]
 # (https://developers.google.com/console/help/new/#projectnumber).
@@ -210,20 +200,18 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 from pprint import pprint
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('container', 'v1', credentials=credentials)
+service = discovery.build('container', 'v1')
 
 # The Google Developers Console [project ID or project number]
 # (https://developers.google.com/console/help/new/#projectnumber).
@@ -253,20 +241,18 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 from pprint import pprint
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('container', 'v1', credentials=credentials)
+service = discovery.build('container', 'v1')
 
 # The Google Developers Console [project ID or project number]
 # (https://developers.google.com/console/help/new/#projectnumber).
@@ -296,20 +282,18 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 from pprint import pprint
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('container', 'v1', credentials=credentials)
+service = discovery.build('container', 'v1')
 
 # The Google Developers Console [project ID or project number]
 # (https://developers.google.com/console/help/new/#projectnumber).
@@ -336,20 +320,18 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 from pprint import pprint
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('container', 'v1', credentials=credentials)
+service = discovery.build('container', 'v1')
 
 # The Google Developers Console [project ID or project number]
 # (https://support.google.com/cloud/answer/6158840).
@@ -381,20 +363,18 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 from pprint import pprint
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('container', 'v1', credentials=credentials)
+service = discovery.build('container', 'v1')
 
 # The Google Developers Console [project ID or project number]
 # (https://support.google.com/cloud/answer/6158840).
@@ -418,20 +398,18 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 from pprint import pprint
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('container', 'v1', credentials=credentials)
+service = discovery.build('container', 'v1')
 
 # The Google Developers Console [project ID or project number]
 # (https://support.google.com/cloud/answer/6158840).
@@ -458,20 +436,18 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 from pprint import pprint
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('container', 'v1', credentials=credentials)
+service = discovery.build('container', 'v1')
 
 # The Google Developers Console [project ID or project number]
 # (https://support.google.com/cloud/answer/6158840).

--- a/toolkit/src/test/java/com/google/api/codegen/testdata/discoveries/py/py_datastore.v1.json.baseline
+++ b/toolkit/src/test/java/com/google/api/codegen/testdata/discoveries/py/py_datastore.v1.json.baseline
@@ -8,20 +8,18 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 from pprint import pprint
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('datastore', 'v1', credentials=credentials)
+service = discovery.build('datastore', 'v1')
 
 # The ID of the project against which to make the request.
 project_id = 'my-project-id'  # TODO: Update placeholder value.
@@ -44,20 +42,18 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 from pprint import pprint
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('datastore', 'v1', credentials=credentials)
+service = discovery.build('datastore', 'v1')
 
 # The ID of the project against which to make the request.
 project_id = 'my-project-id'  # TODO: Update placeholder value.
@@ -80,20 +76,18 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 from pprint import pprint
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('datastore', 'v1', credentials=credentials)
+service = discovery.build('datastore', 'v1')
 
 # The ID of the project against which to make the request.
 project_id = 'my-project-id'  # TODO: Update placeholder value.
@@ -116,20 +110,18 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 from pprint import pprint
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('datastore', 'v1', credentials=credentials)
+service = discovery.build('datastore', 'v1')
 
 # The ID of the project against which to make the request.
 project_id = 'my-project-id'  # TODO: Update placeholder value.
@@ -152,20 +144,18 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 from pprint import pprint
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('datastore', 'v1', credentials=credentials)
+service = discovery.build('datastore', 'v1')
 
 # The ID of the project against which to make the request.
 project_id = 'my-project-id'  # TODO: Update placeholder value.
@@ -188,20 +178,18 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 from pprint import pprint
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('datastore', 'v1', credentials=credentials)
+service = discovery.build('datastore', 'v1')
 
 # The ID of the project against which to make the request.
 project_id = 'my-project-id'  # TODO: Update placeholder value.

--- a/toolkit/src/test/java/com/google/api/codegen/testdata/discoveries/py/py_datastore.v1beta3.json.baseline
+++ b/toolkit/src/test/java/com/google/api/codegen/testdata/discoveries/py/py_datastore.v1beta3.json.baseline
@@ -10,18 +10,18 @@ BEFORE RUNNING:
    https://cloud.google.com/sdk/ and run
    `gcloud beta auth application-default login`
 3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+   `pip install --upgrade google-api-python-client google-auth`
 """
 from pprint import pprint
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
+from google import auth
 
 
 # Use Application Default Credentials for authentication when running locally.
 # For more information, see:
 # https://developers.google.com/identity/protocols/application-default-credentials
-credentials = GoogleCredentials.get_application_default()
+credentials, _ = auth.default()
 
 service = discovery.build('datastore', 'v1beta3', credentials=credentials)
 
@@ -53,18 +53,18 @@ BEFORE RUNNING:
    https://cloud.google.com/sdk/ and run
    `gcloud beta auth application-default login`
 3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+   `pip install --upgrade google-api-python-client google-auth`
 """
 from pprint import pprint
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
+from google import auth
 
 
 # Use Application Default Credentials for authentication when running locally.
 # For more information, see:
 # https://developers.google.com/identity/protocols/application-default-credentials
-credentials = GoogleCredentials.get_application_default()
+credentials, _ = auth.default()
 
 service = discovery.build('datastore', 'v1beta3', credentials=credentials)
 
@@ -96,18 +96,18 @@ BEFORE RUNNING:
    https://cloud.google.com/sdk/ and run
    `gcloud beta auth application-default login`
 3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+   `pip install --upgrade google-api-python-client google-auth`
 """
 from pprint import pprint
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
+from google import auth
 
 
 # Use Application Default Credentials for authentication when running locally.
 # For more information, see:
 # https://developers.google.com/identity/protocols/application-default-credentials
-credentials = GoogleCredentials.get_application_default()
+credentials, _ = auth.default()
 
 service = discovery.build('datastore', 'v1beta3', credentials=credentials)
 
@@ -139,18 +139,18 @@ BEFORE RUNNING:
    https://cloud.google.com/sdk/ and run
    `gcloud beta auth application-default login`
 3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+   `pip install --upgrade google-api-python-client google-auth`
 """
 from pprint import pprint
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
+from google import auth
 
 
 # Use Application Default Credentials for authentication when running locally.
 # For more information, see:
 # https://developers.google.com/identity/protocols/application-default-credentials
-credentials = GoogleCredentials.get_application_default()
+credentials, _ = auth.default()
 
 service = discovery.build('datastore', 'v1beta3', credentials=credentials)
 
@@ -182,18 +182,18 @@ BEFORE RUNNING:
    https://cloud.google.com/sdk/ and run
    `gcloud beta auth application-default login`
 3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+   `pip install --upgrade google-api-python-client google-auth`
 """
 from pprint import pprint
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
+from google import auth
 
 
 # Use Application Default Credentials for authentication when running locally.
 # For more information, see:
 # https://developers.google.com/identity/protocols/application-default-credentials
-credentials = GoogleCredentials.get_application_default()
+credentials, _ = auth.default()
 
 service = discovery.build('datastore', 'v1beta3', credentials=credentials)
 
@@ -225,18 +225,18 @@ BEFORE RUNNING:
    https://cloud.google.com/sdk/ and run
    `gcloud beta auth application-default login`
 3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+   `pip install --upgrade google-api-python-client google-auth`
 """
 from pprint import pprint
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
+from google import auth
 
 
 # Use Application Default Credentials for authentication when running locally.
 # For more information, see:
 # https://developers.google.com/identity/protocols/application-default-credentials
-credentials = GoogleCredentials.get_application_default()
+credentials, _ = auth.default()
 
 service = discovery.build('datastore', 'v1beta3', credentials=credentials)
 

--- a/toolkit/src/test/java/com/google/api/codegen/testdata/discoveries/py/py_deploymentmanager.v2.json.baseline
+++ b/toolkit/src/test/java/com/google/api/codegen/testdata/discoveries/py/py_deploymentmanager.v2.json.baseline
@@ -8,20 +8,18 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 from pprint import pprint
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('deploymentmanager', 'v2', credentials=credentials)
+service = discovery.build('deploymentmanager', 'v2')
 
 # The project ID for this request.
 project = 'my-project'  # TODO: Update placeholder value.
@@ -47,20 +45,18 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 from pprint import pprint
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('deploymentmanager', 'v2', credentials=credentials)
+service = discovery.build('deploymentmanager', 'v2')
 
 # The project ID for this request.
 project = 'my-project'  # TODO: Update placeholder value.
@@ -82,20 +78,18 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 from pprint import pprint
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('deploymentmanager', 'v2', credentials=credentials)
+service = discovery.build('deploymentmanager', 'v2')
 
 # The project ID for this request.
 project = 'my-project'  # TODO: Update placeholder value.
@@ -117,20 +111,18 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 from pprint import pprint
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('deploymentmanager', 'v2', credentials=credentials)
+service = discovery.build('deploymentmanager', 'v2')
 
 # Project ID for this request.
 project = 'my-project'  # TODO: Update placeholder value.
@@ -152,20 +144,18 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 from pprint import pprint
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('deploymentmanager', 'v2', credentials=credentials)
+service = discovery.build('deploymentmanager', 'v2')
 
 # The project ID for this request.
 project = 'my-project'  # TODO: Update placeholder value.
@@ -188,20 +178,18 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 from pprint import pprint
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('deploymentmanager', 'v2', credentials=credentials)
+service = discovery.build('deploymentmanager', 'v2')
 
 # The project ID for this request.
 project = 'my-project'  # TODO: Update placeholder value.
@@ -226,20 +214,18 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 from pprint import pprint
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('deploymentmanager', 'v2', credentials=credentials)
+service = discovery.build('deploymentmanager', 'v2')
 
 # The project ID for this request.
 project = 'my-project'  # TODO: Update placeholder value.
@@ -266,20 +252,18 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 from pprint import pprint
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('deploymentmanager', 'v2', credentials=credentials)
+service = discovery.build('deploymentmanager', 'v2')
 
 # Project ID for this request.
 project = 'my-project'  # TODO: Update placeholder value.
@@ -305,20 +289,18 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 from pprint import pprint
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('deploymentmanager', 'v2', credentials=credentials)
+service = discovery.build('deploymentmanager', 'v2')
 
 # The project ID for this request.
 project = 'my-project'  # TODO: Update placeholder value.
@@ -344,20 +326,18 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 from pprint import pprint
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('deploymentmanager', 'v2', credentials=credentials)
+service = discovery.build('deploymentmanager', 'v2')
 
 # Project ID for this request.
 project = 'my-project'  # TODO: Update placeholder value.
@@ -383,20 +363,18 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 from pprint import pprint
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('deploymentmanager', 'v2', credentials=credentials)
+service = discovery.build('deploymentmanager', 'v2')
 
 # The project ID for this request.
 project = 'my-project'  # TODO: Update placeholder value.
@@ -423,20 +401,18 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 from pprint import pprint
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('deploymentmanager', 'v2', credentials=credentials)
+service = discovery.build('deploymentmanager', 'v2')
 
 # The project ID for this request.
 project = 'my-project'  # TODO: Update placeholder value.
@@ -461,20 +437,18 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 from pprint import pprint
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('deploymentmanager', 'v2', credentials=credentials)
+service = discovery.build('deploymentmanager', 'v2')
 
 # The project ID for this request.
 project = 'my-project'  # TODO: Update placeholder value.
@@ -502,20 +476,18 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 from pprint import pprint
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('deploymentmanager', 'v2', credentials=credentials)
+service = discovery.build('deploymentmanager', 'v2')
 
 # The project ID for this request.
 project = 'my-project'  # TODO: Update placeholder value.
@@ -537,20 +509,18 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 from pprint import pprint
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('deploymentmanager', 'v2', credentials=credentials)
+service = discovery.build('deploymentmanager', 'v2')
 
 # The project ID for this request.
 project = 'my-project'  # TODO: Update placeholder value.
@@ -575,20 +545,18 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 from pprint import pprint
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('deploymentmanager', 'v2', credentials=credentials)
+service = discovery.build('deploymentmanager', 'v2')
 
 # The project ID for this request.
 project = 'my-project'  # TODO: Update placeholder value.
@@ -613,20 +581,18 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 from pprint import pprint
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('deploymentmanager', 'v2', credentials=credentials)
+service = discovery.build('deploymentmanager', 'v2')
 
 # The project ID for this request.
 project = 'my-project'  # TODO: Update placeholder value.
@@ -654,20 +620,18 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 from pprint import pprint
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('deploymentmanager', 'v2', credentials=credentials)
+service = discovery.build('deploymentmanager', 'v2')
 
 # The project ID for this request.
 project = 'my-project'  # TODO: Update placeholder value.

--- a/toolkit/src/test/java/com/google/api/codegen/testdata/discoveries/py/py_dns.v1.json.baseline
+++ b/toolkit/src/test/java/com/google/api/codegen/testdata/discoveries/py/py_dns.v1.json.baseline
@@ -8,20 +8,18 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 from pprint import pprint
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('dns', 'v1', credentials=credentials)
+service = discovery.build('dns', 'v1')
 
 # Identifies the project addressed by this request.
 project = 'my-project'  # TODO: Update placeholder value.
@@ -47,20 +45,18 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 from pprint import pprint
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('dns', 'v1', credentials=credentials)
+service = discovery.build('dns', 'v1')
 
 # Identifies the project addressed by this request.
 project = 'my-project'  # TODO: Update placeholder value.
@@ -85,20 +81,18 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 from pprint import pprint
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('dns', 'v1', credentials=credentials)
+service = discovery.build('dns', 'v1')
 
 # Identifies the project addressed by this request.
 project = 'my-project'  # TODO: Update placeholder value.
@@ -126,20 +120,18 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 from pprint import pprint
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('dns', 'v1', credentials=credentials)
+service = discovery.build('dns', 'v1')
 
 # Identifies the project addressed by this request.
 project = 'my-project'  # TODO: Update placeholder value.
@@ -162,19 +154,17 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('dns', 'v1', credentials=credentials)
+service = discovery.build('dns', 'v1')
 
 # Identifies the project addressed by this request.
 project = 'my-project'  # TODO: Update placeholder value.
@@ -193,20 +183,18 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 from pprint import pprint
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('dns', 'v1', credentials=credentials)
+service = discovery.build('dns', 'v1')
 
 # Identifies the project addressed by this request.
 project = 'my-project'  # TODO: Update placeholder value.
@@ -228,20 +216,18 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 from pprint import pprint
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('dns', 'v1', credentials=credentials)
+service = discovery.build('dns', 'v1')
 
 # Identifies the project addressed by this request.
 project = 'my-project'  # TODO: Update placeholder value.
@@ -266,20 +252,18 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 from pprint import pprint
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('dns', 'v1', credentials=credentials)
+service = discovery.build('dns', 'v1')
 
 # Identifies the project addressed by this request.
 project = 'my-project'  # TODO: Update placeholder value.
@@ -298,20 +282,18 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 from pprint import pprint
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('dns', 'v1', credentials=credentials)
+service = discovery.build('dns', 'v1')
 
 # Identifies the project addressed by this request.
 project = 'my-project'  # TODO: Update placeholder value.

--- a/toolkit/src/test/java/com/google/api/codegen/testdata/discoveries/py/py_genomics.v1.json.baseline
+++ b/toolkit/src/test/java/com/google/api/codegen/testdata/discoveries/py/py_genomics.v1.json.baseline
@@ -8,20 +8,18 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 from pprint import pprint
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('genomics', 'v1', credentials=credentials)
+service = discovery.build('genomics', 'v1')
 
 batch_create_annotations_request_body = {
     # TODO: Add desired entries to the request body.
@@ -41,20 +39,18 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 from pprint import pprint
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('genomics', 'v1', credentials=credentials)
+service = discovery.build('genomics', 'v1')
 
 annotation_body = {
     # TODO: Add desired entries to the request body.
@@ -74,19 +70,17 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('genomics', 'v1', credentials=credentials)
+service = discovery.build('genomics', 'v1')
 
 # The ID of the annotation to be deleted.
 annotation_id = 'my-annotation-id'  # TODO: Update placeholder value.
@@ -102,20 +96,18 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 from pprint import pprint
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('genomics', 'v1', credentials=credentials)
+service = discovery.build('genomics', 'v1')
 
 # The ID of the annotation to be retrieved.
 annotation_id = 'my-annotation-id'  # TODO: Update placeholder value.
@@ -134,20 +126,18 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 from pprint import pprint
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('genomics', 'v1', credentials=credentials)
+service = discovery.build('genomics', 'v1')
 
 search_annotations_request_body = {
     # TODO: Add desired entries to the request body.
@@ -173,20 +163,18 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 from pprint import pprint
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('genomics', 'v1', credentials=credentials)
+service = discovery.build('genomics', 'v1')
 
 # The ID of the annotation to be updated.
 annotation_id = 'my-annotation-id'  # TODO: Update placeholder value.
@@ -210,20 +198,18 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 from pprint import pprint
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('genomics', 'v1', credentials=credentials)
+service = discovery.build('genomics', 'v1')
 
 annotation_set_body = {
     # TODO: Add desired entries to the request body.
@@ -243,19 +229,17 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('genomics', 'v1', credentials=credentials)
+service = discovery.build('genomics', 'v1')
 
 # The ID of the annotation set to be deleted.
 annotation_set_id = 'my-annotation-set-id'  # TODO: Update placeholder value.
@@ -271,20 +255,18 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 from pprint import pprint
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('genomics', 'v1', credentials=credentials)
+service = discovery.build('genomics', 'v1')
 
 # The ID of the annotation set to be retrieved.
 annotation_set_id = 'my-annotation-set-id'  # TODO: Update placeholder value.
@@ -303,20 +285,18 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 from pprint import pprint
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('genomics', 'v1', credentials=credentials)
+service = discovery.build('genomics', 'v1')
 
 search_annotation_sets_request_body = {
     # TODO: Add desired entries to the request body.
@@ -342,20 +322,18 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 from pprint import pprint
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('genomics', 'v1', credentials=credentials)
+service = discovery.build('genomics', 'v1')
 
 # The ID of the annotation set to be updated.
 annotation_set_id = 'my-annotation-set-id'  # TODO: Update placeholder value.
@@ -379,20 +357,18 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 from pprint import pprint
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('genomics', 'v1', credentials=credentials)
+service = discovery.build('genomics', 'v1')
 
 call_set_body = {
     # TODO: Add desired entries to the request body.
@@ -412,19 +388,17 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('genomics', 'v1', credentials=credentials)
+service = discovery.build('genomics', 'v1')
 
 # The ID of the call set to be deleted.
 call_set_id = 'my-call-set-id'  # TODO: Update placeholder value.
@@ -440,20 +414,18 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 from pprint import pprint
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('genomics', 'v1', credentials=credentials)
+service = discovery.build('genomics', 'v1')
 
 # The ID of the call set.
 call_set_id = 'my-call-set-id'  # TODO: Update placeholder value.
@@ -472,20 +444,18 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 from pprint import pprint
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('genomics', 'v1', credentials=credentials)
+service = discovery.build('genomics', 'v1')
 
 # The ID of the call set to be updated.
 call_set_id = 'my-call-set-id'  # TODO: Update placeholder value.
@@ -509,20 +479,18 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 from pprint import pprint
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('genomics', 'v1', credentials=credentials)
+service = discovery.build('genomics', 'v1')
 
 search_call_sets_request_body = {
     # TODO: Add desired entries to the request body.
@@ -548,20 +516,18 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 from pprint import pprint
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('genomics', 'v1', credentials=credentials)
+service = discovery.build('genomics', 'v1')
 
 dataset_body = {
     # TODO: Add desired entries to the request body.
@@ -581,19 +547,17 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('genomics', 'v1', credentials=credentials)
+service = discovery.build('genomics', 'v1')
 
 # The ID of the dataset to be deleted.
 dataset_id = 'my-dataset-id'  # TODO: Update placeholder value.
@@ -609,20 +573,18 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 from pprint import pprint
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('genomics', 'v1', credentials=credentials)
+service = discovery.build('genomics', 'v1')
 
 # The ID of the dataset.
 dataset_id = 'my-dataset-id'  # TODO: Update placeholder value.
@@ -641,20 +603,18 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 from pprint import pprint
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('genomics', 'v1', credentials=credentials)
+service = discovery.build('genomics', 'v1')
 
 # REQUIRED: The resource for which policy is being specified. Format is `datasets/`.
 resource = 'datasets/my-dataset'  # TODO: Update placeholder value.
@@ -677,20 +637,18 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 from pprint import pprint
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('genomics', 'v1', credentials=credentials)
+service = discovery.build('genomics', 'v1')
 
 request = service.datasets().list()
 while True:
@@ -712,20 +670,18 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 from pprint import pprint
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('genomics', 'v1', credentials=credentials)
+service = discovery.build('genomics', 'v1')
 
 # The ID of the dataset to be updated.
 dataset_id = 'my-dataset-id'  # TODO: Update placeholder value.
@@ -749,20 +705,18 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 from pprint import pprint
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('genomics', 'v1', credentials=credentials)
+service = discovery.build('genomics', 'v1')
 
 # REQUIRED: The resource for which policy is being specified. Format is `datasets/`.
 resource = 'datasets/my-dataset'  # TODO: Update placeholder value.
@@ -785,20 +739,18 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 from pprint import pprint
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('genomics', 'v1', credentials=credentials)
+service = discovery.build('genomics', 'v1')
 
 # REQUIRED: The resource for which policy is being specified. Format is `datasets/`.
 resource = 'datasets/my-dataset'  # TODO: Update placeholder value.
@@ -821,20 +773,18 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 from pprint import pprint
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('genomics', 'v1', credentials=credentials)
+service = discovery.build('genomics', 'v1')
 
 # The ID of the dataset to be undeleted.
 dataset_id = 'my-dataset-id'  # TODO: Update placeholder value.
@@ -857,19 +807,17 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('genomics', 'v1', credentials=credentials)
+service = discovery.build('genomics', 'v1')
 
 # The name of the operation resource to be cancelled.
 name = 'operations/my-operation'  # TODO: Update placeholder value.
@@ -889,20 +837,18 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 from pprint import pprint
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('genomics', 'v1', credentials=credentials)
+service = discovery.build('genomics', 'v1')
 
 # The name of the operation resource.
 name = 'operations/my-operation'  # TODO: Update placeholder value.
@@ -921,20 +867,18 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 from pprint import pprint
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('genomics', 'v1', credentials=credentials)
+service = discovery.build('genomics', 'v1')
 
 # The name of the operation collection.
 name = 'operations'  # TODO: Update placeholder value.
@@ -959,20 +903,18 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 from pprint import pprint
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('genomics', 'v1', credentials=credentials)
+service = discovery.build('genomics', 'v1')
 
 # Required. The ID of the read group set over which coverage is requested.
 read_group_set_id = 'my-read-group-set-id'  # TODO: Update placeholder value.
@@ -997,19 +939,17 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('genomics', 'v1', credentials=credentials)
+service = discovery.build('genomics', 'v1')
 
 # The ID of the read group set to be deleted. The caller must have WRITE permissions to the dataset
 # associated with this read group set.
@@ -1026,20 +966,18 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 from pprint import pprint
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('genomics', 'v1', credentials=credentials)
+service = discovery.build('genomics', 'v1')
 
 # Required. The ID of the read group set to export. The caller must have READ access to this read
 # group set.
@@ -1063,20 +1001,18 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 from pprint import pprint
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('genomics', 'v1', credentials=credentials)
+service = discovery.build('genomics', 'v1')
 
 # The ID of the read group set.
 read_group_set_id = 'my-read-group-set-id'  # TODO: Update placeholder value.
@@ -1095,20 +1031,18 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 from pprint import pprint
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('genomics', 'v1', credentials=credentials)
+service = discovery.build('genomics', 'v1')
 
 import_read_group_sets_request_body = {
     # TODO: Add desired entries to the request body.
@@ -1128,20 +1062,18 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 from pprint import pprint
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('genomics', 'v1', credentials=credentials)
+service = discovery.build('genomics', 'v1')
 
 # The ID of the read group set to be updated. The caller must have WRITE permissions to the dataset
 # associated with this read group set.
@@ -1166,20 +1098,18 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 from pprint import pprint
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('genomics', 'v1', credentials=credentials)
+service = discovery.build('genomics', 'v1')
 
 search_read_group_sets_request_body = {
     # TODO: Add desired entries to the request body.
@@ -1205,20 +1135,18 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 from pprint import pprint
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('genomics', 'v1', credentials=credentials)
+service = discovery.build('genomics', 'v1')
 
 search_reads_request_body = {
     # TODO: Add desired entries to the request body.
@@ -1244,20 +1172,18 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 from pprint import pprint
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('genomics', 'v1', credentials=credentials)
+service = discovery.build('genomics', 'v1')
 
 stream_reads_request_body = {
     # TODO: Add desired entries to the request body.
@@ -1277,20 +1203,18 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 from pprint import pprint
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('genomics', 'v1', credentials=credentials)
+service = discovery.build('genomics', 'v1')
 
 # The ID of the reference.
 reference_id = 'my-reference-id'  # TODO: Update placeholder value.
@@ -1314,20 +1238,18 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 from pprint import pprint
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('genomics', 'v1', credentials=credentials)
+service = discovery.build('genomics', 'v1')
 
 # The ID of the reference.
 reference_id = 'my-reference-id'  # TODO: Update placeholder value.
@@ -1346,20 +1268,18 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 from pprint import pprint
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('genomics', 'v1', credentials=credentials)
+service = discovery.build('genomics', 'v1')
 
 search_references_request_body = {
     # TODO: Add desired entries to the request body.
@@ -1385,20 +1305,18 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 from pprint import pprint
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('genomics', 'v1', credentials=credentials)
+service = discovery.build('genomics', 'v1')
 
 # The ID of the reference set.
 reference_set_id = 'my-reference-set-id'  # TODO: Update placeholder value.
@@ -1417,20 +1335,18 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 from pprint import pprint
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('genomics', 'v1', credentials=credentials)
+service = discovery.build('genomics', 'v1')
 
 search_reference_sets_request_body = {
     # TODO: Add desired entries to the request body.
@@ -1456,20 +1372,18 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 from pprint import pprint
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('genomics', 'v1', credentials=credentials)
+service = discovery.build('genomics', 'v1')
 
 variant_body = {
     # TODO: Add desired entries to the request body.
@@ -1489,19 +1403,17 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('genomics', 'v1', credentials=credentials)
+service = discovery.build('genomics', 'v1')
 
 # The ID of the variant to be deleted.
 variant_id = 'my-variant-id'  # TODO: Update placeholder value.
@@ -1517,20 +1429,18 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 from pprint import pprint
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('genomics', 'v1', credentials=credentials)
+service = discovery.build('genomics', 'v1')
 
 # The ID of the variant.
 variant_id = 'my-variant-id'  # TODO: Update placeholder value.
@@ -1549,20 +1459,18 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 from pprint import pprint
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('genomics', 'v1', credentials=credentials)
+service = discovery.build('genomics', 'v1')
 
 import_variants_request_body = {
     # TODO: Add desired entries to the request body.
@@ -1582,19 +1490,17 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('genomics', 'v1', credentials=credentials)
+service = discovery.build('genomics', 'v1')
 
 merge_variants_request_body = {
     # TODO: Add desired entries to the request body.
@@ -1611,20 +1517,18 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 from pprint import pprint
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('genomics', 'v1', credentials=credentials)
+service = discovery.build('genomics', 'v1')
 
 # The ID of the variant to be updated.
 variant_id = 'my-variant-id'  # TODO: Update placeholder value.
@@ -1648,20 +1552,18 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 from pprint import pprint
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('genomics', 'v1', credentials=credentials)
+service = discovery.build('genomics', 'v1')
 
 search_variants_request_body = {
     # TODO: Add desired entries to the request body.
@@ -1687,20 +1589,18 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 from pprint import pprint
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('genomics', 'v1', credentials=credentials)
+service = discovery.build('genomics', 'v1')
 
 stream_variants_request_body = {
     # TODO: Add desired entries to the request body.
@@ -1720,20 +1620,18 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 from pprint import pprint
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('genomics', 'v1', credentials=credentials)
+service = discovery.build('genomics', 'v1')
 
 variant_set_body = {
     # TODO: Add desired entries to the request body.
@@ -1753,19 +1651,17 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('genomics', 'v1', credentials=credentials)
+service = discovery.build('genomics', 'v1')
 
 # The ID of the variant set to be deleted.
 variant_set_id = 'my-variant-set-id'  # TODO: Update placeholder value.
@@ -1781,20 +1677,18 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 from pprint import pprint
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('genomics', 'v1', credentials=credentials)
+service = discovery.build('genomics', 'v1')
 
 # Required. The ID of the variant set that contains variant data which should be exported. The caller
 # must have READ access to this variant set.
@@ -1818,20 +1712,18 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 from pprint import pprint
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('genomics', 'v1', credentials=credentials)
+service = discovery.build('genomics', 'v1')
 
 # Required. The ID of the variant set.
 variant_set_id = 'my-variant-set-id'  # TODO: Update placeholder value.
@@ -1850,20 +1742,18 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 from pprint import pprint
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('genomics', 'v1', credentials=credentials)
+service = discovery.build('genomics', 'v1')
 
 # The ID of the variant to be updated (must already exist).
 variant_set_id = 'my-variant-set-id'  # TODO: Update placeholder value.
@@ -1887,20 +1777,18 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 from pprint import pprint
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('genomics', 'v1', credentials=credentials)
+service = discovery.build('genomics', 'v1')
 
 search_variant_sets_request_body = {
     # TODO: Add desired entries to the request body.

--- a/toolkit/src/test/java/com/google/api/codegen/testdata/discoveries/py/py_healthcase.v1beta1.json.baseline
+++ b/toolkit/src/test/java/com/google/api/codegen/testdata/discoveries/py/py_healthcase.v1beta1.json.baseline
@@ -8,20 +8,18 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 from pprint import pprint
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('healthcare', 'v1beta1', credentials=credentials)
+service = discovery.build('healthcare', 'v1beta1')
 
 # The name of the project in which the dataset should be created (e.g.,
 # `projects/{project_id}/locations/{location_id}`).
@@ -45,20 +43,18 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 from pprint import pprint
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('healthcare', 'v1beta1', credentials=credentials)
+service = discovery.build('healthcare', 'v1beta1')
 
 # Source dataset resource name. (e.g.,
 # `projects/{project_id}/locations/{location_id}/datasets/{dataset_id}`).
@@ -82,19 +78,17 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('healthcare', 'v1beta1', credentials=credentials)
+service = discovery.build('healthcare', 'v1beta1')
 
 # The name of the dataset to delete (e.g.,
 # `projects/{project_id}/locations/{location_id}/datasets/{dataset_id}`).
@@ -111,20 +105,18 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 from pprint import pprint
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('healthcare', 'v1beta1', credentials=credentials)
+service = discovery.build('healthcare', 'v1beta1')
 
 # The name of the dataset this DICOM store belongs to.
 parent = 'projects/my-project/locations/my-location/datasets/my-dataset'  # TODO: Update placeholder value.
@@ -147,19 +139,17 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('healthcare', 'v1beta1', credentials=credentials)
+service = discovery.build('healthcare', 'v1beta1')
 
 # The resource name of the DICOM store to delete.
 name = 'projects/my-project/locations/my-location/datasets/my-dataset/dicomStores/my-dicom-store'  # TODO: Update placeholder value.
@@ -175,20 +165,18 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 from pprint import pprint
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('healthcare', 'v1beta1', credentials=credentials)
+service = discovery.build('healthcare', 'v1beta1')
 
 # The DICOM store resource name from which the data should be exported (e.g.,
 # `projects/{project_id}/locations/{location_id}/datasets/{dataset_id}/dicomStores/{dicom_store_id}`).
@@ -212,20 +200,18 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 from pprint import pprint
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('healthcare', 'v1beta1', credentials=credentials)
+service = discovery.build('healthcare', 'v1beta1')
 
 # The resource name of the DICOM store to get.
 name = 'projects/my-project/locations/my-location/datasets/my-dataset/dicomStores/my-dicom-store'  # TODO: Update placeholder value.
@@ -244,20 +230,18 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 from pprint import pprint
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('healthcare', 'v1beta1', credentials=credentials)
+service = discovery.build('healthcare', 'v1beta1')
 
 # REQUIRED: The resource for which the policy is being requested.
 # See the operation documentation for the appropriate value for this field.
@@ -277,20 +261,18 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 from pprint import pprint
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('healthcare', 'v1beta1', credentials=credentials)
+service = discovery.build('healthcare', 'v1beta1')
 
 # The name of the DICOM store resource into which the data is imported (e.g.,
 # `projects/{project_id}/locations/{location_id}/datasets/{dataset_id}/dicomStores/{dicom_store_id}`).
@@ -314,20 +296,18 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 from pprint import pprint
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('healthcare', 'v1beta1', credentials=credentials)
+service = discovery.build('healthcare', 'v1beta1')
 
 # Name of the dataset.
 parent = 'projects/my-project/locations/my-location/datasets/my-dataset'  # TODO: Update placeholder value.
@@ -352,20 +332,18 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 from pprint import pprint
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('healthcare', 'v1beta1', credentials=credentials)
+service = discovery.build('healthcare', 'v1beta1')
 
 # Output only. Resource name of the DICOM store, of the form
 # `projects/{project_id}/locations/{location_id}/datasets/{dataset_id}/dicomStores/{dicom_store_id}`.
@@ -390,20 +368,18 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 from pprint import pprint
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('healthcare', 'v1beta1', credentials=credentials)
+service = discovery.build('healthcare', 'v1beta1')
 
 # The name of the DICOM store that is being accessed (e.g.,
 # `projects/{project_id}/locations/{location_id}/datasets/{dataset_id}/dicomStores/{dicom_store_id}`).
@@ -428,20 +404,18 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 from pprint import pprint
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('healthcare', 'v1beta1', credentials=credentials)
+service = discovery.build('healthcare', 'v1beta1')
 
 # The name of the DICOM store that is being accessed (e.g.,
 # `projects/{project_id}/locations/{location_id}/datasets/{dataset_id}/dicomStores/{dicom_store_id}`).
@@ -466,20 +440,18 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 from pprint import pprint
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('healthcare', 'v1beta1', credentials=credentials)
+service = discovery.build('healthcare', 'v1beta1')
 
 # The name of the DICOM store that is being accessed (e.g.,
 # `projects/{project_id}/locations/{location_id}/datasets/{dataset_id}/dicomStores/{dicom_store_id}`).
@@ -504,20 +476,18 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 from pprint import pprint
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('healthcare', 'v1beta1', credentials=credentials)
+service = discovery.build('healthcare', 'v1beta1')
 
 # REQUIRED: The resource for which the policy is being specified.
 # See the operation documentation for the appropriate value for this field.
@@ -541,20 +511,18 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 from pprint import pprint
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('healthcare', 'v1beta1', credentials=credentials)
+service = discovery.build('healthcare', 'v1beta1')
 
 # The name of the DICOM store that is being accessed (e.g.,
 # `projects/{project_id}/locations/{location_id}/datasets/{dataset_id}/dicomStores/{dicom_store_id}`).
@@ -582,19 +550,17 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('healthcare', 'v1beta1', credentials=credentials)
+service = discovery.build('healthcare', 'v1beta1')
 
 # The name of the DICOM store that is being accessed (e.g.,
 # `projects/{project_id}/locations/{location_id}/datasets/{dataset_id}/dicomStores/{dicom_store_id}`).
@@ -615,20 +581,18 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 from pprint import pprint
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('healthcare', 'v1beta1', credentials=credentials)
+service = discovery.build('healthcare', 'v1beta1')
 
 # The name of the DICOM store that is being accessed (e.g.,
 # `projects/{project_id}/locations/{location_id}/datasets/{dataset_id}/dicomStores/{dicom_store_id}`).
@@ -652,20 +616,18 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 from pprint import pprint
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('healthcare', 'v1beta1', credentials=credentials)
+service = discovery.build('healthcare', 'v1beta1')
 
 # The name of the DICOM store that is being accessed (e.g.,
 # `projects/{project_id}/locations/{location_id}/datasets/{dataset_id}/dicomStores/{dicom_store_id}`).
@@ -689,20 +651,18 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 from pprint import pprint
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('healthcare', 'v1beta1', credentials=credentials)
+service = discovery.build('healthcare', 'v1beta1')
 
 # The name of the DICOM store that is being accessed (e.g.,
 # `projects/{project_id}/locations/{location_id}/datasets/{dataset_id}/dicomStores/{dicom_store_id}`).
@@ -727,20 +687,18 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 from pprint import pprint
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('healthcare', 'v1beta1', credentials=credentials)
+service = discovery.build('healthcare', 'v1beta1')
 
 # The name of the DICOM store that is being accessed (e.g.,
 # `projects/{project_id}/locations/{location_id}/datasets/{dataset_id}/dicomStores/{dicom_store_id}`).
@@ -765,19 +723,17 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('healthcare', 'v1beta1', credentials=credentials)
+service = discovery.build('healthcare', 'v1beta1')
 
 # The name of the DICOM store that is being accessed (e.g.,
 # `projects/{project_id}/locations/{location_id}/datasets/{dataset_id}/dicomStores/{dicom_store_id}`).
@@ -798,19 +754,17 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('healthcare', 'v1beta1', credentials=credentials)
+service = discovery.build('healthcare', 'v1beta1')
 
 # The name of the DICOM store that is being accessed (e.g.,
 # `projects/{project_id}/locations/{location_id}/datasets/{dataset_id}/dicomStores/{dicom_store_id}`).
@@ -832,20 +786,18 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 from pprint import pprint
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('healthcare', 'v1beta1', credentials=credentials)
+service = discovery.build('healthcare', 'v1beta1')
 
 # The name of the DICOM store that is being accessed (e.g.,
 # `projects/{project_id}/locations/{location_id}/datasets/{dataset_id}/dicomStores/{dicom_store_id}`).
@@ -870,20 +822,18 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 from pprint import pprint
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('healthcare', 'v1beta1', credentials=credentials)
+service = discovery.build('healthcare', 'v1beta1')
 
 # The name of the DICOM store that is being accessed (e.g.,
 # `projects/{project_id}/locations/{location_id}/datasets/{dataset_id}/dicomStores/{dicom_store_id}`).
@@ -908,20 +858,18 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 from pprint import pprint
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('healthcare', 'v1beta1', credentials=credentials)
+service = discovery.build('healthcare', 'v1beta1')
 
 # The name of the DICOM store that is being accessed (e.g.,
 # `projects/{project_id}/locations/{location_id}/datasets/{dataset_id}/dicomStores/{dicom_store_id}`).
@@ -946,20 +894,18 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 from pprint import pprint
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('healthcare', 'v1beta1', credentials=credentials)
+service = discovery.build('healthcare', 'v1beta1')
 
 # The name of the DICOM store that is being accessed (e.g.,
 # `projects/{project_id}/locations/{location_id}/datasets/{dataset_id}/dicomStores/{dicom_store_id}`).
@@ -984,20 +930,18 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 from pprint import pprint
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('healthcare', 'v1beta1', credentials=credentials)
+service = discovery.build('healthcare', 'v1beta1')
 
 # The name of the DICOM store that is being accessed (e.g.,
 # `projects/{project_id}/locations/{location_id}/datasets/{dataset_id}/dicomStores/{dicom_store_id}`).
@@ -1022,20 +966,18 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 from pprint import pprint
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('healthcare', 'v1beta1', credentials=credentials)
+service = discovery.build('healthcare', 'v1beta1')
 
 # The name of the DICOM store that is being accessed (e.g.,
 # `projects/{project_id}/locations/{location_id}/datasets/{dataset_id}/dicomStores/{dicom_store_id}`).
@@ -1059,20 +1001,18 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 from pprint import pprint
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('healthcare', 'v1beta1', credentials=credentials)
+service = discovery.build('healthcare', 'v1beta1')
 
 # The name of the DICOM store that is being accessed (e.g.,
 # `projects/{project_id}/locations/{location_id}/datasets/{dataset_id}/dicomStores/{dicom_store_id}`).
@@ -1096,20 +1036,18 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 from pprint import pprint
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('healthcare', 'v1beta1', credentials=credentials)
+service = discovery.build('healthcare', 'v1beta1')
 
 # The name of the DICOM store that is being accessed (e.g.,
 # `projects/{project_id}/locations/{location_id}/datasets/{dataset_id}/dicomStores/{dicom_store_id}`).
@@ -1134,20 +1072,18 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 from pprint import pprint
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('healthcare', 'v1beta1', credentials=credentials)
+service = discovery.build('healthcare', 'v1beta1')
 
 # The name of the DICOM store that is being accessed (e.g.,
 # `projects/{project_id}/locations/{location_id}/datasets/{dataset_id}/dicomStores/{dicom_store_id}`).
@@ -1175,20 +1111,18 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 from pprint import pprint
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('healthcare', 'v1beta1', credentials=credentials)
+service = discovery.build('healthcare', 'v1beta1')
 
 # REQUIRED: The resource for which the policy detail is being requested.
 # See the operation documentation for the appropriate value for this field.
@@ -1212,20 +1146,18 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 from pprint import pprint
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('healthcare', 'v1beta1', credentials=credentials)
+service = discovery.build('healthcare', 'v1beta1')
 
 # The name of the dataset this FHIR store belongs to.
 parent = 'projects/my-project/locations/my-location/datasets/my-dataset'  # TODO: Update placeholder value.
@@ -1248,19 +1180,17 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('healthcare', 'v1beta1', credentials=credentials)
+service = discovery.build('healthcare', 'v1beta1')
 
 # The resource name of the FHIR store to delete.
 name = 'projects/my-project/locations/my-location/datasets/my-dataset/fhirStores/my-fhir-store'  # TODO: Update placeholder value.
@@ -1276,20 +1206,18 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 from pprint import pprint
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('healthcare', 'v1beta1', credentials=credentials)
+service = discovery.build('healthcare', 'v1beta1')
 
 # The name of the FHIR store to export resource from. The name should be in
 # the format of
@@ -1314,20 +1242,18 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 from pprint import pprint
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('healthcare', 'v1beta1', credentials=credentials)
+service = discovery.build('healthcare', 'v1beta1')
 
 # Name of the FHIR store to retrieve resources from.
 parent = 'projects/my-project/locations/my-location/datasets/my-dataset/fhirStores/my-fhir-store'  # TODO: Update placeholder value.
@@ -1346,20 +1272,18 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 from pprint import pprint
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('healthcare', 'v1beta1', credentials=credentials)
+service = discovery.build('healthcare', 'v1beta1')
 
 # Name of the `Patient` resource for which the information is required.
 name = 'my-name'  # TODO: Update placeholder value.
@@ -1378,19 +1302,17 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('healthcare', 'v1beta1', credentials=credentials)
+service = discovery.build('healthcare', 'v1beta1')
 
 # The name of the resource to purge.
 name = 'my-name'  # TODO: Update placeholder value.
@@ -1406,20 +1328,18 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 from pprint import pprint
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('healthcare', 'v1beta1', credentials=credentials)
+service = discovery.build('healthcare', 'v1beta1')
 
 # Name of the FHIR store to retrieve the capabilities for.
 name = 'projects/my-project/locations/my-location/datasets/my-dataset/fhirStores/my-fhir-store'  # TODO: Update placeholder value.
@@ -1438,19 +1358,17 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('healthcare', 'v1beta1', credentials=credentials)
+service = discovery.build('healthcare', 'v1beta1')
 
 # The name of the FHIR store this resource belongs to.
 parent = 'projects/my-project/locations/my-location/datasets/my-dataset/fhirStores/my-fhir-store'  # TODO: Update placeholder value.
@@ -1469,20 +1387,18 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 from pprint import pprint
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('healthcare', 'v1beta1', credentials=credentials)
+service = discovery.build('healthcare', 'v1beta1')
 
 # The name of the FHIR store this resource belongs to.
 parent = 'projects/my-project/locations/my-location/datasets/my-dataset/fhirStores/my-fhir-store'  # TODO: Update placeholder value.
@@ -1509,20 +1425,18 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 from pprint import pprint
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('healthcare', 'v1beta1', credentials=credentials)
+service = discovery.build('healthcare', 'v1beta1')
 
 # The name of the FHIR store this resource belongs to.
 parent = 'projects/my-project/locations/my-location/datasets/my-dataset/fhirStores/my-fhir-store'  # TODO: Update placeholder value.
@@ -1549,20 +1463,18 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 from pprint import pprint
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('healthcare', 'v1beta1', credentials=credentials)
+service = discovery.build('healthcare', 'v1beta1')
 
 # The name of the FHIR store this resource belongs to.
 parent = 'projects/my-project/locations/my-location/datasets/my-dataset/fhirStores/my-fhir-store'  # TODO: Update placeholder value.
@@ -1588,20 +1500,18 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 from pprint import pprint
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('healthcare', 'v1beta1', credentials=credentials)
+service = discovery.build('healthcare', 'v1beta1')
 
 # The name of the resource to delete.
 name = 'my-name'  # TODO: Update placeholder value.
@@ -1620,20 +1530,18 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 from pprint import pprint
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('healthcare', 'v1beta1', credentials=credentials)
+service = discovery.build('healthcare', 'v1beta1')
 
 # Name of the FHIR store in which this bundle will be executed.
 parent = 'projects/my-project/locations/my-location/datasets/my-dataset/fhirStores/my-fhir-store'  # TODO: Update placeholder value.
@@ -1656,20 +1564,18 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 from pprint import pprint
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('healthcare', 'v1beta1', credentials=credentials)
+service = discovery.build('healthcare', 'v1beta1')
 
 # The name of the resource to retrieve.
 name = 'my-name'  # TODO: Update placeholder value.
@@ -1688,20 +1594,18 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 from pprint import pprint
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('healthcare', 'v1beta1', credentials=credentials)
+service = discovery.build('healthcare', 'v1beta1')
 
 # The name of the resource to update.
 name = 'my-name'  # TODO: Update placeholder value.
@@ -1725,20 +1629,18 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 from pprint import pprint
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('healthcare', 'v1beta1', credentials=credentials)
+service = discovery.build('healthcare', 'v1beta1')
 
 # The name of the resource to retrieve.
 name = 'my-name'  # TODO: Update placeholder value.
@@ -1757,20 +1659,18 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 from pprint import pprint
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('healthcare', 'v1beta1', credentials=credentials)
+service = discovery.build('healthcare', 'v1beta1')
 
 # Name of the FHIR store to retrieve resources from.
 parent = 'projects/my-project/locations/my-location/datasets/my-dataset/fhirStores/my-fhir-store'  # TODO: Update placeholder value.
@@ -1793,20 +1693,18 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 from pprint import pprint
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('healthcare', 'v1beta1', credentials=credentials)
+service = discovery.build('healthcare', 'v1beta1')
 
 # The name of the resource to update.
 name = 'my-name'  # TODO: Update placeholder value.
@@ -1830,20 +1728,18 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 from pprint import pprint
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('healthcare', 'v1beta1', credentials=credentials)
+service = discovery.build('healthcare', 'v1beta1')
 
 # The name of the resource version to retrieve.
 name = 'my-name'  # TODO: Update placeholder value.
@@ -1862,20 +1758,18 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 from pprint import pprint
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('healthcare', 'v1beta1', credentials=credentials)
+service = discovery.build('healthcare', 'v1beta1')
 
 # The resource name of the FHIR store to get.
 name = 'projects/my-project/locations/my-location/datasets/my-dataset/fhirStores/my-fhir-store'  # TODO: Update placeholder value.
@@ -1894,20 +1788,18 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 from pprint import pprint
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('healthcare', 'v1beta1', credentials=credentials)
+service = discovery.build('healthcare', 'v1beta1')
 
 # REQUIRED: The resource for which the policy is being requested.
 # See the operation documentation for the appropriate value for this field.
@@ -1927,20 +1819,18 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 from pprint import pprint
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('healthcare', 'v1beta1', credentials=credentials)
+service = discovery.build('healthcare', 'v1beta1')
 
 # The name of the FHIR store to import FHIR resources to. The name should be
 # in the format of
@@ -1965,20 +1855,18 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 from pprint import pprint
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('healthcare', 'v1beta1', credentials=credentials)
+service = discovery.build('healthcare', 'v1beta1')
 
 # Name of the dataset.
 parent = 'projects/my-project/locations/my-location/datasets/my-dataset'  # TODO: Update placeholder value.
@@ -2003,20 +1891,18 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 from pprint import pprint
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('healthcare', 'v1beta1', credentials=credentials)
+service = discovery.build('healthcare', 'v1beta1')
 
 # Output only. Resource name of the FHIR store, of the form
 # `projects/{project_id}/datasets/{dataset_id}/fhirStores/{fhir_store_id}`.
@@ -2041,20 +1927,18 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 from pprint import pprint
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('healthcare', 'v1beta1', credentials=credentials)
+service = discovery.build('healthcare', 'v1beta1')
 
 # REQUIRED: The resource for which the policy is being specified.
 # See the operation documentation for the appropriate value for this field.
@@ -2078,20 +1962,18 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 from pprint import pprint
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('healthcare', 'v1beta1', credentials=credentials)
+service = discovery.build('healthcare', 'v1beta1')
 
 # REQUIRED: The resource for which the policy detail is being requested.
 # See the operation documentation for the appropriate value for this field.
@@ -2115,20 +1997,18 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 from pprint import pprint
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('healthcare', 'v1beta1', credentials=credentials)
+service = discovery.build('healthcare', 'v1beta1')
 
 # The name of the dataset to read (e.g.,
 # `projects/{project_id}/locations/{location_id}/datasets/{dataset_id}`).
@@ -2148,20 +2028,18 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 from pprint import pprint
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('healthcare', 'v1beta1', credentials=credentials)
+service = discovery.build('healthcare', 'v1beta1')
 
 # REQUIRED: The resource for which the policy is being requested.
 # See the operation documentation for the appropriate value for this field.
@@ -2181,20 +2059,18 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 from pprint import pprint
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('healthcare', 'v1beta1', credentials=credentials)
+service = discovery.build('healthcare', 'v1beta1')
 
 # The name of the dataset this HL7v2 store belongs to.
 parent = 'projects/my-project/locations/my-location/datasets/my-dataset'  # TODO: Update placeholder value.
@@ -2217,19 +2093,17 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('healthcare', 'v1beta1', credentials=credentials)
+service = discovery.build('healthcare', 'v1beta1')
 
 # The resource name of the HL7v2 store to delete.
 name = 'my-name'  # TODO: Update placeholder value.
@@ -2245,20 +2119,18 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 from pprint import pprint
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('healthcare', 'v1beta1', credentials=credentials)
+service = discovery.build('healthcare', 'v1beta1')
 
 # The resource name of the HL7v2 store to get.
 name = 'my-name'  # TODO: Update placeholder value.
@@ -2277,20 +2149,18 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 from pprint import pprint
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('healthcare', 'v1beta1', credentials=credentials)
+service = discovery.build('healthcare', 'v1beta1')
 
 # REQUIRED: The resource for which the policy is being requested.
 # See the operation documentation for the appropriate value for this field.
@@ -2310,20 +2180,18 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 from pprint import pprint
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('healthcare', 'v1beta1', credentials=credentials)
+service = discovery.build('healthcare', 'v1beta1')
 
 # Name of the dataset.
 parent = 'projects/my-project/locations/my-location/datasets/my-dataset'  # TODO: Update placeholder value.
@@ -2348,20 +2216,18 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 from pprint import pprint
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('healthcare', 'v1beta1', credentials=credentials)
+service = discovery.build('healthcare', 'v1beta1')
 
 # The name of the dataset this message belongs to.
 parent = 'my-parent'  # TODO: Update placeholder value.
@@ -2384,19 +2250,17 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('healthcare', 'v1beta1', credentials=credentials)
+service = discovery.build('healthcare', 'v1beta1')
 
 # The resource name of the HL7v2 message to delete.
 name = 'my-name'  # TODO: Update placeholder value.
@@ -2412,20 +2276,18 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 from pprint import pprint
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('healthcare', 'v1beta1', credentials=credentials)
+service = discovery.build('healthcare', 'v1beta1')
 
 # The resource name of the HL7v2 message to retrieve.
 name = 'my-name'  # TODO: Update placeholder value.
@@ -2444,20 +2306,18 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 from pprint import pprint
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('healthcare', 'v1beta1', credentials=credentials)
+service = discovery.build('healthcare', 'v1beta1')
 
 # The name of the HL7v2 store this message belongs to.
 parent = 'my-parent'  # TODO: Update placeholder value.
@@ -2480,20 +2340,18 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 from pprint import pprint
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('healthcare', 'v1beta1', credentials=credentials)
+service = discovery.build('healthcare', 'v1beta1')
 
 # Name of the HL7v2 store to retrieve messages from.
 parent = 'my-parent'  # TODO: Update placeholder value.
@@ -2518,20 +2376,18 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 from pprint import pprint
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('healthcare', 'v1beta1', credentials=credentials)
+service = discovery.build('healthcare', 'v1beta1')
 
 # Resource name of the Message, of the form
 # `projects/{project_id}/datasets/{dataset_id}/hl7V2Stores/{hl7_v2_store_id}/messages/{message_id}`.
@@ -2557,20 +2413,18 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 from pprint import pprint
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('healthcare', 'v1beta1', credentials=credentials)
+service = discovery.build('healthcare', 'v1beta1')
 
 # Output only. Resource name of the HL7v2 store, of the form
 # `projects/{project_id}/datasets/{dataset_id}/hl7V2Stores/{hl7v2_store_id}`.
@@ -2595,20 +2449,18 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 from pprint import pprint
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('healthcare', 'v1beta1', credentials=credentials)
+service = discovery.build('healthcare', 'v1beta1')
 
 # REQUIRED: The resource for which the policy is being specified.
 # See the operation documentation for the appropriate value for this field.
@@ -2632,20 +2484,18 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 from pprint import pprint
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('healthcare', 'v1beta1', credentials=credentials)
+service = discovery.build('healthcare', 'v1beta1')
 
 # REQUIRED: The resource for which the policy detail is being requested.
 # See the operation documentation for the appropriate value for this field.
@@ -2669,20 +2519,18 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 from pprint import pprint
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('healthcare', 'v1beta1', credentials=credentials)
+service = discovery.build('healthcare', 'v1beta1')
 
 # The name of the project whose datasets should be listed (e.g.,
 # `projects/{project_id}/locations/{location_id}`).
@@ -2708,20 +2556,18 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 from pprint import pprint
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('healthcare', 'v1beta1', credentials=credentials)
+service = discovery.build('healthcare', 'v1beta1')
 
 # The name of the operation resource.
 name = 'projects/my-project/locations/my-location/datasets/my-dataset/operations/my-operation'  # TODO: Update placeholder value.
@@ -2740,20 +2586,18 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 from pprint import pprint
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('healthcare', 'v1beta1', credentials=credentials)
+service = discovery.build('healthcare', 'v1beta1')
 
 # The name of the operation's parent resource.
 name = 'projects/my-project/locations/my-location/datasets/my-dataset'  # TODO: Update placeholder value.
@@ -2778,20 +2622,18 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 from pprint import pprint
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('healthcare', 'v1beta1', credentials=credentials)
+service = discovery.build('healthcare', 'v1beta1')
 
 # Output only. Resource name of the dataset, of the form
 # `projects/{project_id}/locations/{location_id}/datasets/{dataset_id}`.
@@ -2816,20 +2658,18 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 from pprint import pprint
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('healthcare', 'v1beta1', credentials=credentials)
+service = discovery.build('healthcare', 'v1beta1')
 
 # REQUIRED: The resource for which the policy is being specified.
 # See the operation documentation for the appropriate value for this field.
@@ -2853,20 +2693,18 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 from pprint import pprint
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('healthcare', 'v1beta1', credentials=credentials)
+service = discovery.build('healthcare', 'v1beta1')
 
 # REQUIRED: The resource for which the policy detail is being requested.
 # See the operation documentation for the appropriate value for this field.
@@ -2890,20 +2728,18 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 from pprint import pprint
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('healthcare', 'v1beta1', credentials=credentials)
+service = discovery.build('healthcare', 'v1beta1')
 
 # Resource name for the location.
 name = 'projects/my-project/locations/my-location'  # TODO: Update placeholder value.
@@ -2922,20 +2758,18 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 from pprint import pprint
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('healthcare', 'v1beta1', credentials=credentials)
+service = discovery.build('healthcare', 'v1beta1')
 
 # The resource that owns the locations collection, if applicable.
 name = 'projects/my-project'  # TODO: Update placeholder value.

--- a/toolkit/src/test/java/com/google/api/codegen/testdata/discoveries/py/py_logging.v2beta1.json.baseline
+++ b/toolkit/src/test/java/com/google/api/codegen/testdata/discoveries/py/py_logging.v2beta1.json.baseline
@@ -8,19 +8,17 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('logging', 'v2beta1', credentials=credentials)
+service = discovery.build('logging', 'v2beta1')
 
 # Required. The resource name of the log to delete:
 # "projects/[PROJECT_ID]/logs/[LOG_ID]"
@@ -41,20 +39,18 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 from pprint import pprint
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('logging', 'v2beta1', credentials=credentials)
+service = discovery.build('logging', 'v2beta1')
 
 # Required. The resource name that owns the logs:
 # "projects/[PROJECT_ID]"
@@ -81,20 +77,18 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 from pprint import pprint
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('logging', 'v2beta1', credentials=credentials)
+service = discovery.build('logging', 'v2beta1')
 
 list_log_entries_request_body = {
     # TODO: Add desired entries to the request body.
@@ -120,20 +114,18 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 from pprint import pprint
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('logging', 'v2beta1', credentials=credentials)
+service = discovery.build('logging', 'v2beta1')
 
 write_log_entries_request_body = {
     # TODO: Add desired entries to the request body.
@@ -153,20 +145,18 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 from pprint import pprint
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('logging', 'v2beta1', credentials=credentials)
+service = discovery.build('logging', 'v2beta1')
 
 request = service.monitoredResourceDescriptors().list()
 while True:
@@ -188,19 +178,17 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('logging', 'v2beta1', credentials=credentials)
+service = discovery.build('logging', 'v2beta1')
 
 # Required. The resource name of the log to delete:
 # "projects/[PROJECT_ID]/logs/[LOG_ID]"
@@ -221,20 +209,18 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 from pprint import pprint
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('logging', 'v2beta1', credentials=credentials)
+service = discovery.build('logging', 'v2beta1')
 
 # Required. The resource name that owns the logs:
 # "projects/[PROJECT_ID]"
@@ -261,19 +247,17 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('logging', 'v2beta1', credentials=credentials)
+service = discovery.build('logging', 'v2beta1')
 
 # Required. The resource name of the log to delete:
 # "projects/[PROJECT_ID]/logs/[LOG_ID]"
@@ -294,20 +278,18 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 from pprint import pprint
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('logging', 'v2beta1', credentials=credentials)
+service = discovery.build('logging', 'v2beta1')
 
 # Required. The resource name that owns the logs:
 # "projects/[PROJECT_ID]"
@@ -334,20 +316,18 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 from pprint import pprint
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('logging', 'v2beta1', credentials=credentials)
+service = discovery.build('logging', 'v2beta1')
 
 # The resource name of the project in which to create the metric:
 # "projects/[PROJECT_ID]"
@@ -372,19 +352,17 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('logging', 'v2beta1', credentials=credentials)
+service = discovery.build('logging', 'v2beta1')
 
 # The resource name of the metric to delete:
 # "projects/[PROJECT_ID]/metrics/[METRIC_ID]"
@@ -401,20 +379,18 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 from pprint import pprint
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('logging', 'v2beta1', credentials=credentials)
+service = discovery.build('logging', 'v2beta1')
 
 # The resource name of the desired metric:
 # "projects/[PROJECT_ID]/metrics/[METRIC_ID]"
@@ -434,20 +410,18 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 from pprint import pprint
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('logging', 'v2beta1', credentials=credentials)
+service = discovery.build('logging', 'v2beta1')
 
 # Required. The name of the project containing the metrics:
 # "projects/[PROJECT_ID]"
@@ -473,20 +447,18 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 from pprint import pprint
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('logging', 'v2beta1', credentials=credentials)
+service = discovery.build('logging', 'v2beta1')
 
 # The resource name of the metric to update:
 # "projects/[PROJECT_ID]/metrics/[METRIC_ID]"
@@ -513,20 +485,18 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 from pprint import pprint
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('logging', 'v2beta1', credentials=credentials)
+service = discovery.build('logging', 'v2beta1')
 
 # Required. The resource in which to create the sink:
 # "projects/[PROJECT_ID]"
@@ -552,19 +522,17 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('logging', 'v2beta1', credentials=credentials)
+service = discovery.build('logging', 'v2beta1')
 
 # Required. The full resource name of the sink to delete, including the parent resource and the sink
 # identifier:
@@ -585,20 +553,18 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 from pprint import pprint
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('logging', 'v2beta1', credentials=credentials)
+service = discovery.build('logging', 'v2beta1')
 
 # Required. The parent resource name of the sink:
 # "projects/[PROJECT_ID]/sinks/[SINK_ID]"
@@ -620,20 +586,18 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 from pprint import pprint
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('logging', 'v2beta1', credentials=credentials)
+service = discovery.build('logging', 'v2beta1')
 
 # Required. The parent resource whose sinks are to be listed. Examples:
 # "projects/my-logging-project", "organizations/123456789".
@@ -659,20 +623,18 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 from pprint import pprint
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('logging', 'v2beta1', credentials=credentials)
+service = discovery.build('logging', 'v2beta1')
 
 # Required. The full resource name of the sink to update, including the parent resource and the sink
 # identifier:

--- a/toolkit/src/test/java/com/google/api/codegen/testdata/discoveries/py/py_prediction.v1.6.json.baseline
+++ b/toolkit/src/test/java/com/google/api/codegen/testdata/discoveries/py/py_prediction.v1.6.json.baseline
@@ -8,20 +8,18 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 from pprint import pprint
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('prediction', 'v1.6', credentials=credentials)
+service = discovery.build('prediction', 'v1.6')
 
 # The project associated with the model.
 project = 'my-project'  # TODO: Update placeholder value.
@@ -47,20 +45,18 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 from pprint import pprint
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('prediction', 'v1.6', credentials=credentials)
+service = discovery.build('prediction', 'v1.6')
 
 # The project associated with the model.
 project = 'my-project'  # TODO: Update placeholder value.
@@ -82,19 +78,17 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('prediction', 'v1.6', credentials=credentials)
+service = discovery.build('prediction', 'v1.6')
 
 # The project associated with the model.
 project = 'my-project'  # TODO: Update placeholder value.
@@ -113,20 +107,18 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 from pprint import pprint
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('prediction', 'v1.6', credentials=credentials)
+service = discovery.build('prediction', 'v1.6')
 
 # The project associated with the model.
 project = 'my-project'  # TODO: Update placeholder value.
@@ -148,20 +140,18 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 from pprint import pprint
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('prediction', 'v1.6', credentials=credentials)
+service = discovery.build('prediction', 'v1.6')
 
 # The project associated with the model.
 project = 'my-project'  # TODO: Update placeholder value.
@@ -184,20 +174,18 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 from pprint import pprint
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('prediction', 'v1.6', credentials=credentials)
+service = discovery.build('prediction', 'v1.6')
 
 # The project associated with the model.
 project = 'my-project'  # TODO: Update placeholder value.
@@ -222,20 +210,18 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 from pprint import pprint
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('prediction', 'v1.6', credentials=credentials)
+service = discovery.build('prediction', 'v1.6')
 
 # The project associated with the model.
 project = 'my-project'  # TODO: Update placeholder value.
@@ -261,20 +247,18 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 from pprint import pprint
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('prediction', 'v1.6', credentials=credentials)
+service = discovery.build('prediction', 'v1.6')
 
 # The project associated with the model.
 project = 'my-project'  # TODO: Update placeholder value.

--- a/toolkit/src/test/java/com/google/api/codegen/testdata/discoveries/py/py_pubsub.v1.json.baseline
+++ b/toolkit/src/test/java/com/google/api/codegen/testdata/discoveries/py/py_pubsub.v1.json.baseline
@@ -8,20 +8,18 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 from pprint import pprint
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('pubsub', 'v1', credentials=credentials)
+service = discovery.build('pubsub', 'v1')
 
 # REQUIRED: The resource for which the policy is being requested.
 # `resource` is usually specified as a path. For example, a Project
@@ -42,20 +40,18 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 from pprint import pprint
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('pubsub', 'v1', credentials=credentials)
+service = discovery.build('pubsub', 'v1')
 
 # REQUIRED: The resource for which the policy is being specified.
 # `resource` is usually specified as a path. For example, a Project
@@ -80,20 +76,18 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 from pprint import pprint
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('pubsub', 'v1', credentials=credentials)
+service = discovery.build('pubsub', 'v1')
 
 # REQUIRED: The resource for which the policy detail is being requested.
 # `resource` is usually specified as a path. For example, a Project
@@ -118,19 +112,17 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('pubsub', 'v1', credentials=credentials)
+service = discovery.build('pubsub', 'v1')
 
 # The subscription whose message is being acknowledged.
 # Format is `projects/{project}/subscriptions/{sub}`.
@@ -151,20 +143,18 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 from pprint import pprint
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('pubsub', 'v1', credentials=credentials)
+service = discovery.build('pubsub', 'v1')
 
 # The name of the subscription. It must have the format
 # `"projects/{project}/subscriptions/{subscription}"`. `{subscription}` must
@@ -193,19 +183,17 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('pubsub', 'v1', credentials=credentials)
+service = discovery.build('pubsub', 'v1')
 
 # The subscription to delete.
 # Format is `projects/{project}/subscriptions/{sub}`.
@@ -222,20 +210,18 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 from pprint import pprint
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('pubsub', 'v1', credentials=credentials)
+service = discovery.build('pubsub', 'v1')
 
 # The name of the subscription to get.
 # Format is `projects/{project}/subscriptions/{sub}`.
@@ -255,20 +241,18 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 from pprint import pprint
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('pubsub', 'v1', credentials=credentials)
+service = discovery.build('pubsub', 'v1')
 
 # REQUIRED: The resource for which the policy is being requested.
 # `resource` is usually specified as a path. For example, a Project
@@ -289,20 +273,18 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 from pprint import pprint
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('pubsub', 'v1', credentials=credentials)
+service = discovery.build('pubsub', 'v1')
 
 # The name of the cloud project that subscriptions belong to.
 # Format is `projects/{project}`.
@@ -328,19 +310,17 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('pubsub', 'v1', credentials=credentials)
+service = discovery.build('pubsub', 'v1')
 
 # The name of the subscription.
 # Format is `projects/{project}/subscriptions/{sub}`.
@@ -361,19 +341,17 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('pubsub', 'v1', credentials=credentials)
+service = discovery.build('pubsub', 'v1')
 
 # The name of the subscription.
 # Format is `projects/{project}/subscriptions/{sub}`.
@@ -394,20 +372,18 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 from pprint import pprint
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('pubsub', 'v1', credentials=credentials)
+service = discovery.build('pubsub', 'v1')
 
 # The subscription from which messages should be pulled.
 # Format is `projects/{project}/subscriptions/{sub}`.
@@ -431,20 +407,18 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 from pprint import pprint
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('pubsub', 'v1', credentials=credentials)
+service = discovery.build('pubsub', 'v1')
 
 # REQUIRED: The resource for which the policy is being specified.
 # `resource` is usually specified as a path. For example, a Project
@@ -469,20 +443,18 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 from pprint import pprint
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('pubsub', 'v1', credentials=credentials)
+service = discovery.build('pubsub', 'v1')
 
 # REQUIRED: The resource for which the policy detail is being requested.
 # `resource` is usually specified as a path. For example, a Project
@@ -507,20 +479,18 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 from pprint import pprint
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('pubsub', 'v1', credentials=credentials)
+service = discovery.build('pubsub', 'v1')
 
 # The name of the topic. It must have the format
 # `"projects/{project}/topics/{topic}"`. `{topic}` must start with a letter,
@@ -549,19 +519,17 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('pubsub', 'v1', credentials=credentials)
+service = discovery.build('pubsub', 'v1')
 
 # Name of the topic to delete.
 # Format is `projects/{project}/topics/{topic}`.
@@ -578,20 +546,18 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 from pprint import pprint
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('pubsub', 'v1', credentials=credentials)
+service = discovery.build('pubsub', 'v1')
 
 # The name of the topic to get.
 # Format is `projects/{project}/topics/{topic}`.
@@ -611,20 +577,18 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 from pprint import pprint
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('pubsub', 'v1', credentials=credentials)
+service = discovery.build('pubsub', 'v1')
 
 # REQUIRED: The resource for which the policy is being requested.
 # `resource` is usually specified as a path. For example, a Project
@@ -645,20 +609,18 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 from pprint import pprint
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('pubsub', 'v1', credentials=credentials)
+service = discovery.build('pubsub', 'v1')
 
 # The name of the cloud project that topics belong to.
 # Format is `projects/{project}`.
@@ -684,20 +646,18 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 from pprint import pprint
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('pubsub', 'v1', credentials=credentials)
+service = discovery.build('pubsub', 'v1')
 
 # The messages in the request will be published on this topic.
 # Format is `projects/{project}/topics/{topic}`.
@@ -721,20 +681,18 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 from pprint import pprint
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('pubsub', 'v1', credentials=credentials)
+service = discovery.build('pubsub', 'v1')
 
 # REQUIRED: The resource for which the policy is being specified.
 # `resource` is usually specified as a path. For example, a Project
@@ -759,20 +717,18 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 from pprint import pprint
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('pubsub', 'v1', credentials=credentials)
+service = discovery.build('pubsub', 'v1')
 
 # The name of the topic that subscriptions are attached to.
 # Format is `projects/{project}/topics/{topic}`.
@@ -798,20 +754,18 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 from pprint import pprint
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('pubsub', 'v1', credentials=credentials)
+service = discovery.build('pubsub', 'v1')
 
 # REQUIRED: The resource for which the policy detail is being requested.
 # `resource` is usually specified as a path. For example, a Project

--- a/toolkit/src/test/java/com/google/api/codegen/testdata/discoveries/py/py_replicapoolupdater.v1beta1.json.baseline
+++ b/toolkit/src/test/java/com/google/api/codegen/testdata/discoveries/py/py_replicapoolupdater.v1beta1.json.baseline
@@ -8,20 +8,18 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 from pprint import pprint
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('replicapoolupdater', 'v1beta1', credentials=credentials)
+service = discovery.build('replicapoolupdater', 'v1beta1')
 
 # The Google Developers Console project name.
 project = 'my-project'  # TODO: Update placeholder value.
@@ -46,20 +44,18 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 from pprint import pprint
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('replicapoolupdater', 'v1beta1', credentials=credentials)
+service = discovery.build('replicapoolupdater', 'v1beta1')
 
 # The Google Developers Console project name.
 project = 'my-project'  # TODO: Update placeholder value.
@@ -84,20 +80,18 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 from pprint import pprint
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('replicapoolupdater', 'v1beta1', credentials=credentials)
+service = discovery.build('replicapoolupdater', 'v1beta1')
 
 # The Google Developers Console project name.
 project = 'my-project'  # TODO: Update placeholder value.
@@ -123,20 +117,18 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 from pprint import pprint
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('replicapoolupdater', 'v1beta1', credentials=credentials)
+service = discovery.build('replicapoolupdater', 'v1beta1')
 
 # The Google Developers Console project name.
 project = 'my-project'  # TODO: Update placeholder value.
@@ -164,20 +156,18 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 from pprint import pprint
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('replicapoolupdater', 'v1beta1', credentials=credentials)
+service = discovery.build('replicapoolupdater', 'v1beta1')
 
 # The Google Developers Console project name.
 project = 'my-project'  # TODO: Update placeholder value.
@@ -208,20 +198,18 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 from pprint import pprint
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('replicapoolupdater', 'v1beta1', credentials=credentials)
+service = discovery.build('replicapoolupdater', 'v1beta1')
 
 # The Google Developers Console project name.
 project = 'my-project'  # TODO: Update placeholder value.
@@ -246,20 +234,18 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 from pprint import pprint
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('replicapoolupdater', 'v1beta1', credentials=credentials)
+service = discovery.build('replicapoolupdater', 'v1beta1')
 
 # The Google Developers Console project name.
 project = 'my-project'  # TODO: Update placeholder value.
@@ -284,20 +270,18 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 from pprint import pprint
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('replicapoolupdater', 'v1beta1', credentials=credentials)
+service = discovery.build('replicapoolupdater', 'v1beta1')
 
 # The Google Developers Console project name.
 project = 'my-project'  # TODO: Update placeholder value.
@@ -322,20 +306,18 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 from pprint import pprint
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('replicapoolupdater', 'v1beta1', credentials=credentials)
+service = discovery.build('replicapoolupdater', 'v1beta1')
 
 # Name of the project scoping this request.
 project = 'my-project'  # TODO: Update placeholder value.
@@ -360,20 +342,18 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 from pprint import pprint
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('replicapoolupdater', 'v1beta1', credentials=credentials)
+service = discovery.build('replicapoolupdater', 'v1beta1')
 
 # Name of the project scoping this request.
 project = 'my-project'  # TODO: Update placeholder value.

--- a/toolkit/src/test/java/com/google/api/codegen/testdata/discoveries/py/py_sqladmin.v1beta4.json.baseline
+++ b/toolkit/src/test/java/com/google/api/codegen/testdata/discoveries/py/py_sqladmin.v1beta4.json.baseline
@@ -8,20 +8,18 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 from pprint import pprint
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('sqladmin', 'v1beta4', credentials=credentials)
+service = discovery.build('sqladmin', 'v1beta4')
 
 # Project ID of the project that contains the instance.
 project = 'my-project'  # TODO: Update placeholder value.
@@ -46,20 +44,18 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 from pprint import pprint
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('sqladmin', 'v1beta4', credentials=credentials)
+service = discovery.build('sqladmin', 'v1beta4')
 
 # Project ID of the project that contains the instance.
 project = 'my-project'  # TODO: Update placeholder value.
@@ -84,20 +80,18 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 from pprint import pprint
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('sqladmin', 'v1beta4', credentials=credentials)
+service = discovery.build('sqladmin', 'v1beta4')
 
 # Project ID of the project that contains the instance.
 project = 'my-project'  # TODO: Update placeholder value.
@@ -123,20 +117,18 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 from pprint import pprint
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('sqladmin', 'v1beta4', credentials=credentials)
+service = discovery.build('sqladmin', 'v1beta4')
 
 # Project ID of the project that contains the instance.
 project = 'my-project'  # TODO: Update placeholder value.
@@ -164,20 +156,18 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 from pprint import pprint
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('sqladmin', 'v1beta4', credentials=credentials)
+service = discovery.build('sqladmin', 'v1beta4')
 
 # Project ID of the project that contains the instance.
 project = 'my-project'  # TODO: Update placeholder value.
@@ -202,20 +192,18 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 from pprint import pprint
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('sqladmin', 'v1beta4', credentials=credentials)
+service = discovery.build('sqladmin', 'v1beta4')
 
 # Project ID of the project that contains the instance.
 project = 'my-project'  # TODO: Update placeholder value.
@@ -240,20 +228,18 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 from pprint import pprint
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('sqladmin', 'v1beta4', credentials=credentials)
+service = discovery.build('sqladmin', 'v1beta4')
 
 # Project ID of the project that contains the instance.
 project = 'my-project'  # TODO: Update placeholder value.
@@ -279,20 +265,18 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 from pprint import pprint
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('sqladmin', 'v1beta4', credentials=credentials)
+service = discovery.build('sqladmin', 'v1beta4')
 
 # Project ID of the project for which to list Cloud SQL instances.
 project = 'my-project'  # TODO: Update placeholder value.
@@ -314,20 +298,18 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 from pprint import pprint
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('sqladmin', 'v1beta4', credentials=credentials)
+service = discovery.build('sqladmin', 'v1beta4')
 
 # Project ID of the project that contains the instance.
 project = 'my-project'  # TODO: Update placeholder value.
@@ -357,20 +339,18 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 from pprint import pprint
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('sqladmin', 'v1beta4', credentials=credentials)
+service = discovery.build('sqladmin', 'v1beta4')
 
 # Project ID of the project that contains the instance.
 project = 'my-project'  # TODO: Update placeholder value.
@@ -400,20 +380,18 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 from pprint import pprint
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('sqladmin', 'v1beta4', credentials=credentials)
+service = discovery.build('sqladmin', 'v1beta4')
 
 request = service.flags().list()
 response = request.execute()
@@ -429,20 +407,18 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 from pprint import pprint
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('sqladmin', 'v1beta4', credentials=credentials)
+service = discovery.build('sqladmin', 'v1beta4')
 
 # Project ID of the source as well as the clone Cloud SQL instance.
 project = 'my-project'  # TODO: Update placeholder value.
@@ -468,20 +444,18 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 from pprint import pprint
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('sqladmin', 'v1beta4', credentials=credentials)
+service = discovery.build('sqladmin', 'v1beta4')
 
 # Project ID of the project that contains the instance to be deleted.
 project = 'my-project'  # TODO: Update placeholder value.
@@ -503,20 +477,18 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 from pprint import pprint
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('sqladmin', 'v1beta4', credentials=credentials)
+service = discovery.build('sqladmin', 'v1beta4')
 
 # Project ID of the project that contains the instance to be exported.
 project = 'my-project'  # TODO: Update placeholder value.
@@ -542,20 +514,18 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 from pprint import pprint
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('sqladmin', 'v1beta4', credentials=credentials)
+service = discovery.build('sqladmin', 'v1beta4')
 
 # ID of the project that contains the read replica.
 project = 'my-project'  # TODO: Update placeholder value.
@@ -581,20 +551,18 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 from pprint import pprint
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('sqladmin', 'v1beta4', credentials=credentials)
+service = discovery.build('sqladmin', 'v1beta4')
 
 # Project ID of the project that contains the instance.
 project = 'my-project'  # TODO: Update placeholder value.
@@ -616,20 +584,18 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 from pprint import pprint
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('sqladmin', 'v1beta4', credentials=credentials)
+service = discovery.build('sqladmin', 'v1beta4')
 
 # Project ID of the project that contains the instance.
 project = 'my-project'  # TODO: Update placeholder value.
@@ -655,20 +621,18 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 from pprint import pprint
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('sqladmin', 'v1beta4', credentials=credentials)
+service = discovery.build('sqladmin', 'v1beta4')
 
 # Project ID of the project to which the newly created Cloud SQL instances should belong.
 project = 'my-project'  # TODO: Update placeholder value.
@@ -691,20 +655,18 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 from pprint import pprint
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('sqladmin', 'v1beta4', credentials=credentials)
+service = discovery.build('sqladmin', 'v1beta4')
 
 # Project ID of the project for which to list Cloud SQL instances.
 project = 'my-project'  # TODO: Update placeholder value.
@@ -729,20 +691,18 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 from pprint import pprint
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('sqladmin', 'v1beta4', credentials=credentials)
+service = discovery.build('sqladmin', 'v1beta4')
 
 # Project ID of the project that contains the instance.
 project = 'my-project'  # TODO: Update placeholder value.
@@ -769,20 +729,18 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 from pprint import pprint
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('sqladmin', 'v1beta4', credentials=credentials)
+service = discovery.build('sqladmin', 'v1beta4')
 
 # ID of the project that contains the read replica.
 project = 'my-project'  # TODO: Update placeholder value.
@@ -804,20 +762,18 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 from pprint import pprint
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('sqladmin', 'v1beta4', credentials=credentials)
+service = discovery.build('sqladmin', 'v1beta4')
 
 # Project ID of the project that contains the instance.
 project = 'my-project'  # TODO: Update placeholder value.
@@ -839,20 +795,18 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 from pprint import pprint
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('sqladmin', 'v1beta4', credentials=credentials)
+service = discovery.build('sqladmin', 'v1beta4')
 
 # Project ID of the project that contains the instance to be restarted.
 project = 'my-project'  # TODO: Update placeholder value.
@@ -874,20 +828,18 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 from pprint import pprint
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('sqladmin', 'v1beta4', credentials=credentials)
+service = discovery.build('sqladmin', 'v1beta4')
 
 # Project ID of the project that contains the instance.
 project = 'my-project'  # TODO: Update placeholder value.
@@ -913,20 +865,18 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 from pprint import pprint
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('sqladmin', 'v1beta4', credentials=credentials)
+service = discovery.build('sqladmin', 'v1beta4')
 
 # ID of the project that contains the read replica.
 project = 'my-project'  # TODO: Update placeholder value.
@@ -948,20 +898,18 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 from pprint import pprint
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('sqladmin', 'v1beta4', credentials=credentials)
+service = discovery.build('sqladmin', 'v1beta4')
 
 # ID of the project that contains the read replica.
 project = 'my-project'  # TODO: Update placeholder value.
@@ -983,20 +931,18 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 from pprint import pprint
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('sqladmin', 'v1beta4', credentials=credentials)
+service = discovery.build('sqladmin', 'v1beta4')
 
 # Project ID of the Cloud SQL project.
 project = 'my-project'  # TODO: Update placeholder value.
@@ -1022,20 +968,18 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 from pprint import pprint
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('sqladmin', 'v1beta4', credentials=credentials)
+service = discovery.build('sqladmin', 'v1beta4')
 
 # Project ID of the project that contains the instance.
 project = 'my-project'  # TODO: Update placeholder value.
@@ -1062,20 +1006,18 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 from pprint import pprint
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('sqladmin', 'v1beta4', credentials=credentials)
+service = discovery.build('sqladmin', 'v1beta4')
 
 # Project ID of the project that contains the instance.
 project = 'my-project'  # TODO: Update placeholder value.
@@ -1097,20 +1039,18 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 from pprint import pprint
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('sqladmin', 'v1beta4', credentials=credentials)
+service = discovery.build('sqladmin', 'v1beta4')
 
 # Project ID of the project that contains the instance.
 project = 'my-project'  # TODO: Update placeholder value.
@@ -1138,20 +1078,18 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 from pprint import pprint
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('sqladmin', 'v1beta4', credentials=credentials)
+service = discovery.build('sqladmin', 'v1beta4')
 
 # Project ID of the Cloud SQL project.
 project = 'my-project'  # TODO: Update placeholder value.
@@ -1177,20 +1115,18 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 from pprint import pprint
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('sqladmin', 'v1beta4', credentials=credentials)
+service = discovery.build('sqladmin', 'v1beta4')
 
 # Project ID of the project that contains the instance to be deleted.
 project = 'my-project'  # TODO: Update placeholder value.
@@ -1215,20 +1151,18 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 from pprint import pprint
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('sqladmin', 'v1beta4', credentials=credentials)
+service = discovery.build('sqladmin', 'v1beta4')
 
 # Project ID of the project that contains the instance.
 project = 'my-project'  # TODO: Update placeholder value.
@@ -1253,20 +1187,18 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 from pprint import pprint
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('sqladmin', 'v1beta4', credentials=credentials)
+service = discovery.build('sqladmin', 'v1beta4')
 
 # Project ID of the project to which the newly created Cloud SQL instances should belong.
 project = 'my-project'  # TODO: Update placeholder value.
@@ -1292,20 +1224,18 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 from pprint import pprint
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('sqladmin', 'v1beta4', credentials=credentials)
+service = discovery.build('sqladmin', 'v1beta4')
 
 # Project ID of the project for which to list Cloud SQL instances.
 project = 'my-project'  # TODO: Update placeholder value.
@@ -1327,20 +1257,18 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 from pprint import pprint
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('sqladmin', 'v1beta4', credentials=credentials)
+service = discovery.build('sqladmin', 'v1beta4')
 
 # Project ID of the project for which to list tiers.
 project = 'my-project'  # TODO: Update placeholder value.
@@ -1359,20 +1287,18 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 from pprint import pprint
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('sqladmin', 'v1beta4', credentials=credentials)
+service = discovery.build('sqladmin', 'v1beta4')
 
 # Project ID of the project that contains the instance.
 project = 'my-project'  # TODO: Update placeholder value.
@@ -1400,20 +1326,18 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 from pprint import pprint
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('sqladmin', 'v1beta4', credentials=credentials)
+service = discovery.build('sqladmin', 'v1beta4')
 
 # Project ID of the project that contains the instance.
 project = 'my-project'  # TODO: Update placeholder value.
@@ -1439,20 +1363,18 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 from pprint import pprint
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('sqladmin', 'v1beta4', credentials=credentials)
+service = discovery.build('sqladmin', 'v1beta4')
 
 # Project ID of the project that contains the instance.
 project = 'my-project'  # TODO: Update placeholder value.
@@ -1474,20 +1396,18 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 from pprint import pprint
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('sqladmin', 'v1beta4', credentials=credentials)
+service = discovery.build('sqladmin', 'v1beta4')
 
 # Project ID of the project that contains the instance.
 project = 'my-project'  # TODO: Update placeholder value.

--- a/toolkit/src/test/java/com/google/api/codegen/testdata/discoveries/py/py_storage.v1.json.baseline
+++ b/toolkit/src/test/java/com/google/api/codegen/testdata/discoveries/py/py_storage.v1.json.baseline
@@ -8,19 +8,17 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('storage', 'v1', credentials=credentials)
+service = discovery.build('storage', 'v1')
 
 # Name of a bucket.
 bucket = 'my-bucket'  # TODO: Update placeholder value.
@@ -40,20 +38,18 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 from pprint import pprint
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('storage', 'v1', credentials=credentials)
+service = discovery.build('storage', 'v1')
 
 # Name of a bucket.
 bucket = 'my-bucket'  # TODO: Update placeholder value.
@@ -76,20 +72,18 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 from pprint import pprint
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('storage', 'v1', credentials=credentials)
+service = discovery.build('storage', 'v1')
 
 # Name of a bucket.
 bucket = 'my-bucket'  # TODO: Update placeholder value.
@@ -112,20 +106,18 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 from pprint import pprint
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('storage', 'v1', credentials=credentials)
+service = discovery.build('storage', 'v1')
 
 # Name of a bucket.
 bucket = 'my-bucket'  # TODO: Update placeholder value.
@@ -144,20 +136,18 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 from pprint import pprint
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('storage', 'v1', credentials=credentials)
+service = discovery.build('storage', 'v1')
 
 # Name of a bucket.
 bucket = 'my-bucket'  # TODO: Update placeholder value.
@@ -185,20 +175,18 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 from pprint import pprint
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('storage', 'v1', credentials=credentials)
+service = discovery.build('storage', 'v1')
 
 # Name of a bucket.
 bucket = 'my-bucket'  # TODO: Update placeholder value.
@@ -226,19 +214,17 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('storage', 'v1', credentials=credentials)
+service = discovery.build('storage', 'v1')
 
 # Name of a bucket.
 bucket = 'my-bucket'  # TODO: Update placeholder value.
@@ -254,20 +240,18 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 from pprint import pprint
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('storage', 'v1', credentials=credentials)
+service = discovery.build('storage', 'v1')
 
 # Name of a bucket.
 bucket = 'my-bucket'  # TODO: Update placeholder value.
@@ -286,20 +270,18 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 from pprint import pprint
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('storage', 'v1', credentials=credentials)
+service = discovery.build('storage', 'v1')
 
 # A valid API project identifier.
 project = ''  # TODO: Update placeholder value.
@@ -322,20 +304,18 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 from pprint import pprint
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('storage', 'v1', credentials=credentials)
+service = discovery.build('storage', 'v1')
 
 # A valid API project identifier.
 project = ''  # TODO: Update placeholder value.
@@ -360,20 +340,18 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 from pprint import pprint
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('storage', 'v1', credentials=credentials)
+service = discovery.build('storage', 'v1')
 
 # Name of a bucket.
 bucket = 'my-bucket'  # TODO: Update placeholder value.
@@ -397,20 +375,18 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 from pprint import pprint
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('storage', 'v1', credentials=credentials)
+service = discovery.build('storage', 'v1')
 
 # Name of a bucket.
 bucket = 'my-bucket'  # TODO: Update placeholder value.
@@ -434,19 +410,17 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('storage', 'v1', credentials=credentials)
+service = discovery.build('storage', 'v1')
 
 channel_body = {
     # TODO: Add desired entries to the request body.
@@ -463,19 +437,17 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('storage', 'v1', credentials=credentials)
+service = discovery.build('storage', 'v1')
 
 # Name of a bucket.
 bucket = 'my-bucket'  # TODO: Update placeholder value.
@@ -495,20 +467,18 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 from pprint import pprint
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('storage', 'v1', credentials=credentials)
+service = discovery.build('storage', 'v1')
 
 # Name of a bucket.
 bucket = 'my-bucket'  # TODO: Update placeholder value.
@@ -531,20 +501,18 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 from pprint import pprint
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('storage', 'v1', credentials=credentials)
+service = discovery.build('storage', 'v1')
 
 # Name of a bucket.
 bucket = 'my-bucket'  # TODO: Update placeholder value.
@@ -567,20 +535,18 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 from pprint import pprint
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('storage', 'v1', credentials=credentials)
+service = discovery.build('storage', 'v1')
 
 # Name of a bucket.
 bucket = 'my-bucket'  # TODO: Update placeholder value.
@@ -599,20 +565,18 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 from pprint import pprint
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('storage', 'v1', credentials=credentials)
+service = discovery.build('storage', 'v1')
 
 # Name of a bucket.
 bucket = 'my-bucket'  # TODO: Update placeholder value.
@@ -640,20 +604,18 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 from pprint import pprint
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('storage', 'v1', credentials=credentials)
+service = discovery.build('storage', 'v1')
 
 # Name of a bucket.
 bucket = 'my-bucket'  # TODO: Update placeholder value.
@@ -681,19 +643,17 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('storage', 'v1', credentials=credentials)
+service = discovery.build('storage', 'v1')
 
 # Name of a bucket.
 bucket = 'my-bucket'  # TODO: Update placeholder value.
@@ -717,20 +677,18 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 from pprint import pprint
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('storage', 'v1', credentials=credentials)
+service = discovery.build('storage', 'v1')
 
 # Name of a bucket.
 bucket = 'my-bucket'  # TODO: Update placeholder value.
@@ -757,20 +715,18 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 from pprint import pprint
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('storage', 'v1', credentials=credentials)
+service = discovery.build('storage', 'v1')
 
 # Name of a bucket.
 bucket = 'my-bucket'  # TODO: Update placeholder value.
@@ -797,20 +753,18 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 from pprint import pprint
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('storage', 'v1', credentials=credentials)
+service = discovery.build('storage', 'v1')
 
 # Name of a bucket.
 bucket = 'my-bucket'  # TODO: Update placeholder value.
@@ -833,20 +787,18 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 from pprint import pprint
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('storage', 'v1', credentials=credentials)
+service = discovery.build('storage', 'v1')
 
 # Name of a bucket.
 bucket = 'my-bucket'  # TODO: Update placeholder value.
@@ -878,20 +830,18 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 from pprint import pprint
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('storage', 'v1', credentials=credentials)
+service = discovery.build('storage', 'v1')
 
 # Name of a bucket.
 bucket = 'my-bucket'  # TODO: Update placeholder value.
@@ -923,20 +873,18 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 from pprint import pprint
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('storage', 'v1', credentials=credentials)
+service = discovery.build('storage', 'v1')
 
 # Name of the bucket in which to store the new object.
 destination_bucket = 'my-destination-bucket'  # TODO: Update placeholder value.
@@ -967,20 +915,18 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 from pprint import pprint
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('storage', 'v1', credentials=credentials)
+service = discovery.build('storage', 'v1')
 
 # Name of the bucket in which to find the source object.
 source_bucket = 'my-source-bucket'  # TODO: Update placeholder value.
@@ -1020,19 +966,17 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('storage', 'v1', credentials=credentials)
+service = discovery.build('storage', 'v1')
 
 # Name of the bucket in which the object resides.
 bucket = 'my-bucket'  # TODO: Update placeholder value.
@@ -1052,20 +996,18 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 from pprint import pprint
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('storage', 'v1', credentials=credentials)
+service = discovery.build('storage', 'v1')
 
 # Name of the bucket in which the object resides.
 bucket = 'my-bucket'  # TODO: Update placeholder value.
@@ -1092,20 +1034,18 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 from pprint import pprint
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('storage', 'v1', credentials=credentials)
+service = discovery.build('storage', 'v1')
 
 # Name of the bucket in which to store the new object. Overrides the provided object metadata's
 # bucket value, if any.
@@ -1132,20 +1072,18 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 from pprint import pprint
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('storage', 'v1', credentials=credentials)
+service = discovery.build('storage', 'v1')
 
 # Name of the bucket in which to look for objects.
 bucket = 'my-bucket'  # TODO: Update placeholder value.
@@ -1170,20 +1108,18 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 from pprint import pprint
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('storage', 'v1', credentials=credentials)
+service = discovery.build('storage', 'v1')
 
 # Name of the bucket in which the object resides.
 bucket = 'my-bucket'  # TODO: Update placeholder value.
@@ -1211,20 +1147,18 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 from pprint import pprint
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('storage', 'v1', credentials=credentials)
+service = discovery.build('storage', 'v1')
 
 # Name of the bucket in which to find the source object.
 source_bucket = 'my-source-bucket'  # TODO: Update placeholder value.
@@ -1260,20 +1194,18 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 from pprint import pprint
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('storage', 'v1', credentials=credentials)
+service = discovery.build('storage', 'v1')
 
 # Name of the bucket in which the object resides.
 bucket = 'my-bucket'  # TODO: Update placeholder value.
@@ -1305,20 +1237,18 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 from pprint import pprint
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('storage', 'v1', credentials=credentials)
+service = discovery.build('storage', 'v1')
 
 # Name of the bucket in which to look for objects.
 bucket = 'my-bucket'  # TODO: Update placeholder value.

--- a/toolkit/src/test/java/com/google/api/codegen/testdata/discoveries/py/py_storagetransfer.v1.json.baseline
+++ b/toolkit/src/test/java/com/google/api/codegen/testdata/discoveries/py/py_storagetransfer.v1.json.baseline
@@ -8,20 +8,18 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 from pprint import pprint
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('storagetransfer', 'v1', credentials=credentials)
+service = discovery.build('storagetransfer', 'v1')
 
 request = service.getGoogleServiceAccount()
 response = request.execute()
@@ -37,20 +35,18 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 from pprint import pprint
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('storagetransfer', 'v1', credentials=credentials)
+service = discovery.build('storagetransfer', 'v1')
 
 # The ID of the Google Developers Console project that the Google service account is associated with.
 # Required.
@@ -70,20 +66,18 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 from pprint import pprint
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('storagetransfer', 'v1', credentials=credentials)
+service = discovery.build('storagetransfer', 'v1')
 
 transfer_job_body = {
     # TODO: Add desired entries to the request body.
@@ -103,20 +97,18 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 from pprint import pprint
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('storagetransfer', 'v1', credentials=credentials)
+service = discovery.build('storagetransfer', 'v1')
 
 # The job to get. Required.
 job_name = 'transferJobs/my-transfer-job'  # TODO: Update placeholder value.
@@ -135,20 +127,18 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 from pprint import pprint
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('storagetransfer', 'v1', credentials=credentials)
+service = discovery.build('storagetransfer', 'v1')
 
 request = service.transferJobs().list()
 while True:
@@ -170,20 +160,18 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 from pprint import pprint
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('storagetransfer', 'v1', credentials=credentials)
+service = discovery.build('storagetransfer', 'v1')
 
 # The name of job to update. Required.
 job_name = 'transferJobs/my-transfer-job'  # TODO: Update placeholder value.
@@ -207,19 +195,17 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('storagetransfer', 'v1', credentials=credentials)
+service = discovery.build('storagetransfer', 'v1')
 
 # The name of the operation resource to be cancelled.
 name = 'transferOperations/my-transfer-operation'  # TODO: Update placeholder value.
@@ -235,19 +221,17 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('storagetransfer', 'v1', credentials=credentials)
+service = discovery.build('storagetransfer', 'v1')
 
 # The name of the operation resource to be deleted.
 name = 'transferOperations/my-transfer-operation'  # TODO: Update placeholder value.
@@ -263,20 +247,18 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 from pprint import pprint
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('storagetransfer', 'v1', credentials=credentials)
+service = discovery.build('storagetransfer', 'v1')
 
 # The name of the operation resource.
 name = 'transferOperations/my-transfer-operation'  # TODO: Update placeholder value.
@@ -295,20 +277,18 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 from pprint import pprint
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('storagetransfer', 'v1', credentials=credentials)
+service = discovery.build('storagetransfer', 'v1')
 
 # The value `transferOperations`.
 name = 'transferOperations'  # TODO: Update placeholder value.
@@ -333,19 +313,17 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('storagetransfer', 'v1', credentials=credentials)
+service = discovery.build('storagetransfer', 'v1')
 
 # The name of the transfer operation. Required.
 name = 'transferOperations/my-transfer-operation'  # TODO: Update placeholder value.
@@ -365,19 +343,17 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('storagetransfer', 'v1', credentials=credentials)
+service = discovery.build('storagetransfer', 'v1')
 
 # The name of the transfer operation. Required.
 name = 'transferOperations/my-transfer-operation'  # TODO: Update placeholder value.

--- a/toolkit/src/test/java/com/google/api/codegen/testdata/discoveries/py/py_vision.v1.json.baseline
+++ b/toolkit/src/test/java/com/google/api/codegen/testdata/discoveries/py/py_vision.v1.json.baseline
@@ -8,20 +8,18 @@ BEFORE RUNNING:
 2. This sample uses Application Default Credentials for authentication.
    If not already done, install the gcloud CLI from
    https://cloud.google.com/sdk and run
-   `gcloud beta auth application-default login`.
+   `gcloud auth application-default login`.
+   Google API Client will automatically use them as long as googl-auth is installed.
    For more information, see
    https://developers.google.com/identity/protocols/application-default-credentials
-3. Install the Python client library for Google APIs by running
-   `pip install --upgrade google-api-python-client`
+3. Install the Python client library for Google APIs and Google Auth Python Library by running
+   `pip install --upgrade google-api-python-client google-auth`
 """
 from pprint import pprint
 
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
-credentials = GoogleCredentials.get_application_default()
-
-service = discovery.build('vision', 'v1', credentials=credentials)
+service = discovery.build('vision', 'v1')
 
 batch_annotate_images_request_body = {
     # TODO: Add desired entries to the request body.


### PR DESCRIPTION
Fixes #152

### Notes
* discoGen jar is generated via `cd toolkit && ./gradlew discoJar`

### Testing
* `cd toolkit && ./gradlew test` passes
* I also modified run_test.py to produce override with `'authType': 'APPLICATION_DEFAULT_CREDENTIALS'` and ran `./run_tests.py -l python discoveries/cloudbilling.v1.json`. All tests also passed as soon as I generated default credentials via `gcloud auth application-default login` and all generated code samples looked sane.