### PR TITLE
fix: type of score in PageSpeedOnlineV5

### DIFF
--- a/discoveries/pagespeedonline.v5.json
+++ b/discoveries/pagespeedonline.v5.json
@@ -447,7 +447,8 @@
         },
         "score": {
           "description": "The score of the audit, can be null.",
-          "type": "any"
+          "format": "double",
+          "type": "number"
         },
         "scoreDisplayMode": {
           "description": "The enumerated score display mode.",
@@ -489,7 +490,8 @@
         },
         "score": {
           "description": "The overall score of the category, the weighted average of all its audits. (The category's score, can be null.)",
-          "type": "any"
+          "format": "double",
+          "type": "number"
         },
         "title": {
           "description": "The human-friendly name of the category.",


### PR DESCRIPTION
Score is returned as a double between 0 and 1