### PR TITLE
fix: remove "index" from services

### DIFF
--- a/.github/workflows/list-services.yml
+++ b/.github/workflows/list-services.yml
@@ -40,9 +40,9 @@ jobs:
               tree_sha: discoveryTreeSha,
             });
 
-            // limit files that end in .json and grab the service name
+            // limit files that end in .json and grab the service name. Exclude index.json
             const services = discoveryFiles.filter((file) => {
-              return file.path.endsWith(".json");
+              return file.path.endsWith(".json") && file.path !== "index.json";
             }).map(file => file.path.split(".")[0]);
 
             // make unique


### PR DESCRIPTION
fixes https://github.com/googleapis/discovery-artifact-manager/issues/6142

Index is not a service, so it should be excluded from the list of services.