### PR TITLE
build: add workflow to normalize discovery docs

### DIFF
--- a/.github/workflows/normalize-disco.yml
+++ b/.github/workflows/normalize-disco.yml
@@ -1,0 +1,30 @@
+name: Normalize discovery documents
+on:
+  workflow_dispatch:
+
+jobs:
+  normalize-discoveries:
+    if: ${{ github.repository == 'googleapis/discovery-artifact-manager' }}
+    runs-on: ubuntu-latest
+    env:
+      ACCESS_TOKEN: ${{ secrets.YOSHI_CODE_BOT_TOKEN }}
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v3
+      - name: Install Python 3.10
+        uses: actions/setup-python@v4
+        with:
+          python-version: "3.10"
+      - name: execute
+        run: |
+          python scripts/normalize_discovery.py
+      - uses: googleapis/code-suggester@v4 # takes the changes from git directory
+        with:
+          command: pr
+          upstream_owner: googleapis
+          upstream_repo: discovery-artifact-manager
+          description: 'Ran scripts/normalize_discovery.py'
+          title: 'chore: normalize discovery docs'
+          message: 'chore: normalize discovery docs'
+          branch: normalize-discovery
+          git_dir: '.'

--- a/scripts/normalize_discovery.py
+++ b/scripts/normalize_discovery.py
@@ -1,0 +1,46 @@
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Updates the discovery documents in the discoveries directory."""
+
+import glob
+import json
+import logging
+import os
+
+
+def main() -> None:
+  """The entrypoint for normalizing discovery documents.
+
+  This script sorts the JSON keys in each discovery document and writes it back
+  to the file. This makes it easier to compare documents for semantic diffs.
+  """
+  logging.basicConfig(level=logging.INFO)
+  os.chdir("discoveries")
+  for filename in glob.glob("*.json"):
+    logging.info("Normalizing %s", filename)
+    with open(filename, "rb+") as f:
+      content = f.read()
+      data = json.loads(content)
+      normalized_content = json.dumps(data, indent=2, sort_keys=True).encode(
+          "utf-8"
+      )
+
+    with open(filename, "wb") as f:
+      f.write(normalized_content)
+  os.chdir("..")
+
+
+if __name__ == "__main__":
+  main()

--- a/scripts/normalize_discovery.py
+++ b/scripts/normalize_discovery.py
@@ -21,26 +21,26 @@ import os
 
 
 def main() -> None:
-  """The entrypoint for normalizing discovery documents.
+    """The entrypoint for normalizing discovery documents.
 
-  This script sorts the JSON keys in each discovery document and writes it back
-  to the file. This makes it easier to compare documents for semantic diffs.
-  """
-  logging.basicConfig(level=logging.INFO)
-  os.chdir("discoveries")
-  for filename in glob.glob("*.json"):
-    logging.info("Normalizing %s", filename)
-    with open(filename, "rb+") as f:
-      content = f.read()
-      data = json.loads(content)
-      normalized_content = json.dumps(data, indent=2, sort_keys=True).encode(
-          "utf-8"
-      )
+    This script sorts the JSON keys in each discovery document and writes it back
+    to the file. This makes it easier to compare documents for semantic diffs.
+    """
+    logging.basicConfig(level=logging.INFO)
+    os.chdir("discoveries")
+    for filename in glob.glob("*.json"):
+        logging.info("Normalizing %s", filename)
+        with open(filename, "rb+") as f:
+            content = f.read()
+            data = json.loads(content)
+            normalized_content = json.dumps(data, indent=2, sort_keys=True).encode(
+                "utf-8"
+            )
 
-    with open(filename, "wb") as f:
-      f.write(normalized_content)
-  os.chdir("..")
+        with open(filename, "wb") as f:
+            f.write(normalized_content)
+    os.chdir("..")
 
 
 if __name__ == "__main__":
-  main()
+    main()


### PR DESCRIPTION
A manually triggered one-off action/script to create a PR like: https://github.com/googleapis/discovery-artifact-manager/pull/10699

Future discovery docs are already being normalized in the update_disco.py script, but it won't be updated in the directory until there is a new revision with substantial changes. This will normalize all the existing docs in place (sorted keys, consistent indentation) so future diffs are readable/reviewable.