### PR TITLE
build: add GitHub Actions workflow for discovery sync

### DIFF
--- a/.github/workflows/autoapprove.yml
+++ b/.github/workflows/autoapprove.yml
@@ -1,0 +1,41 @@
+name: AutoApprove
+
+on:
+  pull_request:
+    branches:
+      - master
+    types:
+      - opened
+
+jobs:
+  auto-approve:
+    runs-on: ubuntu-latest
+    steps:
+      - name: AutoApprove
+        uses: actions/github-script@v2
+        with:
+          github-token: ${{secrets.YOSHI_APPROVER_TOKEN}}
+          script: |
+            if (context.payload.sender.login != "yoshi-automation") {
+              core.error("AutoApprove: Not running for this sender.");
+              return;
+            }
+            if (!context.payload.pull_request.title.startsWith("chore: automatic update of discovery json")) {
+              core.error("AutoApprove: Not running for this PR title.");
+              return;
+            }
+            await github.pulls.createReview({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: "AutoApprove: Rubber stamped discovery json download!",
+              pull_number: context.payload.pull_request.number,
+              event: "APPROVE"
+            });
+            core.info("AutoApprove: Rubber stamped discovery json download!");
+            await github.issues.addLabels({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.payload.pull_request.number,
+              labels: ["automerge"]
+            });
+            core.info("AutoApprove: Applied automerge label!");

--- a/.github/workflows/update-discovery.yml
+++ b/.github/workflows/update-discovery.yml
@@ -1,0 +1,40 @@
+name: Update Discovery
+
+on:
+  schedule:
+    - cron: "0 */3 * * *"
+  workflow_dispatch:
+
+jobs:
+  update-discovery:
+    if: ${{ github.repository_owner == 'googleapis' }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v1
+        with:
+          node-version: 12
+      - run: npm install
+      - run: npm run update-discovery
+      - name: Push changes to branch
+        run: |
+          git config --global user.email "yoshi-automation@google.com"
+          git config --global user.name "Yoshi Automation Bot"
+          git checkout -b action/auto-update-discovery
+          git commit -a -m "chore: automatic update of discovery json"
+          git push -f origin action/auto-update-discovery
+      - name: Open PR
+        uses: actions/github-script@v2
+        with:
+          github-token: ${{ secrets.YOSHI_CODE_BOT_TOKEN }}
+          script: |
+            const result = await github.pulls.create({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              title: "chore: automatic update of discovery json",
+              head: context.repo.owner + ":action/auto-update-discovery",
+              base: "master",
+              maintainer_can_modify: true,
+              body: "This was created by a GitHub Action 🤖"
+            });
+            core.info(`Created PR ${result.data.number}`);

--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ mockgen/dist
 mockgen/mockgen.egg-info
 test
 .vscode
+node_modules

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,105 @@
+{
+  "name": "discovery-artifact-manager",
+  "version": "1.0.0",
+  "lockfileVersion": 1,
+  "requires": true,
+  "dependencies": {
+    "abort-controller": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/abort-controller/-/abort-controller-3.0.0.tgz",
+      "integrity": "sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==",
+      "requires": {
+        "event-target-shim": "^5.0.0"
+      }
+    },
+    "agent-base": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.1.tgz",
+      "integrity": "sha512-01q25QQDwLSsyfhrKbn8yuur+JNw0H+0Y4JiGIKd3z9aYk/w/2kxD/Upc+t2ZBBSUNff50VjPsSW2YxM8QYKVg==",
+      "requires": {
+        "debug": "4"
+      }
+    },
+    "debug": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.2.0.tgz",
+      "integrity": "sha512-IX2ncY78vDTjZMFUdmsvIRFY2Cf4FnD0wRs+nQwJU8Lu99/tPFdb0VybiiMTPe3I6rQmwsqQqRBvxU+bZ/I8sg==",
+      "requires": {
+        "ms": "2.1.2"
+      }
+    },
+    "event-target-shim": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/event-target-shim/-/event-target-shim-5.0.1.tgz",
+      "integrity": "sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ=="
+    },
+    "eventemitter3": {
+      "version": "4.0.7",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.7.tgz",
+      "integrity": "sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw=="
+    },
+    "extend": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
+      "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g=="
+    },
+    "gaxios": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/gaxios/-/gaxios-3.2.0.tgz",
+      "integrity": "sha512-+6WPeVzPvOshftpxJwRi2Ozez80tn/hdtOUag7+gajDHRJvAblKxTFSSMPtr2hmnLy7p0mvYz0rMXLBl8pSO7Q==",
+      "requires": {
+        "abort-controller": "^3.0.0",
+        "extend": "^3.0.2",
+        "https-proxy-agent": "^5.0.0",
+        "is-stream": "^2.0.0",
+        "node-fetch": "^2.3.0"
+      }
+    },
+    "https-proxy-agent": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.0.tgz",
+      "integrity": "sha512-EkYm5BcKUGiduxzSt3Eppko+PiNWNEpa4ySk9vTC6wDsQJW9rHSa+UhGNJoRYp7bz6Ht1eaRIa6QaJqO5rCFbA==",
+      "requires": {
+        "agent-base": "6",
+        "debug": "4"
+      }
+    },
+    "is-stream": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.0.tgz",
+      "integrity": "sha512-XCoy+WlUr7d1+Z8GgSuXmpuUFC9fOhRXglJMx+dwLKTkL44Cjd4W1Z5P+BQZpr+cR93aGP4S/s7Ftw6Nd/kiEw=="
+    },
+    "ms": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+    },
+    "node-fetch": {
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.1.tgz",
+      "integrity": "sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw=="
+    },
+    "p-finally": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz",
+      "integrity": "sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4="
+    },
+    "p-queue": {
+      "version": "6.6.1",
+      "resolved": "https://registry.npmjs.org/p-queue/-/p-queue-6.6.1.tgz",
+      "integrity": "sha512-miQiSxLYPYBxGkrldecZC18OTLjdUqnlRebGzPRiVxB8mco7usCmm7hFuxiTvp93K18JnLtE4KMMycjAu/cQQg==",
+      "requires": {
+        "eventemitter3": "^4.0.4",
+        "p-timeout": "^3.1.0"
+      }
+    },
+    "p-timeout": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/p-timeout/-/p-timeout-3.2.0.tgz",
+      "integrity": "sha512-rhIwUycgwwKcP9yTOOFK/AKsAopjjCakVqLHePO3CC6Mir1Z99xT+R63jZxAT5lFZLa2inS5h+ZS2GvR99/FBg==",
+      "requires": {
+        "p-finally": "^1.0.0"
+      }
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,24 @@
+{
+  "name": "discovery-artifact-manager",
+  "private": "true",
+  "description": "The Discovery Artifact Manager is intended to facilitate testing, publishing, and synchronization of generators and artifacts for client libraries and generated code samples of Google APIs defined by the API Discovery Service.",
+  "main": "update-discovery.js",
+  "scripts": {
+    "update-discovery": "node update-discovery.js"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/googleapis/discovery-artifact-manager.git"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "bugs": {
+    "url": "https://github.com/googleapis/discovery-artifact-manager/issues"
+  },
+  "homepage": "https://github.com/googleapis/discovery-artifact-manager#readme",
+  "dependencies": {
+    "gaxios": "^3.2.0",
+    "p-queue": "^6.6.1"
+  }
+}

--- a/update-discovery.js
+++ b/update-discovery.js
@@ -1,0 +1,117 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+const path = require('path');
+const fs = require('fs');
+const {default: Q} = require('p-queue');
+const {request} = require('gaxios');
+
+const DISCOVERY_URL = 'https://www.googleapis.com/discovery/v1/apis/';
+const DOWNLOAD_PATH = "discoveries";
+
+/**
+ * Download all discovery documents into the /discovery directory.
+ */
+async function downloadDiscoveryDocs() {
+  const headers = {'X-User-Ip': '0.0.0.0'};
+  console.log(`sending request to ${DISCOVERY_URL}`);
+  const res = await request({url: DISCOVERY_URL, headers});
+  const apis = res.data.items;
+  const indexPath = path.join(DOWNLOAD_PATH, 'index.json');
+  fs.writeFileSync(indexPath, JSON.stringify(res.data, null, 2));
+  const queue = new Q({concurrency: 25});
+  console.log(`Downloading ${apis.length} APIs...`);
+  const changes = await queue.addAll(
+    apis.map(api => async () => {
+      console.log(`Downloading ${api.id}...`);
+      const apiPath = path.join(
+        DOWNLOAD_PATH,
+        api.id.replace(':', '.') + '.json'
+      );
+      const url = api.discoveryRestUrl;
+      const changeSet = {api, changes: []};
+      try {
+        const res = await request({url});
+        // The keys in the downloaded JSON come back in an arbitrary order from
+        // request to request. Sort them before storing.
+        const newDoc = sortKeys(res.data);
+        let updateFile = true;
+
+        try {
+          const oldDoc = JSON.parse(fs.readFileSync(apiPath, 'utf8'));
+          updateFile = shouldUpdate(newDoc, oldDoc);
+          changeSet.changes = getDiffs(oldDoc, newDoc);
+        } catch {
+          // If the file doesn't exist, that's fine it's just new
+        }
+        if (updateFile) {
+          fs.writeFileSync(apiPath, JSON.stringify(newDoc, null, 2));
+        }
+      } catch (e) {
+        console.error(`Error downloading: ${url}`);
+      }
+      return changeSet;
+    })
+  );
+  return changes;
+}
+
+const ignoreLines = /^\s+"(?:etag|revision)": ".+"/;
+
+/**
+ * Determine if any of the changes in the discovery docs were interesting
+ * @param newDoc New downloaded schema
+ * @param oldDoc The existing schema from disk
+ */
+function shouldUpdate(newDoc, oldDoc) {
+  const [newLines, oldLines] = [newDoc, oldDoc].map(doc =>
+    JSON.stringify(doc, null, 2)
+      .split('\n')
+      .filter(l => !ignoreLines.test(l))
+      .join('\n')
+  );
+  return newLines !== oldLines;
+}
+
+/**
+ * Given an arbitrary object, recursively sort the properties on the object
+ * by the name of the key.  For example:
+ * {
+ *   b: 1,
+ *   a: 2
+ * }
+ * becomes....
+ * {
+ *   a: 2,
+ *   b: 1
+ * }
+ * @param obj Object to be sorted
+ * @returns object with sorted keys
+ */
+function sortKeys(obj) {
+  const sorted = {};
+  let keys = Object.keys(obj);
+  keys = keys.sort();
+  for (const key of keys) {
+    // typeof [] === 'object', which is maddening
+    if (!Array.isArray(obj[key]) && typeof obj[key] === 'object') {
+      sorted[key] = sortKeys(obj[key]);
+    } else {
+      sorted[key] = obj[key];
+    }
+  }
+  return sorted;
+}
+
+downloadDiscoveryDocs();


### PR DESCRIPTION
This is in pursuit of enabling default branch protection.  This PR does a few things:
- It introduces a `npm run update-discovery` command, which updates all discovery files locally 
- ~~It runs said script, which causes a lot of changes (which I want feedback on @vchudnov-g).  Some of the changes are sorting keys to reduce diffs in future commits.~~
- It adds an automated workflow for running this process nightly
- It adds an automated workflow for auto-approving and merging the PR

After something like this lands and is verified, the bot that auto-pushes to master would no longer be needed.  We could also enable default branch protection rules and codeowners.  