### PR TITLE
chore: Delete weekly Ruby release cron

### DIFF
--- a/server/cron.yaml
+++ b/server/cron.yaml
@@ -33,10 +33,6 @@ cron:
   url: /cron/clients/ruby/update
   schedule: every 99999 hours  # 11 years.
 
-- description: release google/google-api-ruby-client
-  url: /cron/clients/ruby/release
-  schedule: every monday 01:30
-
 - description: release (force) google/google-api-ruby-client
   url: /cron/clients/ruby/release?force=true
   schedule: every 99999 hours  # 11 years.


### PR DESCRIPTION
Ruby is migrating to release-please and autorelease. Disable weekly dartman-driven releases by deleting the cron entry.